### PR TITLE
engine/audio: fix resampling

### DIFF
--- a/src/engine/audio_stream.c
+++ b/src/engine/audio_stream.c
@@ -342,7 +342,7 @@ static bool Audio_Stream_InitialiseFromPath(
     stream->stop_at = -1.0; // negative value means unset
 
     stream->sdl.stream = SDL_NewAudioStream(
-        AUDIO_WORKING_FORMAT, sdl_channels, sdl_sample_rate,
+        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE,
         AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE);
     if (!stream->sdl.stream) {
         LOG_ERROR("Failed to create SDL stream: %s", SDL_GetError());


### PR DESCRIPTION
Resolves LostArtefacts/TR1X#1417.

The problem arises from using ffmpeg's swr component to resample the music, and then directing SDL to perform another resampling using its `SDL_NewAudioStream` API, effectively doubling the resampling factor.