### PR TITLE
Improve crash stacktraces

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,12 @@ project(
   ],
 )
 
+fs = import('fs')
+
 c_compiler = meson.get_compiler('c')
+relative_dir = fs.relative_to(meson.current_source_dir(), meson.global_build_root())
 build_opts = [
+  '-fmacro-prefix-map=@0@/src=libtrx'.format(relative_dir),
   '-Wno-unused',
   '-DMESON_BUILD',
   '-DPCRE2_STATIC',

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ build_opts = [
   '-fmacro-prefix-map=@0@/src=libtrx'.format(relative_dir),
   '-Wno-unused',
   '-DMESON_BUILD',
+  '-DDWST_STATIC',
   '-DPCRE2_STATIC',
   '-DPCRE2_CODE_UNIT_WIDTH=8',
 ]
@@ -76,8 +77,10 @@ if dep_backtrace.found() and host_machine.system() == 'linux'
   sources += ['src/log_linux.c']
 elif host_machine.system() == 'windows'
   sources += ['src/log_windows.c']
+  dwarfstack = subproject('dwarfstack', default_options: ['warning_level=0'])
+  dep_dwarfstack = dwarfstack.get_variable('dep_dwarfstack')
   dep_dbghelp = c_compiler.find_library('dbghelp')
-  dependencies += [dep_dbghelp]
+  dependencies += [dep_dbghelp, dep_dwarfstack]
 else
   sources += ['src/log_unknown.c']
 endif

--- a/src/log_linux.c
+++ b/src/log_linux.c
@@ -7,9 +7,9 @@
 #include <stdlib.h>
 
 static void Log_ErrorCallback(void *data, const char *msg, int errnum);
-static int Log_FullTrace(
+static int Log_StackTrace(
     void *data, uintptr_t pc, const char *filename, int lineno,
-    const char *function);
+    const char *func_name);
 static void Log_SignalHandler(int sig);
 
 static void Log_ErrorCallback(void *data, const char *msg, int errnum)
@@ -17,16 +17,16 @@ static void Log_ErrorCallback(void *data, const char *msg, int errnum)
     LOG_ERROR("%s", msg);
 }
 
-static int Log_FullTrace(
+static int Log_StackTrace(
     void *data, uintptr_t pc, const char *filename, int lineno,
-    const char *function)
+    const char *func_name)
 {
     if (filename) {
         LOG_INFO(
-            "0x%08X: %s (%s:%d)", pc, function ? function : "???",
+            "0x%08X: %s (%s:%d)", pc, func_name ? func_name : "???",
             filename ? filename : "???", lineno);
     } else {
-        LOG_INFO("0x%08X: %s", pc, function ? function : "???");
+        LOG_INFO("0x%08X: %s", pc, func_name ? func_name : "???");
     }
     return 0;
 }
@@ -38,7 +38,7 @@ static void Log_SignalHandler(int sig)
     LOG_INFO("STACK TRACE:");
     struct backtrace_state *state = backtrace_create_state(
         NULL, BACKTRACE_SUPPORTS_THREADS, Log_ErrorCallback, NULL);
-    backtrace_full(state, 0, Log_FullTrace, Log_ErrorCallback, NULL);
+    backtrace_full(state, 0, Log_StackTrace, Log_ErrorCallback, NULL);
     exit(EXIT_FAILURE);
 }
 

--- a/subprojects/dwarfstack.wrap
+++ b/subprojects/dwarfstack.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = dwarfstack-2.2
+source_url = https://github.com/ssbssa/dwarfstack/archive/refs/tags/2.2.tar.gz
+source_filename = dwarfstack-2.2.tar.gz
+source_hash = 1fca1d12756941c4c932b50f9abe56a3756f012a1e93deef553e141a78cc2709
+patch_directory = dwarfstack
+
+[provide]
+dwarfstack = dwarfstack_dep

--- a/subprojects/packagefiles/dwarfstack/meson.build
+++ b/subprojects/packagefiles/dwarfstack/meson.build
@@ -1,0 +1,84 @@
+project(
+  'dwarfstack',
+  'c',
+  default_options: [
+    'c_std=c2x',
+    'warning_level=2',
+  ],
+)
+
+c_compiler = meson.get_compiler('c')
+build_opts = [
+  '-Wno-unused',
+  '-DDWST_STATIC',
+  '-DNO_DBGHELP',
+  '-DLIBDWARF_STATIC',
+]
+add_project_arguments(build_opts, language: 'c')
+dep_zlib = dependency('zlib')
+
+sources = [
+  'mgwhelp/dwarf_pe.c',
+  'src/dwst-exception-dialog.c',
+  'src/dwst-exception.c',
+  'src/dwst-process.c',
+  'src/dwst-location.c',
+  'src/dwst-file.c',
+  'libdwarf/dwarf_debugnames.c',
+  'libdwarf/dwarf_dsc.c',
+  'libdwarf/dwarf_alloc.c',
+  'libdwarf/dwarf_loclists.c',
+  'libdwarf/dwarf_macro5.c',
+  'libdwarf/dwarf_harmless.c',
+  'libdwarf/dwarf_locationop_read.c',
+  'libdwarf/dwarf_gnu_index.c',
+  'libdwarf/dwarf_rnglists.c',
+  'libdwarf/dwarf_error.c',
+  'libdwarf/dwarf_init_finish.c',
+  'libdwarf/dwarf_abbrev.c',
+  'libdwarf/dwarf_xu_index.c',
+  'libdwarf/dwarf_names.c',
+  'libdwarf/dwarf_str_offsets.c',
+  'libdwarf/dwarf_tsearchhash.c',
+  'libdwarf/dwarf_die_deliv.c',
+  'libdwarf/dwarf_frame.c',
+  'libdwarf/dwarf_query.c',
+  'libdwarf/dwarf_global.c',
+  'libdwarf/dwarf_loc.c',
+  'libdwarf/dwarf_tied.c',
+  'libdwarf/dwarf_util.c',
+  'libdwarf/dwarf_form.c',
+  'libdwarf/dwarf_groups.c',
+  'libdwarf/dwarf_frame2.c',
+  'libdwarf/dwarf_memcpy_swap.c',
+  'libdwarf/dwarf_leb.c',
+  'libdwarf/dwarf_debuglink.c',
+  'libdwarf/dwarf_string.c',
+  'libdwarf/dwarf_line.c',
+  'libdwarf/dwarf_fission_to_cu.c',
+  'libdwarf/dwarf_find_sigref.c',
+  'libdwarf/dwarf_ranges.c',
+]
+
+dependencies = [
+  dep_zlib,
+]
+
+libdwarfstack = static_library(
+  'libdwarfstack',
+  sources,
+  dependencies: dependencies,
+  include_directories: [
+    'include/',
+    'mgwhelp/',
+    'src/',
+    'libdwarf/',
+  ]
+)
+
+dep_dwarfstack = declare_dependency(
+  link_whole: libdwarfstack,
+  include_directories: [
+    include_directories('include', is_system: true)
+  ]
+)


