### PR TITLE
filesystem: improve read/write apis

### DIFF
--- a/include/libtrx/filesystem.h
+++ b/include/libtrx/filesystem.h
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef enum {
     FILE_SEEK_SET,
@@ -37,12 +38,24 @@ char *File_GuessExtension(const char *path, const char **extensions);
 
 MYFILE *File_Open(const char *path, FILE_OPEN_MODE mode);
 
-size_t File_Read(void *data, size_t item_size, size_t count, MYFILE *file);
+void File_ReadData(MYFILE *file, void *data, size_t size);
+void File_ReadItems(MYFILE *file, void *data, size_t count, size_t item_size);
+int8_t File_ReadS8(MYFILE *file);
+int16_t File_ReadS16(MYFILE *file);
+int32_t File_ReadS32(MYFILE *file);
+uint8_t File_ReadU8(MYFILE *file);
+uint16_t File_ReadU16(MYFILE *file);
+uint32_t File_ReadU32(MYFILE *file);
 
-size_t File_Write(
-    const void *data, size_t item_size, size_t count, MYFILE *file);
-
-void File_CreateDirectory(const char *path);
+void File_WriteData(MYFILE *file, const void *data, size_t size);
+void File_WriteItems(
+    MYFILE *file, const void *data, size_t count, size_t item_size);
+void File_WriteS8(MYFILE *file, int8_t value);
+void File_WriteS16(MYFILE *file, int16_t value);
+void File_WriteS32(MYFILE *file, int32_t value);
+void File_WriteU8(MYFILE *file, uint8_t value);
+void File_WriteU16(MYFILE *file, uint16_t value);
+void File_WriteU32(MYFILE *file, uint32_t value);
 
 size_t File_Pos(MYFILE *file);
 
@@ -57,3 +70,5 @@ void File_Seek(MYFILE *file, size_t pos, FILE_SEEK_MODE mode);
 void File_Close(MYFILE *file);
 
 bool File_Load(const char *path, char **output_data, size_t *output_size);
+
+void File_CreateDirectory(const char *path);

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -235,27 +235,100 @@ MYFILE *File_Open(const char *path, FILE_OPEN_MODE mode)
     return file;
 }
 
-size_t File_Read(void *data, size_t item_size, size_t count, MYFILE *file)
+void File_ReadData(MYFILE *const file, void *const data, const size_t size)
 {
-    return fread(data, item_size, count, file->fp);
+    fread(data, size, 1, file->fp);
 }
 
-size_t File_Write(
-    const void *data, size_t item_size, size_t count, MYFILE *file)
+void File_ReadItems(
+    MYFILE *const file, void *data, const size_t count, const size_t item_size)
 {
-    return fwrite(data, item_size, count, file->fp);
+    fread(data, item_size, count, file->fp);
 }
 
-void File_CreateDirectory(const char *path)
+int8_t File_ReadS8(MYFILE *const file)
 {
-    char *full_path = File_GetFullPath(path);
-    assert(full_path);
-#if defined(_WIN32)
-    _mkdir(full_path);
-#else
-    mkdir(full_path, 0775);
-#endif
-    Memory_FreePointer(&full_path);
+    int8_t result;
+    fread(&result, sizeof(result), 1, file->fp);
+    return result;
+}
+
+int16_t File_ReadS16(MYFILE *const file)
+{
+    int16_t result;
+    fread(&result, sizeof(result), 1, file->fp);
+    return result;
+}
+
+int32_t File_ReadS32(MYFILE *const file)
+{
+    int32_t result;
+    fread(&result, sizeof(result), 1, file->fp);
+    return result;
+}
+
+uint8_t File_ReadU8(MYFILE *const file)
+{
+    uint8_t result;
+    fread(&result, sizeof(result), 1, file->fp);
+    return result;
+}
+
+uint16_t File_ReadU16(MYFILE *const file)
+{
+    uint16_t result;
+    fread(&result, sizeof(result), 1, file->fp);
+    return result;
+}
+
+uint32_t File_ReadU32(MYFILE *const file)
+{
+    uint32_t result;
+    fread(&result, sizeof(result), 1, file->fp);
+    return result;
+}
+
+void File_WriteData(
+    MYFILE *const file, const void *const data, const size_t size)
+{
+    fwrite(data, size, 1, file->fp);
+}
+
+void File_WriteItems(
+    MYFILE *const file, const void *const data, const size_t count,
+    const size_t item_size)
+{
+    fwrite(data, item_size, count, file->fp);
+}
+
+void File_WriteS8(MYFILE *const file, const int8_t value)
+{
+    fwrite(&value, sizeof(value), 1, file->fp);
+}
+
+void File_WriteS16(MYFILE *const file, const int16_t value)
+{
+    fwrite(&value, sizeof(value), 1, file->fp);
+}
+
+void File_WriteS32(MYFILE *const file, const int32_t value)
+{
+    fwrite(&value, sizeof(value), 1, file->fp);
+}
+
+void File_WriteU8(MYFILE *const file, const uint8_t value)
+{
+    fwrite(&value, sizeof(value), 1, file->fp);
+}
+
+void File_WriteU16(MYFILE *const file, const uint16_t value)
+{
+    fwrite(&value, sizeof(value), 1, file->fp);
+}
+
+void File_WriteU32(MYFILE *const file, const uint32_t value)
+{
+    fwrite(&value, sizeof(value), 1, file->fp);
 }
 
 void File_Skip(MYFILE *file, size_t bytes)
