### PR TITLE
benchmark: support incremental benchmarking

### DIFF
--- a/include/libtrx/benchmark.h
+++ b/include/libtrx/benchmark.h
@@ -4,13 +4,21 @@
 
 typedef struct {
     Uint64 start;
+    Uint64 last;
 } BENCHMARK;
 
 BENCHMARK *Benchmark_Start(void);
 
-#define Benchmark_End(...)                                                     \
-    Benchmark_End_Impl(__FILE__, __LINE__, __func__, __VA_ARGS__)
+#define Benchmark_End(b, ...)                                                  \
+    Benchmark_End_Impl(b, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
+#define Benchmark_Tick(b, ...)                                                 \
+    Benchmark_Tick_Impl(b, __FILE__, __LINE__, __func__, __VA_ARGS__)
 
 void Benchmark_End_Impl(
-    const char *file, int32_t line, const char *func, BENCHMARK *b,
+    BENCHMARK *b, const char *file, int32_t line, const char *func,
+    const char *message);
+
+void Benchmark_Tick_Impl(
+    BENCHMARK *b, const char *file, int32_t line, const char *func,
     const char *message);

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -5,25 +5,58 @@
 
 #include <SDL2/SDL_timer.h>
 
+static void Benchmark_Log(
+    BENCHMARK *const b, const char *file, int32_t line, const char *func,
+    Uint64 current, const char *message)
+{
+    const Uint64 freq = SDL_GetPerformanceFrequency();
+    const double elapsed_start =
+        (double)(current - b->start) * 1000.0 / (double)freq;
+    const double elapsed_last =
+        (double)(current - b->last) * 1000.0 / (double)freq;
+
+    if (b->last != b->start) {
+        if (message == NULL) {
+            Log_Message(
+                file, line, func, "took %.02f ms (%.02f ms)", elapsed_start,
+                elapsed_last);
+        } else {
+            Log_Message(
+                file, line, func, "%s: took %.02f ms (%.02f ms)", message,
+                elapsed_start, elapsed_last);
+        }
+    } else {
+        if (message == NULL) {
+            Log_Message(file, line, func, "took %.02f ms", elapsed_start);
+        } else {
+            Log_Message(
+                file, line, func, "%s: took %.02f ms (%.02f ms)", message,
+                elapsed_start);
+        }
+    }
+}
+
 BENCHMARK *Benchmark_Start(void)
 {
     BENCHMARK *const b = Memory_Alloc(sizeof(BENCHMARK));
     b->start = SDL_GetPerformanceCounter();
+    b->last = b->start;
     return b;
 }
 
-void Benchmark_End_Impl(
-    const char *const file, const int32_t line, const char *const func,
-    BENCHMARK *b, const char *const message)
+void Benchmark_Tick_Impl(
+    BENCHMARK *const b, const char *const file, const int32_t line,
+    const char *const func, const char *const message)
 {
-    const double elapsed = (double)(SDL_GetPerformanceCounter() - b->start)
-        * 1000.0 / (double)SDL_GetPerformanceFrequency();
+    const Uint64 current = SDL_GetPerformanceCounter();
+    Benchmark_Log(b, file, line, func, current, message);
+    b->last = current;
+}
 
-    if (message == NULL) {
-        Log_Message(file, line, func, "took %.02f ms", elapsed);
-    } else {
-        Log_Message(file, line, func, "%s: took %.02f ms", message, elapsed);
-    }
-
+void Benchmark_End_Impl(
+    BENCHMARK *b, const char *const file, const int32_t line,
+    const char *const func, const char *const message)
+{
+    Benchmark_Tick_Impl(b, file, line, func, message);
     Memory_FreePointer(&b);
 }


### PR DESCRIPTION
- Added `Benchmark_Tick`, which allows measuring intermediate steps during a function's runtime, not just before and after the entire execution.
- Added milliseconds that show difference between the previous and current benchmark tick. For simple benchmarks (start to end) this information is skipped as there's no difference.