### PR DESCRIPTION
To provide players with detailed stack traces, we need to embed debug information, including symbol names, into our DLL and EXE files. Recently, we've implemented platform-specific stack resolution techniques: using the `backtrace` library on Linux and Windows APIs on Windows. However, a challenge arises with Windows: it can only resolve symbol names from PDB-based debug information. Our compiler, MinGW, generates debug information in DWARF format (since it's based on GCC), which Windows cannot interpret. As a result, current stack traces on Windows lack meaningful information.

We have a few potential solutions to address this issue:
- Switching to the MSVC compiler for Windows, which is impractical
- Using the cv2pdb project, which can convert and embed PDB into EXEs
- Developing our own stack resolver capable of parsing DWARF debug information

I had little luck with cv2pdb. It turns out, however, that there is already a project which implements the third solution – it's called `dwarfstack` and is available here: https://github.com/ssbssa/dwarfstack/

And so, this PR switches the Windows stack resolver from its APIs to this library. Instead of trying to link it statically via Docker's toolchain like we do for SDL and others, I found it easier to use Meson's wrap system. This mechanism lets us use external code just as if it were our own, without having to actually add it to our codebase – even if the upstream repo doesn't use Meson itself. It's really neat IMO.

Example output information from TR2X with a simulated crash in `Text_DrawText`:

```
libtrx/log_windows.c 87 Log_CrashHandler == CRASH REPORT ==
libtrx/log_windows.c 88 Log_CrashHandler EXCEPTION CODE: c0000005
libtrx/log_windows.c 89 Log_CrashHandler EXCEPTION ADDRESS: 77ce4be9
libtrx/log_windows.c 90 Log_CrashHandler STACK TRACE:
libtrx/log_windows.c 46 Log_StackTrace --- 0x77ca0000: Z:\home\rr-\work\priv\TR2X\test\TR2X.dll
libtrx/log_windows.c 58 Log_StackTrace 00. 0x77ce4be9: (/app/build/win/game/text.c:351:18) Text_DrawText
libtrx/log_windows.c 46 Log_StackTrace --- 0x77ca0000: Z:\home\rr-\work\priv\TR2X\test\TR2X.dll
libtrx/log_windows.c 58 Log_StackTrace 01. 0x77ce492c: (/app/build/win/game/text.c:312:13) Text_Draw
libtrx/log_windows.c 58 Log_StackTrace 02. 0x77cb3875: (/app/build/win/game/inventory.c:309:9) Inv_Display
libtrx/log_windows.c 58 Log_StackTrace 03. 0x77ca24d7: (/app/build/win/decomp/decomp.c:575:5) TitleSequence
libtrx/log_windows.c 58 Log_StackTrace 04. 0x77ce3530: (/app/build/win/game/shell.c:133:29) Shell_Main
libtrx/log_windows.c 58 Log_StackTrace 05. 0x77ca19d9: (/app/build/win/decomp/decomp.c:241:9) WinMain
libtrx/log_windows.c 46 Log_StackTrace --- 0x00400000: Z:\home\rr-\work\priv\TR2X\test\Tomb2.exe
libtrx/log_windows.c 52 Log_StackTrace 06. 0x00459e9e: Z:\home\rr-\work\priv\TR2X\test\Tomb2.exe
libtrx/log_windows.c 46 Log_StackTrace --- 0x7beb0000: C:\windows\system32\kernel32.dll
libtrx/log_windows.c 52 Log_StackTrace 07. 0x7bed8b5f: C:\windows\system32\kernel32.dll
libtrx/log_windows.c 46 Log_StackTrace --- 0x7bf30000: C:\windows\system32\ntdll.dll
libtrx/log_windows.c 52 Log_StackTrace 08. 0x7bf84972: C:\windows\system32\ntdll.dll
libtrx/log_windows.c 52 Log_StackTrace 09. 0x7bf853d4: C:\windows\system32\ntdll.dll
libtrx/log_windows.c 82 Log_CreateMiniDump Crash dump info put in Z:\home\rr-\work\priv\TR2X\test\TR2X.dmp
```