@@ -314,7 +387,8 @@ bool File_Load(const char *path, char **output_data, size_t *output_size)
 
     size_t data_size = File_Size(fp);
     char *data = Memory_Alloc(data_size + 1);
-    if (File_Read(data, sizeof(char), data_size, fp) != data_size) {
+    File_ReadData(fp, data, data_size);
+    if (File_Pos(fp) != data_size) {
         LOG_ERROR("Can't read file %s", path);
         Memory_FreePointer(&data);
         return false;
@@ -327,4 +401,16 @@ bool File_Load(const char *path, char **output_data, size_t *output_size)
         *output_size = data_size;
     }
     return true;
+}
+
+void File_CreateDirectory(const char *path)
+{
+    char *full_path = File_GetFullPath(path);
+    assert(full_path);
+#if defined(_WIN32)
+    _mkdir(full_path);
+#else
+    mkdir(full_path, 0775);
+#endif
+    Memory_FreePointer(&full_path);
 }


### PR DESCRIPTION
Instead of a code like this:

```c
int32_t version;
File_Read(&version, sizeof(int32_t), 1, fp);
```

this PR lets us write code like this:

```c
const int32_t version = File_ReadS32(fp);
```

---

This also has the additional benefit of not causing problems if the storage size of the target variable is different than the read size:

```c
int32_t foo = 0x12735471;
File_Read(&foo, sizeof(int16_t), 1, fp); // read two bytes that are both 0xFF
// foo now contains a garbage value of 0x1273FFFF.
// Because we only overrode two bytes, parts of the old value remain intact.
```

<details>
<summary>Full example using POSIX C</summary>
<blockquote>

First off, a sample code, `test.c`:

```c
#include <stdio.h>
#include <stdint.h>

int main(void)
{
    int32_t value = 0x12735471;
    printf("%x\n", value);
    FILE *fp = fopen("test.txt", "rb");
    fread(&value, sizeof(int16_t), 1, fp);
    printf("%x\n", value);
    fclose(fp);
    return 0;
}
```

Compiling and examining the results:

```console
$ echo -ne "\xff\xff" > test.txt
$ gcc ./test.c -o ./test
$ chmod +x ./test
$ ./test
12735471
1273ffff
```
</blockquote>
</details>

Thanks to having the type promotion work through an assignment, the value of `foo` in the new API will be correctly set to `0xFFFFFFFF` (eg -1 as intended).

<details>
<summary>Full example using POSIX C</summary>
<blockquote>

Updated `test.c`:

```c
#include <stdio.h>
#include <stdint.h>

static int16_t read_s16(FILE *fp)
{
    int16_t result;
    fread(&result, sizeof(int16_t), 1, fp);
    return result;
}

int main(void)
{
    int32_t value = 0x12735471;
    printf("%x\n", value);
    FILE *fp = fopen("test.txt", "rb");
    value = read_s16(fp);
    printf("%x\n", value);
    fclose(fp);
    return 0;
}
```

Examining the results:
```console
$ echo -ne "\xff\xff" > test.txt
$ gcc ./test.c -o ./test
$ chmod +x ./test
$ ./test
12735471
ffffffff
```
</blockquote>
</details>