### PR TITLE
gfx: import from tr1x

### DIFF
--- a/include/libtrx/game/shell.h
+++ b/include/libtrx/game/shell.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void Shell_ExitSystem(const char *message);
+void Shell_ExitSystemFmt(const char *fmt, ...);

--- a/include/libtrx/gfx/2d/2d_renderer.h
+++ b/include/libtrx/gfx/2d/2d_renderer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "2d_surface.h"
+#include "../gl/buffer.h"
+#include "../gl/program.h"
+#include "../gl/sampler.h"
+#include "../gl/texture.h"
+#include "../gl/vertex_array.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct GFX_2D_Renderer {
+    uint32_t width;
+    uint32_t height;
+    GFX_GL_VertexArray surface_format;
+    GFX_GL_Buffer surface_buffer;
+    GFX_GL_Texture surface_texture;
+    GFX_GL_Sampler sampler;
+    GFX_GL_Program program;
+} GFX_2D_Renderer;
+
+void GFX_2D_Renderer_Init(GFX_2D_Renderer *renderer);
+void GFX_2D_Renderer_Close(GFX_2D_Renderer *renderer);
+
+void GFX_2D_Renderer_Upload(
+    GFX_2D_Renderer *renderer, GFX_2D_SurfaceDesc *desc, const uint8_t *data);
+void GFX_2D_Renderer_Render(GFX_2D_Renderer *renderer);

--- a/include/libtrx/gfx/2d/2d_surface.h
+++ b/include/libtrx/gfx/2d/2d_surface.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../gl/gl_core_3_3.h"
+
+#include "../../engine/image.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    int32_t width;
+    int32_t height;
+    int32_t pitch;
+    void *pixels;
+    int32_t bit_count;
+    GLenum tex_format;
+    GLenum tex_type;
+} GFX_2D_SurfaceDesc;
+
+typedef struct GFX_2D_Surface {
+    uint8_t *buffer;
+    GFX_2D_SurfaceDesc desc;
+    bool is_locked;
+    bool is_dirty;
+} GFX_2D_Surface;
+
+GFX_2D_Surface *GFX_2D_Surface_Create(const GFX_2D_SurfaceDesc *desc);
+GFX_2D_Surface *GFX_2D_Surface_CreateFromImage(const IMAGE *image);
+void GFX_2D_Surface_Free(GFX_2D_Surface *surface);
+
+void GFX_2D_Surface_Init(
+    GFX_2D_Surface *surface, const GFX_2D_SurfaceDesc *desc);
+void GFX_2D_Surface_Close(GFX_2D_Surface *surface);
+
+bool GFX_2D_Surface_Clear(GFX_2D_Surface *surface);
+
+bool GFX_2D_Surface_Lock(GFX_2D_Surface *surface, GFX_2D_SurfaceDesc *out_desc);
+bool GFX_2D_Surface_Unlock(GFX_2D_Surface *surface);

--- a/include/libtrx/gfx/3d/3d_renderer.h
+++ b/include/libtrx/gfx/3d/3d_renderer.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "vertex_stream.h"
+#include "../common.h"
+#include "../config.h"
+#include "../gl/gl_core_3_3.h"
+#include "../gl/program.h"
+#include "../gl/sampler.h"
+#include "../gl/texture.h"
+
+#define GFX_MAX_TEXTURES 128
+#define GFX_NO_TEXTURE (-1)
+#define GFX_ENV_MAP_TEXTURE (-2)
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+    GFX_BlendMode_Off,
+    GFX_BlendMode_Normal,
+    GFX_BlendMode_Multiply,
+} GFX_BlendMode;
+
+typedef struct GFX_3D_Renderer {
+    const GFX_CONFIG *config;
+
+    GFX_GL_Program program;
+    GFX_GL_Sampler sampler;
+    GFX_3D_VertexStream vertex_stream;
+
+    GFX_GL_Texture *textures[GFX_MAX_TEXTURES];
+    GFX_GL_Texture *env_map_texture;
+    int selected_texture_num;
+
+    // shader variable locations
+    GLint loc_mat_projection;
+    GLint loc_mat_model_view;
+    GLint loc_texturing_enabled;
+    GLint loc_smoothing_enabled;
+} GFX_3D_Renderer;
+
+void GFX_3D_Renderer_Init(GFX_3D_Renderer *renderer, const GFX_CONFIG *config);
+void GFX_3D_Renderer_Close(GFX_3D_Renderer *renderer);
+
+void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer);
+void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer);
+void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer);
+
+int GFX_3D_Renderer_RegisterTexturePage(
+    GFX_3D_Renderer *renderer, const void *data, int width, int height);
+bool GFX_3D_Renderer_UnregisterTexturePage(
+    GFX_3D_Renderer *renderer, int texture_num);
+
+int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_Renderer *renderer);
+bool GFX_3D_Renderer_UnregisterEnvironmentMap(
+    GFX_3D_Renderer *renderer, int texture_num);
+void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_Renderer *renderer);
+
+void GFX_3D_Renderer_SelectTexture(GFX_3D_Renderer *renderer, int texture_num);
+void GFX_3D_Renderer_RestoreTexture(GFX_3D_Renderer *renderer);
+
+void GFX_3D_Renderer_RenderPrimStrip(
+    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count);
+void GFX_3D_Renderer_RenderPrimFan(
+    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count);
+void GFX_3D_Renderer_RenderPrimList(
+    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count);
+
+void GFX_3D_Renderer_SetPrimType(
+    GFX_3D_Renderer *renderer, GFX_3D_PrimType value);
+void GFX_3D_Renderer_SetTextureFilter(
+    GFX_3D_Renderer *renderer, GFX_TEXTURE_FILTER filter);
+void GFX_3D_Renderer_SetDepthTestEnabled(
+    GFX_3D_Renderer *renderer, bool is_enabled);
+void GFX_3D_Renderer_SetBlendingMode(
+    GFX_3D_Renderer *renderer, GFX_BlendMode blend_mode);
+void GFX_3D_Renderer_SetTexturingEnabled(
+    GFX_3D_Renderer *renderer, bool is_enabled);

--- a/include/libtrx/gfx/3d/vertex_stream.h
+++ b/include/libtrx/gfx/3d/vertex_stream.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "../gl/buffer.h"
+#include "../gl/vertex_array.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef enum {
+    GFX_3D_PRIM_LINE = 0,
+    GFX_3D_PRIM_TRI = 1,
+} GFX_3D_PrimType;
+
+typedef struct {
+    float x, y, z;
+    float s, t, w;
+    float r, g, b, a;
+} GFX_3D_Vertex;
+
+typedef struct GFX_3D_VertexStream {
+    GFX_3D_PrimType prim_type;
+    size_t buffer_size;
+    GFX_GL_Buffer buffer;
+    GFX_GL_VertexArray vtc_format;
+    struct {
+        GFX_3D_Vertex *data;
+        size_t count;
+        size_t capacity;
+    } pending_vertices;
+} GFX_3D_VertexStream;
+
+void GFX_3D_VertexStream_Init(GFX_3D_VertexStream *vertex_stream);
+void GFX_3D_VertexStream_Close(GFX_3D_VertexStream *vertex_stream);
+
+void GFX_3D_VertexStream_Bind(GFX_3D_VertexStream *vertex_stream);
+
+void GFX_3D_VertexStream_SetPrimType(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_PrimType prim_type);
+
+bool GFX_3D_VertexStream_PushPrimStrip(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count);
+bool GFX_3D_VertexStream_PushPrimFan(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count);
+bool GFX_3D_VertexStream_PushPrimList(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count);
+
+void GFX_3D_VertexStream_RenderPending(GFX_3D_VertexStream *vertex_stream);

--- a/include/libtrx/gfx/common.h
+++ b/include/libtrx/gfx/common.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef enum GFX_TEXTURE_FILTER {
+    GFX_TF_FIRST = 0,
+    GFX_TF_NN = GFX_TF_FIRST,
+    GFX_TF_BILINEAR,
+    GFX_TF_LAST = GFX_TF_BILINEAR,
+    GFX_TF_NUMBER_OF,
+} GFX_TEXTURE_FILTER;
+
+typedef enum GFX_RENDER_MODE {
+    GFX_RM_LEGACY,
+    GFX_RM_FRAMEBUFFER,
+} GFX_RENDER_MODE;
+
+typedef enum GFX_GL_BACKEND {
+    GFX_GL_21,
+    GFX_GL_33C,
+} GFX_GL_BACKEND;

--- a/include/libtrx/gfx/config.h
+++ b/include/libtrx/gfx/config.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "common.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    GFX_TEXTURE_FILTER display_filter;
+    bool enable_wireframe;
+    int32_t line_width;
+} GFX_CONFIG;

--- a/include/libtrx/gfx/context.h
+++ b/include/libtrx/gfx/context.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "2d/2d_renderer.h"
+#include "3d/3d_renderer.h"
+#include "common.h"
+#include "renderers/fbo_renderer.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct GFX_CONTEXT GFX_CONTEXT;
+
+void GFX_Context_Attach(void *window_handle);
+void GFX_Context_Detach(void);
+
+void GFX_Context_SetDisplayFilter(GFX_TEXTURE_FILTER filter);
+void GFX_Context_SetWireframeMode(bool enable);
+void GFX_Context_SetLineWidth(int32_t line_width);
+void GFX_Context_SetAnisotropyFilter(float value);
+void GFX_Context_SetVSync(bool vsync);
+void GFX_Context_SetWindowSize(int32_t width, int32_t height);
+void GFX_Context_SetDisplaySize(int32_t width, int32_t height);
+void GFX_Context_SetRenderingMode(GFX_RENDER_MODE target_mode);
+
+void *GFX_Context_GetWindowHandle(void);
+int32_t GFX_Context_GetDisplayWidth(void);
+int32_t GFX_Context_GetDisplayHeight(void);
+
+void GFX_Context_Clear(void);
+void GFX_Context_SwapBuffers(void);
+void GFX_Context_SetRendered(void);
+
+void GFX_Context_SwitchToWindowViewport(void);
+void GFX_Context_SwitchToWindowViewportAR(void);
+void GFX_Context_SwitchToDisplayViewport(void);
+
+void GFX_Context_ScheduleScreenshot(const char *path);
+const char *GFX_Context_GetScheduledScreenshotPath(void);
+void GFX_Context_ClearScheduledScreenshotPath(void);
+
+GFX_2D_Renderer *GFX_Context_GetRenderer2D(void);
+GFX_3D_Renderer *GFX_Context_GetRenderer3D(void);

--- a/include/libtrx/gfx/gl/buffer.h
+++ b/include/libtrx/gfx/gl/buffer.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "gl_core_3_3.h"
+
+typedef struct GFX_GL_Buffer {
+    GLuint id;
+    GLenum target;
+} GFX_GL_Buffer;
+
+void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target);
+void GFX_GL_Buffer_Close(GFX_GL_Buffer *buf);
+
+void GFX_GL_Buffer_Bind(GFX_GL_Buffer *buf);
+void GFX_GL_Buffer_Data(
+    GFX_GL_Buffer *buf, GLsizei size, const void *data, GLenum usage);
+void GFX_GL_Buffer_SubData(
+    GFX_GL_Buffer *buf, GLsizei offset, GLsizei size, const void *data);
+void *GFX_GL_Buffer_Map(GFX_GL_Buffer *buf, GLenum access);
+void GFX_GL_Buffer_Unmap(GFX_GL_Buffer *buf);
+GLint GFX_GL_Buffer_Parameter(GFX_GL_Buffer *buf, GLenum pname);

--- a/include/libtrx/gfx/gl/gl_core_3_3.h
+++ b/include/libtrx/gfx/gl/gl_core_3_3.h
@@ -1,0 +1,3354 @@
+#ifndef OPENGL_NOLOAD_STYLE_H
+#define OPENGL_NOLOAD_STYLE_H
+
+#if defined(__glew_h__) || defined(__GLEW_H__)
+    #error Attempt to include auto-generated header after including glew.h
+#endif
+#if defined(__gl_h_) || defined(__GL_H__)
+    #error Attempt to include auto-generated header after including gl.h
+#endif
+#if defined(__glext_h_) || defined(__GLEXT_H_)
+    #error Attempt to include auto-generated header after including glext.h
+#endif
+#if defined(__gltypes_h_)
+    #error Attempt to include auto-generated header after gltypes.h
+#endif
+#if defined(__gl_ATI_h_)
+    #error Attempt to include auto-generated header after including glATI.h
+#endif
+
+#define __glew_h__
+#define __GLEW_H__
+#define __gl_h_
+#define __GL_H__
+#define __glext_h_
+#define __GLEXT_H_
+#define __gltypes_h_
+#define __gl_ATI_h_
+
+#ifndef APIENTRY
+    #if defined(__MINGW32__)
+        #ifndef WIN32_LEAN_AND_MEAN
+            #define WIN32_LEAN_AND_MEAN 1
+        #endif
+        #ifndef NOMINMAX
+            #define NOMINMAX
+        #endif
+        #include <windows.h>
+    #elif (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED)                     \
+        || defined(__BORLANDC__)
+        #ifndef WIN32_LEAN_AND_MEAN
+            #define WIN32_LEAN_AND_MEAN 1
+        #endif
+        #ifndef NOMINMAX
+            #define NOMINMAX
+        #endif
+        #include <windows.h>
+    #else
+        #define APIENTRY
+    #endif
+#endif /*APIENTRY*/
+
+#ifndef CODEGEN_FUNCPTR
+    #define CODEGEN_REMOVE_FUNCPTR
+    #if defined(_WIN32)
+        #define CODEGEN_FUNCPTR APIENTRY
+    #else
+        #define CODEGEN_FUNCPTR
+    #endif
+#endif /*CODEGEN_FUNCPTR*/
+
+#ifndef GLAPI
+    #define GLAPI extern
+#endif
+
+#ifndef GL_LOAD_GEN_BASIC_OPENGL_TYPEDEFS
+    #define GL_LOAD_GEN_BASIC_OPENGL_TYPEDEFS
+
+#endif /*GL_LOAD_GEN_BASIC_OPENGL_TYPEDEFS*/
+
+#include <stddef.h>
+#ifndef GLEXT_64_TYPES_DEFINED
+    /* This code block is duplicated in glxext.h, so must be protected */
+    #define GLEXT_64_TYPES_DEFINED
+    /* Define int32_t, int64_t, and uint64_t types for UST/MSC */
+    /* (as used in the GL_EXT_timer_query extension). */
+    #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+        #include <inttypes.h>
+    #elif defined(__sun__) || defined(__digital__)
+        #include <inttypes.h>
+        #if defined(__STDC__)
+            #if defined(__arch64__) || defined(_LP64)
+typedef long int int64_t;
+typedef unsigned long int uint64_t;
+            #else
+typedef long long int int64_t;
+typedef unsigned long long int uint64_t;
+            #endif /* __arch64__ */
+        #endif /* __STDC__ */
+    #elif defined(__VMS) || defined(__sgi)
+        #include <inttypes.h>
+    #elif defined(__SCO__) || defined(__USLC__)
+        #include <stdint.h>
+    #elif defined(__UNIXOS2__) || defined(__SOL64__)
+typedef long int int32_t;
+typedef long long int int64_t;
+typedef unsigned long long int uint64_t;
+    #elif defined(_WIN32) && defined(__GNUC__)
+        #include <stdint.h>
+    #elif defined(_WIN32)
+typedef __int32 int32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+    #else
+        /* Fallback if nothing above works */
+        #include <inttypes.h>
+    #endif
+#endif
+typedef unsigned int GLenum;
+typedef unsigned char GLboolean;
+typedef unsigned int GLbitfield;
+typedef void GLvoid;
+typedef signed char GLbyte;
+typedef short GLshort;
+typedef int GLint;
+typedef unsigned char GLubyte;
+typedef unsigned short GLushort;
+typedef unsigned int GLuint;
+typedef int GLsizei;
+typedef float GLfloat;
+typedef float GLclampf;
+typedef double GLdouble;
+typedef double GLclampd;
+typedef char GLchar;
+typedef char GLcharARB;
+#ifdef __APPLE__
+typedef void *GLhandleARB;
+#else
+typedef unsigned int GLhandleARB;
+#endif
+typedef unsigned short GLhalfARB;
+typedef unsigned short GLhalf;
+typedef GLint GLfixed;
+typedef ptrdiff_t GLintptr;
+typedef ptrdiff_t GLsizeiptr;
+typedef int64_t GLint64;
+typedef uint64_t GLuint64;
+typedef ptrdiff_t GLintptrARB;
+typedef ptrdiff_t GLsizeiptrARB;
+typedef int64_t GLint64EXT;
+typedef uint64_t GLuint64EXT;
+typedef struct __GLsync *GLsync;
+struct _cl_context;
+struct _cl_event;
+
+typedef void(APIENTRY *GLDEBUGPROC)(
+    GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+    const GLchar *message, const void *userParam);
+typedef void(APIENTRY *GLDEBUGPROCARB)(
+    GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+    const GLchar *message, const void *userParam);
+typedef void(APIENTRY *GLDEBUGPROCAMD)(
+    GLuint id, GLenum category, GLenum severity, GLsizei length,
+    const GLchar *message, void *userParam);
+typedef unsigned short GLhalfNV;
+typedef GLintptr GLvdpauSurfaceNV;
+
+#ifdef __cplusplus
+extern "C" {
+#endif /*__cplusplus*/
+
+/***********************/
+/* Extension Variables*/
+
+extern int ogl_ext_EXT_texture_compression_s3tc;
+extern int ogl_ext_EXT_texture_sRGB;
+extern int ogl_ext_EXT_texture_filter_anisotropic;
+extern int ogl_ext_ARB_compressed_texture_pixel_storage;
+extern int ogl_ext_ARB_conservative_depth;
+extern int ogl_ext_ARB_ES2_compatibility;
+extern int ogl_ext_ARB_get_program_binary;
+extern int ogl_ext_ARB_explicit_uniform_location;
+extern int ogl_ext_ARB_internalformat_query;
+extern int ogl_ext_ARB_internalformat_query2;
+extern int ogl_ext_ARB_map_buffer_alignment;
+extern int ogl_ext_ARB_program_interface_query;
+extern int ogl_ext_ARB_separate_shader_objects;
+extern int ogl_ext_ARB_shading_language_420pack;
+extern int ogl_ext_ARB_shading_language_packing;
+extern int ogl_ext_ARB_texture_buffer_range;
+extern int ogl_ext_ARB_texture_storage;
+extern int ogl_ext_ARB_texture_view;
+extern int ogl_ext_ARB_vertex_attrib_binding;
+extern int ogl_ext_ARB_viewport_array;
+extern int ogl_ext_ARB_arrays_of_arrays;
+extern int ogl_ext_ARB_clear_buffer_object;
+extern int ogl_ext_ARB_copy_image;
+extern int ogl_ext_ARB_ES3_compatibility;
+extern int ogl_ext_ARB_fragment_layer_viewport;
+extern int ogl_ext_ARB_framebuffer_no_attachments;
+extern int ogl_ext_ARB_invalidate_subdata;
+extern int ogl_ext_ARB_robust_buffer_access_behavior;
+extern int ogl_ext_ARB_stencil_texturing;
+extern int ogl_ext_ARB_texture_query_levels;
+extern int ogl_ext_ARB_texture_storage_multisample;
+extern int ogl_ext_KHR_debug;
+extern int ogl_ext_ARB_buffer_storage;
+extern int ogl_ext_ARB_clear_texture;
+extern int ogl_ext_ARB_enhanced_layouts;
+extern int ogl_ext_ARB_multi_bind;
+extern int ogl_ext_ARB_query_buffer_object;
+extern int ogl_ext_ARB_texture_mirror_clamp_to_edge;
+extern int ogl_ext_ARB_texture_stencil8;
+extern int ogl_ext_ARB_vertex_type_10f_11f_11f_rev;
+extern int ogl_ext_ARB_seamless_cubemap_per_texture;
+extern int ogl_ext_ARB_clip_control;
+extern int ogl_ext_ARB_conditional_render_inverted;
+extern int ogl_ext_ARB_cull_distance;
+extern int ogl_ext_ARB_derivative_control;
+extern int ogl_ext_ARB_direct_state_access;
+extern int ogl_ext_ARB_get_texture_sub_image;
+extern int ogl_ext_ARB_shader_texture_image_samples;
+extern int ogl_ext_ARB_texture_barrier;
+extern int ogl_ext_KHR_context_flush_control;
+extern int ogl_ext_KHR_robust_buffer_access_behavior;
+extern int ogl_ext_KHR_robustness;
+
+/* Extension: EXT_texture_compression_s3tc*/
+#define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT 0x83F1
+#define GL_COMPRESSED_RGBA_S3TC_DXT3_EXT 0x83F2
+#define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT 0x83F3
+#define GL_COMPRESSED_RGB_S3TC_DXT1_EXT 0x83F0
+
+/* Extension: EXT_texture_sRGB*/
+#define GL_COMPRESSED_SLUMINANCE_ALPHA_EXT 0x8C4B
+#define GL_COMPRESSED_SLUMINANCE_EXT 0x8C4A
+#define GL_COMPRESSED_SRGB_ALPHA_EXT 0x8C49
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT 0x8C4D
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT 0x8C4E
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT 0x8C4F
+#define GL_COMPRESSED_SRGB_EXT 0x8C48
+#define GL_COMPRESSED_SRGB_S3TC_DXT1_EXT 0x8C4C
+#define GL_SLUMINANCE8_ALPHA8_EXT 0x8C45
+#define GL_SLUMINANCE8_EXT 0x8C47
+#define GL_SLUMINANCE_ALPHA_EXT 0x8C44
+#define GL_SLUMINANCE_EXT 0x8C46
+#define GL_SRGB8_ALPHA8_EXT 0x8C43
+#define GL_SRGB8_EXT 0x8C41
+#define GL_SRGB_ALPHA_EXT 0x8C42
+#define GL_SRGB_EXT 0x8C40
+
+/* Extension: EXT_texture_filter_anisotropic*/
+#define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
+#define GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
+
+/* Extension: ARB_compressed_texture_pixel_storage*/
+#define GL_PACK_COMPRESSED_BLOCK_DEPTH 0x912D
+#define GL_PACK_COMPRESSED_BLOCK_HEIGHT 0x912C
+#define GL_PACK_COMPRESSED_BLOCK_SIZE 0x912E
+#define GL_PACK_COMPRESSED_BLOCK_WIDTH 0x912B
+#define GL_UNPACK_COMPRESSED_BLOCK_DEPTH 0x9129
+#define GL_UNPACK_COMPRESSED_BLOCK_HEIGHT 0x9128
+#define GL_UNPACK_COMPRESSED_BLOCK_SIZE 0x912A
+#define GL_UNPACK_COMPRESSED_BLOCK_WIDTH 0x9127
+
+/* Extension: ARB_ES2_compatibility*/
+#define GL_FIXED 0x140C
+#define GL_HIGH_FLOAT 0x8DF2
+#define GL_HIGH_INT 0x8DF5
+#define GL_IMPLEMENTATION_COLOR_READ_FORMAT 0x8B9B
+#define GL_IMPLEMENTATION_COLOR_READ_TYPE 0x8B9A
+#define GL_LOW_FLOAT 0x8DF0
+#define GL_LOW_INT 0x8DF3
+#define GL_MAX_FRAGMENT_UNIFORM_VECTORS 0x8DFD
+#define GL_MAX_VARYING_VECTORS 0x8DFC
+#define GL_MAX_VERTEX_UNIFORM_VECTORS 0x8DFB
+#define GL_MEDIUM_FLOAT 0x8DF1
+#define GL_MEDIUM_INT 0x8DF4
+#define GL_NUM_SHADER_BINARY_FORMATS 0x8DF9
+#define GL_RGB565 0x8D62
+#define GL_SHADER_BINARY_FORMATS 0x8DF8
+#define GL_SHADER_COMPILER 0x8DFA
+
+/* Extension: ARB_get_program_binary*/
+#define GL_NUM_PROGRAM_BINARY_FORMATS 0x87FE
+#define GL_PROGRAM_BINARY_FORMATS 0x87FF
+#define GL_PROGRAM_BINARY_LENGTH 0x8741
+#define GL_PROGRAM_BINARY_RETRIEVABLE_HINT 0x8257
+
+/* Extension: ARB_explicit_uniform_location*/
+#define GL_MAX_UNIFORM_LOCATIONS 0x826E
+
+/* Extension: ARB_internalformat_query*/
+#define GL_NUM_SAMPLE_COUNTS 0x9380
+
+/* Extension: ARB_internalformat_query2*/
+#define GL_AUTO_GENERATE_MIPMAP 0x8295
+#define GL_CAVEAT_SUPPORT 0x82B8
+#define GL_CLEAR_BUFFER 0x82B4
+#define GL_COLOR_COMPONENTS 0x8283
+#define GL_COLOR_ENCODING 0x8296
+#define GL_COLOR_RENDERABLE 0x8286
+#define GL_COMPUTE_TEXTURE 0x82A0
+#define GL_DEPTH_COMPONENTS 0x8284
+#define GL_DEPTH_RENDERABLE 0x8287
+#define GL_FILTER 0x829A
+#define GL_FRAGMENT_TEXTURE 0x829F
+#define GL_FRAMEBUFFER_BLEND 0x828B
+#define GL_FRAMEBUFFER_RENDERABLE 0x8289
+#define GL_FRAMEBUFFER_RENDERABLE_LAYERED 0x828A
+#define GL_FULL_SUPPORT 0x82B7
+#define GL_GEOMETRY_TEXTURE 0x829E
+#define GL_GET_TEXTURE_IMAGE_FORMAT 0x8291
+#define GL_GET_TEXTURE_IMAGE_TYPE 0x8292
+#define GL_IMAGE_CLASS_10_10_10_2 0x82C3
+#define GL_IMAGE_CLASS_11_11_10 0x82C2
+#define GL_IMAGE_CLASS_1_X_16 0x82BE
+#define GL_IMAGE_CLASS_1_X_32 0x82BB
+#define GL_IMAGE_CLASS_1_X_8 0x82C1
+#define GL_IMAGE_CLASS_2_X_16 0x82BD
+#define GL_IMAGE_CLASS_2_X_32 0x82BA
+#define GL_IMAGE_CLASS_2_X_8 0x82C0
+#define GL_IMAGE_CLASS_4_X_16 0x82BC
+#define GL_IMAGE_CLASS_4_X_32 0x82B9
+#define GL_IMAGE_CLASS_4_X_8 0x82BF
+#define GL_IMAGE_COMPATIBILITY_CLASS 0x82A8
+#define GL_IMAGE_FORMAT_COMPATIBILITY_TYPE 0x90C7
+#define GL_IMAGE_PIXEL_FORMAT 0x82A9
+#define GL_IMAGE_PIXEL_TYPE 0x82AA
+#define GL_IMAGE_TEXEL_SIZE 0x82A7
+#define GL_INTERNALFORMAT_ALPHA_SIZE 0x8274
+#define GL_INTERNALFORMAT_ALPHA_TYPE 0x827B
+#define GL_INTERNALFORMAT_BLUE_SIZE 0x8273
+#define GL_INTERNALFORMAT_BLUE_TYPE 0x827A
+#define GL_INTERNALFORMAT_DEPTH_SIZE 0x8275
+#define GL_INTERNALFORMAT_DEPTH_TYPE 0x827C
+#define GL_INTERNALFORMAT_GREEN_SIZE 0x8272
+#define GL_INTERNALFORMAT_GREEN_TYPE 0x8279
+#define GL_INTERNALFORMAT_PREFERRED 0x8270
+#define GL_INTERNALFORMAT_RED_SIZE 0x8271
+#define GL_INTERNALFORMAT_RED_TYPE 0x8278
+#define GL_INTERNALFORMAT_SHARED_SIZE 0x8277
+#define GL_INTERNALFORMAT_STENCIL_SIZE 0x8276
+#define GL_INTERNALFORMAT_STENCIL_TYPE 0x827D
+#define GL_INTERNALFORMAT_SUPPORTED 0x826F
+#define GL_MANUAL_GENERATE_MIPMAP 0x8294
+#define GL_MAX_COMBINED_DIMENSIONS 0x8282
+#define GL_MAX_DEPTH 0x8280
+#define GL_MAX_HEIGHT 0x827F
+#define GL_MAX_LAYERS 0x8281
+#define GL_MAX_WIDTH 0x827E
+#define GL_MIPMAP 0x8293
+/*GL_NUM_SAMPLE_COUNTS seen in ARB_internalformat_query*/
+#define GL_READ_PIXELS 0x828C
+#define GL_READ_PIXELS_FORMAT 0x828D
+#define GL_READ_PIXELS_TYPE 0x828E
+#define GL_RENDERBUFFER 0x8D41
+#define GL_SAMPLES 0x80A9
+#define GL_SHADER_IMAGE_ATOMIC 0x82A6
+#define GL_SHADER_IMAGE_LOAD 0x82A4
+#define GL_SHADER_IMAGE_STORE 0x82A5
+#define GL_SIMULTANEOUS_TEXTURE_AND_DEPTH_TEST 0x82AC
+#define GL_SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE 0x82AE
+#define GL_SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST 0x82AD
+#define GL_SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE 0x82AF
+#define GL_SRGB_DECODE_ARB 0x8299
+#define GL_SRGB_READ 0x8297
+#define GL_SRGB_WRITE 0x8298
+#define GL_STENCIL_COMPONENTS 0x8285
+#define GL_STENCIL_RENDERABLE 0x8288
+#define GL_TESS_CONTROL_TEXTURE 0x829C
+#define GL_TESS_EVALUATION_TEXTURE 0x829D
+#define GL_TEXTURE_1D 0x0DE0
+#define GL_TEXTURE_1D_ARRAY 0x8C18
+#define GL_TEXTURE_2D 0x0DE1
+#define GL_TEXTURE_2D_ARRAY 0x8C1A
+#define GL_TEXTURE_2D_MULTISAMPLE 0x9100
+#define GL_TEXTURE_2D_MULTISAMPLE_ARRAY 0x9102
+#define GL_TEXTURE_3D 0x806F
+#define GL_TEXTURE_BUFFER 0x8C2A
+#define GL_TEXTURE_COMPRESSED 0x86A1
+#define GL_TEXTURE_COMPRESSED_BLOCK_HEIGHT 0x82B2
+#define GL_TEXTURE_COMPRESSED_BLOCK_SIZE 0x82B3
+#define GL_TEXTURE_COMPRESSED_BLOCK_WIDTH 0x82B1
+#define GL_TEXTURE_CUBE_MAP 0x8513
+#define GL_TEXTURE_CUBE_MAP_ARRAY 0x9009
+#define GL_TEXTURE_GATHER 0x82A2
+#define GL_TEXTURE_GATHER_SHADOW 0x82A3
+#define GL_TEXTURE_IMAGE_FORMAT 0x828F
+#define GL_TEXTURE_IMAGE_TYPE 0x8290
+#define GL_TEXTURE_RECTANGLE 0x84F5
+#define GL_TEXTURE_SHADOW 0x82A1
+#define GL_TEXTURE_VIEW 0x82B5
+#define GL_VERTEX_TEXTURE 0x829B
+#define GL_VIEW_CLASS_128_BITS 0x82C4
+#define GL_VIEW_CLASS_16_BITS 0x82CA
+#define GL_VIEW_CLASS_24_BITS 0x82C9
+#define GL_VIEW_CLASS_32_BITS 0x82C8
+#define GL_VIEW_CLASS_48_BITS 0x82C7
+#define GL_VIEW_CLASS_64_BITS 0x82C6
+#define GL_VIEW_CLASS_8_BITS 0x82CB
+#define GL_VIEW_CLASS_96_BITS 0x82C5
+#define GL_VIEW_CLASS_BPTC_FLOAT 0x82D3
+#define GL_VIEW_CLASS_BPTC_UNORM 0x82D2
+#define GL_VIEW_CLASS_RGTC1_RED 0x82D0
+#define GL_VIEW_CLASS_RGTC2_RG 0x82D1
+#define GL_VIEW_CLASS_S3TC_DXT1_RGB 0x82CC
+#define GL_VIEW_CLASS_S3TC_DXT1_RGBA 0x82CD
+#define GL_VIEW_CLASS_S3TC_DXT3_RGBA 0x82CE
+#define GL_VIEW_CLASS_S3TC_DXT5_RGBA 0x82CF
+#define GL_VIEW_COMPATIBILITY_CLASS 0x82B6
+
+/* Extension: ARB_map_buffer_alignment*/
+#define GL_MIN_MAP_BUFFER_ALIGNMENT 0x90BC
+
+/* Extension: ARB_program_interface_query*/
+#define GL_ACTIVE_RESOURCES 0x92F5
+#define GL_ACTIVE_VARIABLES 0x9305
+#define GL_ARRAY_SIZE 0x92FB
+#define GL_ARRAY_STRIDE 0x92FE
+#define GL_ATOMIC_COUNTER_BUFFER 0x92C0
+#define GL_ATOMIC_COUNTER_BUFFER_INDEX 0x9301
+#define GL_BLOCK_INDEX 0x92FD
+#define GL_BUFFER_BINDING 0x9302
+#define GL_BUFFER_DATA_SIZE 0x9303
+#define GL_BUFFER_VARIABLE 0x92E5
+#define GL_COMPATIBLE_SUBROUTINES 0x8E4B
+#define GL_COMPUTE_SUBROUTINE 0x92ED
+#define GL_COMPUTE_SUBROUTINE_UNIFORM 0x92F3
+#define GL_FRAGMENT_SUBROUTINE 0x92EC
+#define GL_FRAGMENT_SUBROUTINE_UNIFORM 0x92F2
+#define GL_GEOMETRY_SUBROUTINE 0x92EB
+#define GL_GEOMETRY_SUBROUTINE_UNIFORM 0x92F1
+#define GL_IS_PER_PATCH 0x92E7
+#define GL_IS_ROW_MAJOR 0x9300
+#define GL_LOCATION 0x930E
+#define GL_LOCATION_INDEX 0x930F
+#define GL_MATRIX_STRIDE 0x92FF
+#define GL_MAX_NAME_LENGTH 0x92F6
+#define GL_MAX_NUM_ACTIVE_VARIABLES 0x92F7
+#define GL_MAX_NUM_COMPATIBLE_SUBROUTINES 0x92F8
+#define GL_NAME_LENGTH 0x92F9
+#define GL_NUM_ACTIVE_VARIABLES 0x9304
+#define GL_NUM_COMPATIBLE_SUBROUTINES 0x8E4A
+#define GL_OFFSET 0x92FC
+#define GL_PROGRAM_INPUT 0x92E3
+#define GL_PROGRAM_OUTPUT 0x92E4
+#define GL_REFERENCED_BY_COMPUTE_SHADER 0x930B
+#define GL_REFERENCED_BY_FRAGMENT_SHADER 0x930A
+#define GL_REFERENCED_BY_GEOMETRY_SHADER 0x9309
+#define GL_REFERENCED_BY_TESS_CONTROL_SHADER 0x9307
+#define GL_REFERENCED_BY_TESS_EVALUATION_SHADER 0x9308
+#define GL_REFERENCED_BY_VERTEX_SHADER 0x9306
+#define GL_SHADER_STORAGE_BLOCK 0x92E6
+#define GL_TESS_CONTROL_SUBROUTINE 0x92E9
+#define GL_TESS_CONTROL_SUBROUTINE_UNIFORM 0x92EF
+#define GL_TESS_EVALUATION_SUBROUTINE 0x92EA
+#define GL_TESS_EVALUATION_SUBROUTINE_UNIFORM 0x92F0
+#define GL_TOP_LEVEL_ARRAY_SIZE 0x930C
+#define GL_TOP_LEVEL_ARRAY_STRIDE 0x930D
+#define GL_TRANSFORM_FEEDBACK_VARYING 0x92F4
+#define GL_TYPE 0x92FA
+#define GL_UNIFORM 0x92E1
+#define GL_UNIFORM_BLOCK 0x92E2
+#define GL_VERTEX_SUBROUTINE 0x92E8
+#define GL_VERTEX_SUBROUTINE_UNIFORM 0x92EE
+
+/* Extension: ARB_separate_shader_objects*/
+#define GL_ACTIVE_PROGRAM 0x8259
+#define GL_ALL_SHADER_BITS 0xFFFFFFFF
+#define GL_FRAGMENT_SHADER_BIT 0x00000002
+#define GL_GEOMETRY_SHADER_BIT 0x00000004
+#define GL_PROGRAM_PIPELINE_BINDING 0x825A
+#define GL_PROGRAM_SEPARABLE 0x8258
+#define GL_TESS_CONTROL_SHADER_BIT 0x00000008
+#define GL_TESS_EVALUATION_SHADER_BIT 0x00000010
+#define GL_VERTEX_SHADER_BIT 0x00000001
+
+/* Extension: ARB_texture_buffer_range*/
+#define GL_TEXTURE_BUFFER_OFFSET 0x919D
+#define GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT 0x919F
+#define GL_TEXTURE_BUFFER_SIZE 0x919E
+
+/* Extension: ARB_texture_storage*/
+#define GL_TEXTURE_IMMUTABLE_FORMAT 0x912F
+
+/* Extension: ARB_texture_view*/
+#define GL_TEXTURE_IMMUTABLE_LEVELS 0x82DF
+#define GL_TEXTURE_VIEW_MIN_LAYER 0x82DD
+#define GL_TEXTURE_VIEW_MIN_LEVEL 0x82DB
+#define GL_TEXTURE_VIEW_NUM_LAYERS 0x82DE
+#define GL_TEXTURE_VIEW_NUM_LEVELS 0x82DC
+
+/* Extension: ARB_vertex_attrib_binding*/
+#define GL_MAX_VERTEX_ATTRIB_BINDINGS 0x82DA
+#define GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET 0x82D9
+#define GL_VERTEX_ATTRIB_BINDING 0x82D4
+#define GL_VERTEX_ATTRIB_RELATIVE_OFFSET 0x82D5
+#define GL_VERTEX_BINDING_DIVISOR 0x82D6
+#define GL_VERTEX_BINDING_OFFSET 0x82D7
+#define GL_VERTEX_BINDING_STRIDE 0x82D8
+
+/* Extension: ARB_viewport_array*/
+#define GL_DEPTH_RANGE 0x0B70
+#define GL_FIRST_VERTEX_CONVENTION 0x8E4D
+#define GL_LAST_VERTEX_CONVENTION 0x8E4E
+#define GL_LAYER_PROVOKING_VERTEX 0x825E
+#define GL_MAX_VIEWPORTS 0x825B
+#define GL_PROVOKING_VERTEX 0x8E4F
+#define GL_SCISSOR_BOX 0x0C10
+#define GL_SCISSOR_TEST 0x0C11
+#define GL_UNDEFINED_VERTEX 0x8260
+#define GL_VIEWPORT 0x0BA2
+#define GL_VIEWPORT_BOUNDS_RANGE 0x825D
+#define GL_VIEWPORT_INDEX_PROVOKING_VERTEX 0x825F
+#define GL_VIEWPORT_SUBPIXEL_BITS 0x825C
+
+/* Extension: ARB_ES3_compatibility*/
+#define GL_ANY_SAMPLES_PASSED_CONSERVATIVE 0x8D6A
+#define GL_COMPRESSED_R11_EAC 0x9270
+#define GL_COMPRESSED_RG11_EAC 0x9272
+#define GL_COMPRESSED_RGB8_ETC2 0x9274
+#define GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 0x9276
+#define GL_COMPRESSED_RGBA8_ETC2_EAC 0x9278
+#define GL_COMPRESSED_SIGNED_R11_EAC 0x9271
+#define GL_COMPRESSED_SIGNED_RG11_EAC 0x9273
+#define GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC 0x9279
+#define GL_COMPRESSED_SRGB8_ETC2 0x9275
+#define GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 0x9277
+#define GL_MAX_ELEMENT_INDEX 0x8D6B
+#define GL_PRIMITIVE_RESTART_FIXED_INDEX 0x8D69
+
+/* Extension: ARB_framebuffer_no_attachments*/
+#define GL_FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS 0x9314
+#define GL_FRAMEBUFFER_DEFAULT_HEIGHT 0x9311
+#define GL_FRAMEBUFFER_DEFAULT_LAYERS 0x9312
+#define GL_FRAMEBUFFER_DEFAULT_SAMPLES 0x9313
+#define GL_FRAMEBUFFER_DEFAULT_WIDTH 0x9310
+#define GL_MAX_FRAMEBUFFER_HEIGHT 0x9316
+#define GL_MAX_FRAMEBUFFER_LAYERS 0x9317
+#define GL_MAX_FRAMEBUFFER_SAMPLES 0x9318
+#define GL_MAX_FRAMEBUFFER_WIDTH 0x9315
+
+/* Extension: ARB_stencil_texturing*/
+#define GL_DEPTH_STENCIL_TEXTURE_MODE 0x90EA
+
+/* Extension: KHR_debug*/
+#define GL_BUFFER 0x82E0
+#define GL_CONTEXT_FLAG_DEBUG_BIT 0x00000002
+#define GL_DEBUG_CALLBACK_FUNCTION 0x8244
+#define GL_DEBUG_CALLBACK_USER_PARAM 0x8245
+#define GL_DEBUG_GROUP_STACK_DEPTH 0x826D
+#define GL_DEBUG_LOGGED_MESSAGES 0x9145
+#define GL_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH 0x8243
+#define GL_DEBUG_OUTPUT 0x92E0
+#define GL_DEBUG_OUTPUT_SYNCHRONOUS 0x8242
+#define GL_DEBUG_SEVERITY_HIGH 0x9146
+#define GL_DEBUG_SEVERITY_LOW 0x9148
+#define GL_DEBUG_SEVERITY_MEDIUM 0x9147
+#define GL_DEBUG_SEVERITY_NOTIFICATION 0x826B
+#define GL_DEBUG_SOURCE_API 0x8246
+#define GL_DEBUG_SOURCE_APPLICATION 0x824A
+#define GL_DEBUG_SOURCE_OTHER 0x824B
+#define GL_DEBUG_SOURCE_SHADER_COMPILER 0x8248
+#define GL_DEBUG_SOURCE_THIRD_PARTY 0x8249
+#define GL_DEBUG_SOURCE_WINDOW_SYSTEM 0x8247
+#define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
+#define GL_DEBUG_TYPE_ERROR 0x824C
+#define GL_DEBUG_TYPE_MARKER 0x8268
+#define GL_DEBUG_TYPE_OTHER 0x8251
+#define GL_DEBUG_TYPE_PERFORMANCE 0x8250
+#define GL_DEBUG_TYPE_POP_GROUP 0x826A
+#define GL_DEBUG_TYPE_PORTABILITY 0x824F
+#define GL_DEBUG_TYPE_PUSH_GROUP 0x8269
+#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR 0x824E
+#define GL_DISPLAY_LIST 0x82E7
+#define GL_MAX_DEBUG_GROUP_STACK_DEPTH 0x826C
+#define GL_MAX_DEBUG_LOGGED_MESSAGES 0x9144
+#define GL_MAX_DEBUG_MESSAGE_LENGTH 0x9143
+#define GL_MAX_LABEL_LENGTH 0x82E8
+#define GL_PROGRAM 0x82E2
+#define GL_PROGRAM_PIPELINE 0x82E4
+#define GL_QUERY 0x82E3
+#define GL_SAMPLER 0x82E6
+#define GL_SHADER 0x82E1
+#define GL_STACK_OVERFLOW 0x0503
+#define GL_STACK_UNDERFLOW 0x0504
+#define GL_VERTEX_ARRAY 0x8074
+/*GL_VERTEX_ARRAY seen in KHR_debug*/
+
+/* Extension: ARB_buffer_storage*/
+#define GL_BUFFER_IMMUTABLE_STORAGE 0x821F
+#define GL_BUFFER_STORAGE_FLAGS 0x8220
+#define GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT 0x00004000
+#define GL_CLIENT_STORAGE_BIT 0x0200
+#define GL_DYNAMIC_STORAGE_BIT 0x0100
+#define GL_MAP_COHERENT_BIT 0x0080
+#define GL_MAP_PERSISTENT_BIT 0x0040
+#define GL_MAP_READ_BIT 0x0001
+#define GL_MAP_WRITE_BIT 0x0002
+
+/* Extension: ARB_clear_texture*/
+#define GL_CLEAR_TEXTURE 0x9365
+
+/* Extension: ARB_enhanced_layouts*/
+#define GL_LOCATION_COMPONENT 0x934A
+#define GL_TRANSFORM_FEEDBACK_BUFFER 0x8C8E
+#define GL_TRANSFORM_FEEDBACK_BUFFER_INDEX 0x934B
+#define GL_TRANSFORM_FEEDBACK_BUFFER_STRIDE 0x934C
+
+/* Extension: ARB_query_buffer_object*/
+#define GL_QUERY_BUFFER 0x9192
+#define GL_QUERY_BUFFER_BARRIER_BIT 0x00008000
+#define GL_QUERY_BUFFER_BINDING 0x9193
+#define GL_QUERY_RESULT_NO_WAIT 0x9194
+
+/* Extension: ARB_texture_mirror_clamp_to_edge*/
+#define GL_MIRROR_CLAMP_TO_EDGE 0x8743
+
+/* Extension: ARB_texture_stencil8*/
+#define GL_STENCIL_INDEX 0x1901
+#define GL_STENCIL_INDEX8 0x8D48
+
+/* Extension: ARB_vertex_type_10f_11f_11f_rev*/
+#define GL_UNSIGNED_INT_10F_11F_11F_REV 0x8C3B
+
+/* Extension: ARB_seamless_cubemap_per_texture*/
+#define GL_TEXTURE_CUBE_MAP_SEAMLESS 0x884F
+
+/* Extension: ARB_clip_control*/
+#define GL_CLIP_DEPTH_MODE 0x935D
+#define GL_CLIP_ORIGIN 0x935C
+#define GL_LOWER_LEFT 0x8CA1
+#define GL_NEGATIVE_ONE_TO_ONE 0x935E
+#define GL_UPPER_LEFT 0x8CA2
+#define GL_ZERO_TO_ONE 0x935F
+
+/* Extension: ARB_conditional_render_inverted*/
+#define GL_QUERY_BY_REGION_NO_WAIT_INVERTED 0x8E1A
+#define GL_QUERY_BY_REGION_WAIT_INVERTED 0x8E19
+#define GL_QUERY_NO_WAIT_INVERTED 0x8E18
+#define GL_QUERY_WAIT_INVERTED 0x8E17
+
+/* Extension: ARB_cull_distance*/
+#define GL_MAX_COMBINED_CLIP_AND_CULL_DISTANCES 0x82FA
+#define GL_MAX_CULL_DISTANCES 0x82F9
+
+/* Extension: ARB_direct_state_access*/
+#define GL_QUERY_TARGET 0x82EA
+#define GL_TEXTURE_BINDING_1D 0x8068
+#define GL_TEXTURE_BINDING_1D_ARRAY 0x8C1C
+#define GL_TEXTURE_BINDING_2D 0x8069
+#define GL_TEXTURE_BINDING_2D_ARRAY 0x8C1D
+#define GL_TEXTURE_BINDING_2D_MULTISAMPLE 0x9104
+#define GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY 0x9105
+#define GL_TEXTURE_BINDING_3D 0x806A
+#define GL_TEXTURE_BINDING_BUFFER 0x8C2C
+#define GL_TEXTURE_BINDING_CUBE_MAP 0x8514
+#define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY 0x900A
+#define GL_TEXTURE_BINDING_RECTANGLE 0x84F6
+#define GL_TEXTURE_TARGET 0x1006
+
+/* Extension: KHR_context_flush_control*/
+#define GL_CONTEXT_RELEASE_BEHAVIOR 0x82FB
+#define GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH 0x82FC
+#define GL_NONE 0
+
+/* Extension: KHR_robustness*/
+#define GL_CONTEXT_LOST 0x0507
+#define GL_CONTEXT_ROBUST_ACCESS 0x90F3
+#define GL_GUILTY_CONTEXT_RESET 0x8253
+#define GL_INNOCENT_CONTEXT_RESET 0x8254
+#define GL_LOSE_CONTEXT_ON_RESET 0x8252
+#define GL_NO_ERROR 0
+#define GL_NO_RESET_NOTIFICATION 0x8261
+#define GL_RESET_NOTIFICATION_STRATEGY 0x8256
+#define GL_UNKNOWN_CONTEXT_RESET 0x8255
+
+/* Version: 1.1*/
+#define GL_ALPHA 0x1906
+#define GL_ALWAYS 0x0207
+#define GL_AND 0x1501
+#define GL_AND_INVERTED 0x1504
+#define GL_AND_REVERSE 0x1502
+#define GL_BACK 0x0405
+#define GL_BACK_LEFT 0x0402
+#define GL_BACK_RIGHT 0x0403
+#define GL_BLEND 0x0BE2
+#define GL_BLEND_DST 0x0BE0
+#define GL_BLEND_SRC 0x0BE1
+#define GL_BLUE 0x1905
+#define GL_BYTE 0x1400
+#define GL_CCW 0x0901
+#define GL_CLEAR 0x1500
+#define GL_COLOR 0x1800
+#define GL_COLOR_BUFFER_BIT 0x00004000
+#define GL_COLOR_CLEAR_VALUE 0x0C22
+#define GL_COLOR_LOGIC_OP 0x0BF2
+#define GL_COLOR_WRITEMASK 0x0C23
+#define GL_COPY 0x1503
+#define GL_COPY_INVERTED 0x150C
+#define GL_CULL_FACE 0x0B44
+#define GL_CULL_FACE_MODE 0x0B45
+#define GL_CW 0x0900
+#define GL_DECR 0x1E03
+#define GL_DEPTH 0x1801
+#define GL_DEPTH_BUFFER_BIT 0x00000100
+#define GL_DEPTH_CLEAR_VALUE 0x0B73
+#define GL_DEPTH_COMPONENT 0x1902
+#define GL_DEPTH_FUNC 0x0B74
+/*GL_DEPTH_RANGE seen in ARB_viewport_array*/
+#define GL_DEPTH_TEST 0x0B71
+#define GL_DEPTH_WRITEMASK 0x0B72
+#define GL_DITHER 0x0BD0
+#define GL_DONT_CARE 0x1100
+#define GL_DOUBLE 0x140A
+#define GL_DOUBLEBUFFER 0x0C32
+#define GL_DRAW_BUFFER 0x0C01
+#define GL_DST_ALPHA 0x0304
+#define GL_DST_COLOR 0x0306
+#define GL_EQUAL 0x0202
+#define GL_EQUIV 0x1509
+#define GL_EXTENSIONS 0x1F03
+#define GL_FALSE 0
+#define GL_FASTEST 0x1101
+#define GL_FILL 0x1B02
+#define GL_FLOAT 0x1406
+#define GL_FRONT 0x0404
+#define GL_FRONT_AND_BACK 0x0408
+#define GL_FRONT_FACE 0x0B46
+#define GL_FRONT_LEFT 0x0400
+#define GL_FRONT_RIGHT 0x0401
+#define GL_GEQUAL 0x0206
+#define GL_GREATER 0x0204
+#define GL_GREEN 0x1904
+#define GL_INCR 0x1E02
+#define GL_INT 0x1404
+#define GL_INVALID_ENUM 0x0500
+#define GL_INVALID_OPERATION 0x0502
+#define GL_INVALID_VALUE 0x0501
+#define GL_INVERT 0x150A
+#define GL_KEEP 0x1E00
+#define GL_LEFT 0x0406
+#define GL_LEQUAL 0x0203
+#define GL_LESS 0x0201
+#define GL_LINE 0x1B01
+#define GL_LINEAR 0x2601
+#define GL_LINEAR_MIPMAP_LINEAR 0x2703
+#define GL_LINEAR_MIPMAP_NEAREST 0x2701
+#define GL_LINES 0x0001
+#define GL_LINE_LOOP 0x0002
+#define GL_LINE_SMOOTH 0x0B20
+#define GL_LINE_SMOOTH_HINT 0x0C52
+#define GL_LINE_STRIP 0x0003
+#define GL_LINE_WIDTH 0x0B21
+#define GL_LINE_WIDTH_GRANULARITY 0x0B23
+#define GL_LINE_WIDTH_RANGE 0x0B22
+#define GL_LOGIC_OP_MODE 0x0BF0
+#define GL_MAX_TEXTURE_SIZE 0x0D33
+#define GL_MAX_VIEWPORT_DIMS 0x0D3A
+#define GL_NAND 0x150E
+#define GL_NEAREST 0x2600
+#define GL_NEAREST_MIPMAP_LINEAR 0x2702
+#define GL_NEAREST_MIPMAP_NEAREST 0x2700
+#define GL_NEVER 0x0200
+#define GL_NICEST 0x1102
+/*GL_NONE seen in KHR_context_flush_control*/
+#define GL_NOOP 0x1505
+#define GL_NOR 0x1508
+#define GL_NOTEQUAL 0x0205
+/*GL_NO_ERROR seen in KHR_robustness*/
+#define GL_ONE 1
+#define GL_ONE_MINUS_DST_ALPHA 0x0305
+#define GL_ONE_MINUS_DST_COLOR 0x0307
+#define GL_ONE_MINUS_SRC_ALPHA 0x0303
+#define GL_ONE_MINUS_SRC_COLOR 0x0301
+#define GL_OR 0x1507
+#define GL_OR_INVERTED 0x150D
+#define GL_OR_REVERSE 0x150B
+#define GL_OUT_OF_MEMORY 0x0505
+#define GL_PACK_ALIGNMENT 0x0D05
+#define GL_PACK_LSB_FIRST 0x0D01
+#define GL_PACK_ROW_LENGTH 0x0D02
+#define GL_PACK_SKIP_PIXELS 0x0D04
+#define GL_PACK_SKIP_ROWS 0x0D03
+#define GL_PACK_SWAP_BYTES 0x0D00
+#define GL_POINT 0x1B00
+#define GL_POINTS 0x0000
+#define GL_POINT_SIZE 0x0B11
+#define GL_POINT_SIZE_GRANULARITY 0x0B13
+#define GL_POINT_SIZE_RANGE 0x0B12
+#define GL_POLYGON_MODE 0x0B40
+#define GL_POLYGON_OFFSET_FACTOR 0x8038
+#define GL_POLYGON_OFFSET_FILL 0x8037
+#define GL_POLYGON_OFFSET_LINE 0x2A02
+#define GL_POLYGON_OFFSET_POINT 0x2A01
+#define GL_POLYGON_OFFSET_UNITS 0x2A00
+#define GL_POLYGON_SMOOTH 0x0B41
+#define GL_POLYGON_SMOOTH_HINT 0x0C53
+#define GL_PROXY_TEXTURE_1D 0x8063
+#define GL_PROXY_TEXTURE_2D 0x8064
+#define GL_R3_G3_B2 0x2A10
+#define GL_READ_BUFFER 0x0C02
+#define GL_RED 0x1903
+#define GL_RENDERER 0x1F01
+#define GL_REPEAT 0x2901
+#define GL_REPLACE 0x1E01
+#define GL_RGB 0x1907
+#define GL_RGB10 0x8052
+#define GL_RGB10_A2 0x8059
+#define GL_RGB12 0x8053
+#define GL_RGB16 0x8054
+#define GL_RGB4 0x804F
+#define GL_RGB5 0x8050
+#define GL_RGB5_A1 0x8057
+#define GL_RGB8 0x8051
+#define GL_RGBA 0x1908
+#define GL_RGBA12 0x805A
+#define GL_RGBA16 0x805B
+#define GL_RGBA2 0x8055
+#define GL_RGBA4 0x8056
+#define GL_RGBA8 0x8058
+#define GL_RIGHT 0x0407
+/*GL_SCISSOR_BOX seen in ARB_viewport_array*/
+/*GL_SCISSOR_TEST seen in ARB_viewport_array*/
+#define GL_SET 0x150F
+#define GL_SHORT 0x1402
+#define GL_SRC_ALPHA 0x0302
+#define GL_SRC_ALPHA_SATURATE 0x0308
+#define GL_SRC_COLOR 0x0300
+#define GL_STENCIL 0x1802
+#define GL_STENCIL_BUFFER_BIT 0x00000400
+#define GL_STENCIL_CLEAR_VALUE 0x0B91
+#define GL_STENCIL_FAIL 0x0B94
+#define GL_STENCIL_FUNC 0x0B92
+/*GL_STENCIL_INDEX seen in ARB_texture_stencil8*/
+#define GL_STENCIL_PASS_DEPTH_FAIL 0x0B95
+#define GL_STENCIL_PASS_DEPTH_PASS 0x0B96
+#define GL_STENCIL_REF 0x0B97
+#define GL_STENCIL_TEST 0x0B90
+#define GL_STENCIL_VALUE_MASK 0x0B93
+#define GL_STENCIL_WRITEMASK 0x0B98
+#define GL_STEREO 0x0C33
+#define GL_SUBPIXEL_BITS 0x0D50
+#define GL_TEXTURE 0x1702
+/*GL_TEXTURE_1D seen in ARB_internalformat_query2*/
+/*GL_TEXTURE_2D seen in ARB_internalformat_query2*/
+#define GL_TEXTURE_ALPHA_SIZE 0x805F
+/*GL_TEXTURE_BINDING_1D seen in ARB_direct_state_access*/
+/*GL_TEXTURE_BINDING_2D seen in ARB_direct_state_access*/
+#define GL_TEXTURE_BLUE_SIZE 0x805E
+#define GL_TEXTURE_BORDER_COLOR 0x1004
+#define GL_TEXTURE_GREEN_SIZE 0x805D
+#define GL_TEXTURE_HEIGHT 0x1001
+#define GL_TEXTURE_INTERNAL_FORMAT 0x1003
+#define GL_TEXTURE_MAG_FILTER 0x2800
+#define GL_TEXTURE_MIN_FILTER 0x2801
+#define GL_TEXTURE_RED_SIZE 0x805C
+#define GL_TEXTURE_WIDTH 0x1000
+#define GL_TEXTURE_WRAP_S 0x2802
+#define GL_TEXTURE_WRAP_T 0x2803
+#define GL_TRIANGLES 0x0004
+#define GL_TRIANGLE_FAN 0x0006
+#define GL_TRIANGLE_STRIP 0x0005
+#define GL_TRUE 1
+#define GL_UNPACK_ALIGNMENT 0x0CF5
+#define GL_UNPACK_LSB_FIRST 0x0CF1
+#define GL_UNPACK_ROW_LENGTH 0x0CF2
+#define GL_UNPACK_SKIP_PIXELS 0x0CF4
+#define GL_UNPACK_SKIP_ROWS 0x0CF3
+#define GL_UNPACK_SWAP_BYTES 0x0CF0
+#define GL_UNSIGNED_BYTE 0x1401
+#define GL_UNSIGNED_INT 0x1405
+#define GL_UNSIGNED_SHORT 0x1403
+#define GL_VENDOR 0x1F00
+#define GL_VERSION 0x1F02
+/*GL_VIEWPORT seen in ARB_viewport_array*/
+#define GL_XOR 0x1506
+#define GL_ZERO 0
+
+/* Version: 1.2*/
+#define GL_ALIASED_LINE_WIDTH_RANGE 0x846E
+#define GL_BGR 0x80E0
+#define GL_BGRA 0x80E1
+#define GL_CLAMP_TO_EDGE 0x812F
+#define GL_MAX_3D_TEXTURE_SIZE 0x8073
+#define GL_MAX_ELEMENTS_INDICES 0x80E9
+#define GL_MAX_ELEMENTS_VERTICES 0x80E8
+#define GL_PACK_IMAGE_HEIGHT 0x806C
+#define GL_PACK_SKIP_IMAGES 0x806B
+#define GL_PROXY_TEXTURE_3D 0x8070
+#define GL_SMOOTH_LINE_WIDTH_GRANULARITY 0x0B23
+#define GL_SMOOTH_LINE_WIDTH_RANGE 0x0B22
+#define GL_SMOOTH_POINT_SIZE_GRANULARITY 0x0B13
+#define GL_SMOOTH_POINT_SIZE_RANGE 0x0B12
+/*GL_TEXTURE_3D seen in ARB_internalformat_query2*/
+#define GL_TEXTURE_BASE_LEVEL 0x813C
+/*GL_TEXTURE_BINDING_3D seen in ARB_direct_state_access*/
+#define GL_TEXTURE_DEPTH 0x8071
+#define GL_TEXTURE_MAX_LEVEL 0x813D
+#define GL_TEXTURE_MAX_LOD 0x813B
+#define GL_TEXTURE_MIN_LOD 0x813A
+#define GL_TEXTURE_WRAP_R 0x8072
+#define GL_UNPACK_IMAGE_HEIGHT 0x806E
+#define GL_UNPACK_SKIP_IMAGES 0x806D
+#define GL_UNSIGNED_BYTE_2_3_3_REV 0x8362
+#define GL_UNSIGNED_BYTE_3_3_2 0x8032
+#define GL_UNSIGNED_INT_10_10_10_2 0x8036
+#define GL_UNSIGNED_INT_2_10_10_10_REV 0x8368
+#define GL_UNSIGNED_INT_8_8_8_8 0x8035
+#define GL_UNSIGNED_INT_8_8_8_8_REV 0x8367
+#define GL_UNSIGNED_SHORT_1_5_5_5_REV 0x8366
+#define GL_UNSIGNED_SHORT_4_4_4_4 0x8033
+#define GL_UNSIGNED_SHORT_4_4_4_4_REV 0x8365
+#define GL_UNSIGNED_SHORT_5_5_5_1 0x8034
+#define GL_UNSIGNED_SHORT_5_6_5 0x8363
+#define GL_UNSIGNED_SHORT_5_6_5_REV 0x8364
+
+/* Version: 1.3*/
+#define GL_ACTIVE_TEXTURE 0x84E0
+#define GL_CLAMP_TO_BORDER 0x812D
+#define GL_COMPRESSED_RGB 0x84ED
+#define GL_COMPRESSED_RGBA 0x84EE
+#define GL_COMPRESSED_TEXTURE_FORMATS 0x86A3
+#define GL_MAX_CUBE_MAP_TEXTURE_SIZE 0x851C
+#define GL_MULTISAMPLE 0x809D
+#define GL_NUM_COMPRESSED_TEXTURE_FORMATS 0x86A2
+#define GL_PROXY_TEXTURE_CUBE_MAP 0x851B
+/*GL_SAMPLES seen in ARB_internalformat_query2*/
+#define GL_SAMPLE_ALPHA_TO_COVERAGE 0x809E
+#define GL_SAMPLE_ALPHA_TO_ONE 0x809F
+#define GL_SAMPLE_BUFFERS 0x80A8
+#define GL_SAMPLE_COVERAGE 0x80A0
+#define GL_SAMPLE_COVERAGE_INVERT 0x80AB
+#define GL_SAMPLE_COVERAGE_VALUE 0x80AA
+#define GL_TEXTURE0 0x84C0
+#define GL_TEXTURE1 0x84C1
+#define GL_TEXTURE10 0x84CA
+#define GL_TEXTURE11 0x84CB
+#define GL_TEXTURE12 0x84CC
+#define GL_TEXTURE13 0x84CD
+#define GL_TEXTURE14 0x84CE
+#define GL_TEXTURE15 0x84CF
+#define GL_TEXTURE16 0x84D0
+#define GL_TEXTURE17 0x84D1
+#define GL_TEXTURE18 0x84D2
+#define GL_TEXTURE19 0x84D3
+#define GL_TEXTURE2 0x84C2
+#define GL_TEXTURE20 0x84D4
+#define GL_TEXTURE21 0x84D5
+#define GL_TEXTURE22 0x84D6
+#define GL_TEXTURE23 0x84D7
+#define GL_TEXTURE24 0x84D8
+#define GL_TEXTURE25 0x84D9
+#define GL_TEXTURE26 0x84DA
+#define GL_TEXTURE27 0x84DB
+#define GL_TEXTURE28 0x84DC
+#define GL_TEXTURE29 0x84DD
+#define GL_TEXTURE3 0x84C3
+#define GL_TEXTURE30 0x84DE
+#define GL_TEXTURE31 0x84DF
+#define GL_TEXTURE4 0x84C4
+#define GL_TEXTURE5 0x84C5
+#define GL_TEXTURE6 0x84C6
+#define GL_TEXTURE7 0x84C7
+#define GL_TEXTURE8 0x84C8
+#define GL_TEXTURE9 0x84C9
+/*GL_TEXTURE_BINDING_CUBE_MAP seen in ARB_direct_state_access*/
+/*GL_TEXTURE_COMPRESSED seen in ARB_internalformat_query2*/
+#define GL_TEXTURE_COMPRESSED_IMAGE_SIZE 0x86A0
+#define GL_TEXTURE_COMPRESSION_HINT 0x84EF
+/*GL_TEXTURE_CUBE_MAP seen in ARB_internalformat_query2*/
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_X 0x8516
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Y 0x8518
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Z 0x851A
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_X 0x8515
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_Y 0x8517
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_Z 0x8519
+
+/* Version: 1.4*/
+#define GL_BLEND_COLOR 0x8005
+#define GL_BLEND_DST_ALPHA 0x80CA
+#define GL_BLEND_DST_RGB 0x80C8
+#define GL_BLEND_EQUATION 0x8009
+#define GL_BLEND_SRC_ALPHA 0x80CB
+#define GL_BLEND_SRC_RGB 0x80C9
+#define GL_CONSTANT_ALPHA 0x8003
+#define GL_CONSTANT_COLOR 0x8001
+#define GL_DECR_WRAP 0x8508
+#define GL_DEPTH_COMPONENT16 0x81A5
+#define GL_DEPTH_COMPONENT24 0x81A6
+#define GL_DEPTH_COMPONENT32 0x81A7
+#define GL_FUNC_ADD 0x8006
+#define GL_FUNC_REVERSE_SUBTRACT 0x800B
+#define GL_FUNC_SUBTRACT 0x800A
+#define GL_INCR_WRAP 0x8507
+#define GL_MAX 0x8008
+#define GL_MAX_TEXTURE_LOD_BIAS 0x84FD
+#define GL_MIN 0x8007
+#define GL_MIRRORED_REPEAT 0x8370
+#define GL_ONE_MINUS_CONSTANT_ALPHA 0x8004
+#define GL_ONE_MINUS_CONSTANT_COLOR 0x8002
+#define GL_POINT_FADE_THRESHOLD_SIZE 0x8128
+#define GL_TEXTURE_COMPARE_FUNC 0x884D
+#define GL_TEXTURE_COMPARE_MODE 0x884C
+#define GL_TEXTURE_DEPTH_SIZE 0x884A
+#define GL_TEXTURE_LOD_BIAS 0x8501
+
+/* Version: 1.5*/
+#define GL_ARRAY_BUFFER 0x8892
+#define GL_ARRAY_BUFFER_BINDING 0x8894
+#define GL_BUFFER_ACCESS 0x88BB
+#define GL_BUFFER_MAPPED 0x88BC
+#define GL_BUFFER_MAP_POINTER 0x88BD
+#define GL_BUFFER_SIZE 0x8764
+#define GL_BUFFER_USAGE 0x8765
+#define GL_CURRENT_QUERY 0x8865
+#define GL_DYNAMIC_COPY 0x88EA
+#define GL_DYNAMIC_DRAW 0x88E8
+#define GL_DYNAMIC_READ 0x88E9
+#define GL_ELEMENT_ARRAY_BUFFER 0x8893
+#define GL_ELEMENT_ARRAY_BUFFER_BINDING 0x8895
+#define GL_QUERY_COUNTER_BITS 0x8864
+#define GL_QUERY_RESULT 0x8866
+#define GL_QUERY_RESULT_AVAILABLE 0x8867
+#define GL_READ_ONLY 0x88B8
+#define GL_READ_WRITE 0x88BA
+#define GL_SAMPLES_PASSED 0x8914
+#define GL_SRC1_ALPHA 0x8589
+#define GL_STATIC_COPY 0x88E6
+#define GL_STATIC_DRAW 0x88E4
+#define GL_STATIC_READ 0x88E5
+#define GL_STREAM_COPY 0x88E2
+#define GL_STREAM_DRAW 0x88E0
+#define GL_STREAM_READ 0x88E1
+#define GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING 0x889F
+#define GL_WRITE_ONLY 0x88B9
+
+/* Version: 2.0*/
+#define GL_ACTIVE_ATTRIBUTES 0x8B89
+#define GL_ACTIVE_ATTRIBUTE_MAX_LENGTH 0x8B8A
+#define GL_ACTIVE_UNIFORMS 0x8B86
+#define GL_ACTIVE_UNIFORM_MAX_LENGTH 0x8B87
+#define GL_ATTACHED_SHADERS 0x8B85
+#define GL_BLEND_EQUATION_ALPHA 0x883D
+#define GL_BLEND_EQUATION_RGB 0x8009
+#define GL_BOOL 0x8B56
+#define GL_BOOL_VEC2 0x8B57
+#define GL_BOOL_VEC3 0x8B58
+#define GL_BOOL_VEC4 0x8B59
+#define GL_COMPILE_STATUS 0x8B81
+#define GL_CURRENT_PROGRAM 0x8B8D
+#define GL_CURRENT_VERTEX_ATTRIB 0x8626
+#define GL_DELETE_STATUS 0x8B80
+#define GL_DRAW_BUFFER0 0x8825
+#define GL_DRAW_BUFFER1 0x8826
+#define GL_DRAW_BUFFER10 0x882F
+#define GL_DRAW_BUFFER11 0x8830
+#define GL_DRAW_BUFFER12 0x8831
+#define GL_DRAW_BUFFER13 0x8832
+#define GL_DRAW_BUFFER14 0x8833
+#define GL_DRAW_BUFFER15 0x8834
+#define GL_DRAW_BUFFER2 0x8827
+#define GL_DRAW_BUFFER3 0x8828
+#define GL_DRAW_BUFFER4 0x8829
+#define GL_DRAW_BUFFER5 0x882A
+#define GL_DRAW_BUFFER6 0x882B
+#define GL_DRAW_BUFFER7 0x882C
+#define GL_DRAW_BUFFER8 0x882D
+#define GL_DRAW_BUFFER9 0x882E
+#define GL_FLOAT_MAT2 0x8B5A
+#define GL_FLOAT_MAT3 0x8B5B
+#define GL_FLOAT_MAT4 0x8B5C
+#define GL_FLOAT_VEC2 0x8B50
+#define GL_FLOAT_VEC3 0x8B51
+#define GL_FLOAT_VEC4 0x8B52
+#define GL_FRAGMENT_SHADER 0x8B30
+#define GL_FRAGMENT_SHADER_DERIVATIVE_HINT 0x8B8B
+#define GL_INFO_LOG_LENGTH 0x8B84
+#define GL_INT_VEC2 0x8B53
+#define GL_INT_VEC3 0x8B54
+#define GL_INT_VEC4 0x8B55
+#define GL_LINK_STATUS 0x8B82
+/*GL_LOWER_LEFT seen in ARB_clip_control*/
+#define GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS 0x8B4D
+#define GL_MAX_DRAW_BUFFERS 0x8824
+#define GL_MAX_FRAGMENT_UNIFORM_COMPONENTS 0x8B49
+#define GL_MAX_TEXTURE_IMAGE_UNITS 0x8872
+#define GL_MAX_VARYING_FLOATS 0x8B4B
+#define GL_MAX_VERTEX_ATTRIBS 0x8869
+#define GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS 0x8B4C
+#define GL_MAX_VERTEX_UNIFORM_COMPONENTS 0x8B4A
+#define GL_POINT_SPRITE_COORD_ORIGIN 0x8CA0
+#define GL_SAMPLER_1D 0x8B5D
+#define GL_SAMPLER_1D_SHADOW 0x8B61
+#define GL_SAMPLER_2D 0x8B5E
+#define GL_SAMPLER_2D_SHADOW 0x8B62
+#define GL_SAMPLER_3D 0x8B5F
+#define GL_SAMPLER_CUBE 0x8B60
+#define GL_SHADER_SOURCE_LENGTH 0x8B88
+#define GL_SHADER_TYPE 0x8B4F
+#define GL_SHADING_LANGUAGE_VERSION 0x8B8C
+#define GL_STENCIL_BACK_FAIL 0x8801
+#define GL_STENCIL_BACK_FUNC 0x8800
+#define GL_STENCIL_BACK_PASS_DEPTH_FAIL 0x8802
+#define GL_STENCIL_BACK_PASS_DEPTH_PASS 0x8803
+#define GL_STENCIL_BACK_REF 0x8CA3
+#define GL_STENCIL_BACK_VALUE_MASK 0x8CA4
+#define GL_STENCIL_BACK_WRITEMASK 0x8CA5
+/*GL_UPPER_LEFT seen in ARB_clip_control*/
+#define GL_VALIDATE_STATUS 0x8B83
+#define GL_VERTEX_ATTRIB_ARRAY_ENABLED 0x8622
+#define GL_VERTEX_ATTRIB_ARRAY_NORMALIZED 0x886A
+#define GL_VERTEX_ATTRIB_ARRAY_POINTER 0x8645
+#define GL_VERTEX_ATTRIB_ARRAY_SIZE 0x8623
+#define GL_VERTEX_ATTRIB_ARRAY_STRIDE 0x8624
+#define GL_VERTEX_ATTRIB_ARRAY_TYPE 0x8625
+#define GL_VERTEX_PROGRAM_POINT_SIZE 0x8642
+#define GL_VERTEX_SHADER 0x8B31
+
+/* Version: 2.1*/
+#define GL_COMPRESSED_SRGB 0x8C48
+#define GL_COMPRESSED_SRGB_ALPHA 0x8C49
+#define GL_FLOAT_MAT2x3 0x8B65
+#define GL_FLOAT_MAT2x4 0x8B66
+#define GL_FLOAT_MAT3x2 0x8B67
+#define GL_FLOAT_MAT3x4 0x8B68
+#define GL_FLOAT_MAT4x2 0x8B69
+#define GL_FLOAT_MAT4x3 0x8B6A
+#define GL_PIXEL_PACK_BUFFER 0x88EB
+#define GL_PIXEL_PACK_BUFFER_BINDING 0x88ED
+#define GL_PIXEL_UNPACK_BUFFER 0x88EC
+#define GL_PIXEL_UNPACK_BUFFER_BINDING 0x88EF
+#define GL_SRGB 0x8C40
+#define GL_SRGB8 0x8C41
+#define GL_SRGB8_ALPHA8 0x8C43
+#define GL_SRGB_ALPHA 0x8C42
+
+/* Version: 3.0*/
+#define GL_BGRA_INTEGER 0x8D9B
+#define GL_BGR_INTEGER 0x8D9A
+#define GL_BLUE_INTEGER 0x8D96
+#define GL_BUFFER_ACCESS_FLAGS 0x911F
+#define GL_BUFFER_MAP_LENGTH 0x9120
+#define GL_BUFFER_MAP_OFFSET 0x9121
+#define GL_CLAMP_READ_COLOR 0x891C
+#define GL_CLIP_DISTANCE0 0x3000
+#define GL_CLIP_DISTANCE1 0x3001
+#define GL_CLIP_DISTANCE2 0x3002
+#define GL_CLIP_DISTANCE3 0x3003
+#define GL_CLIP_DISTANCE4 0x3004
+#define GL_CLIP_DISTANCE5 0x3005
+#define GL_CLIP_DISTANCE6 0x3006
+#define GL_CLIP_DISTANCE7 0x3007
+#define GL_COLOR_ATTACHMENT0 0x8CE0
+#define GL_COLOR_ATTACHMENT1 0x8CE1
+#define GL_COLOR_ATTACHMENT10 0x8CEA
+#define GL_COLOR_ATTACHMENT11 0x8CEB
+#define GL_COLOR_ATTACHMENT12 0x8CEC
+#define GL_COLOR_ATTACHMENT13 0x8CED
+#define GL_COLOR_ATTACHMENT14 0x8CEE
+#define GL_COLOR_ATTACHMENT15 0x8CEF
+#define GL_COLOR_ATTACHMENT2 0x8CE2
+#define GL_COLOR_ATTACHMENT3 0x8CE3
+#define GL_COLOR_ATTACHMENT4 0x8CE4
+#define GL_COLOR_ATTACHMENT5 0x8CE5
+#define GL_COLOR_ATTACHMENT6 0x8CE6
+#define GL_COLOR_ATTACHMENT7 0x8CE7
+#define GL_COLOR_ATTACHMENT8 0x8CE8
+#define GL_COLOR_ATTACHMENT9 0x8CE9
+#define GL_COMPARE_REF_TO_TEXTURE 0x884E
+#define GL_COMPRESSED_RED 0x8225
+#define GL_COMPRESSED_RED_RGTC1 0x8DBB
+#define GL_COMPRESSED_RG 0x8226
+#define GL_COMPRESSED_RG_RGTC2 0x8DBD
+#define GL_COMPRESSED_SIGNED_RED_RGTC1 0x8DBC
+#define GL_COMPRESSED_SIGNED_RG_RGTC2 0x8DBE
+#define GL_CONTEXT_FLAGS 0x821E
+#define GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT 0x00000001
+#define GL_DEPTH24_STENCIL8 0x88F0
+#define GL_DEPTH32F_STENCIL8 0x8CAD
+#define GL_DEPTH_ATTACHMENT 0x8D00
+#define GL_DEPTH_COMPONENT32F 0x8CAC
+#define GL_DEPTH_STENCIL 0x84F9
+#define GL_DEPTH_STENCIL_ATTACHMENT 0x821A
+#define GL_DRAW_FRAMEBUFFER 0x8CA9
+#define GL_DRAW_FRAMEBUFFER_BINDING 0x8CA6
+#define GL_FIXED_ONLY 0x891D
+#define GL_FLOAT_32_UNSIGNED_INT_24_8_REV 0x8DAD
+#define GL_FRAMEBUFFER 0x8D40
+#define GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE 0x8215
+#define GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE 0x8214
+#define GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING 0x8210
+#define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE 0x8211
+#define GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE 0x8216
+#define GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE 0x8213
+#define GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME 0x8CD1
+#define GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE 0x8CD0
+#define GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE 0x8212
+#define GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE 0x8217
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE 0x8CD3
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER 0x8CD4
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL 0x8CD2
+#define GL_FRAMEBUFFER_BINDING 0x8CA6
+#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
+#define GL_FRAMEBUFFER_DEFAULT 0x8218
+#define GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT 0x8CD6
+#define GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER 0x8CDB
+#define GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT 0x8CD7
+#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE 0x8D56
+#define GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER 0x8CDC
+#define GL_FRAMEBUFFER_SRGB 0x8DB9
+#define GL_FRAMEBUFFER_UNDEFINED 0x8219
+#define GL_FRAMEBUFFER_UNSUPPORTED 0x8CDD
+#define GL_GREEN_INTEGER 0x8D95
+#define GL_HALF_FLOAT 0x140B
+#define GL_INTERLEAVED_ATTRIBS 0x8C8C
+#define GL_INT_SAMPLER_1D 0x8DC9
+#define GL_INT_SAMPLER_1D_ARRAY 0x8DCE
+#define GL_INT_SAMPLER_2D 0x8DCA
+#define GL_INT_SAMPLER_2D_ARRAY 0x8DCF
+#define GL_INT_SAMPLER_3D 0x8DCB
+#define GL_INT_SAMPLER_CUBE 0x8DCC
+#define GL_INVALID_FRAMEBUFFER_OPERATION 0x0506
+#define GL_MAJOR_VERSION 0x821B
+#define GL_MAP_FLUSH_EXPLICIT_BIT 0x0010
+#define GL_MAP_INVALIDATE_BUFFER_BIT 0x0008
+#define GL_MAP_INVALIDATE_RANGE_BIT 0x0004
+/*GL_MAP_READ_BIT seen in ARB_buffer_storage*/
+#define GL_MAP_UNSYNCHRONIZED_BIT 0x0020
+/*GL_MAP_WRITE_BIT seen in ARB_buffer_storage*/
+#define GL_MAX_ARRAY_TEXTURE_LAYERS 0x88FF
+#define GL_MAX_CLIP_DISTANCES 0x0D32
+#define GL_MAX_COLOR_ATTACHMENTS 0x8CDF
+#define GL_MAX_PROGRAM_TEXEL_OFFSET 0x8905
+#define GL_MAX_RENDERBUFFER_SIZE 0x84E8
+#define GL_MAX_SAMPLES 0x8D57
+#define GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS 0x8C8A
+#define GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS 0x8C8B
+#define GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS 0x8C80
+#define GL_MAX_VARYING_COMPONENTS 0x8B4B
+#define GL_MINOR_VERSION 0x821C
+#define GL_MIN_PROGRAM_TEXEL_OFFSET 0x8904
+#define GL_NUM_EXTENSIONS 0x821D
+#define GL_PRIMITIVES_GENERATED 0x8C87
+#define GL_PROXY_TEXTURE_1D_ARRAY 0x8C19
+#define GL_PROXY_TEXTURE_2D_ARRAY 0x8C1B
+#define GL_QUERY_BY_REGION_NO_WAIT 0x8E16
+#define GL_QUERY_BY_REGION_WAIT 0x8E15
+#define GL_QUERY_NO_WAIT 0x8E14
+#define GL_QUERY_WAIT 0x8E13
+#define GL_R11F_G11F_B10F 0x8C3A
+#define GL_R16 0x822A
+#define GL_R16F 0x822D
+#define GL_R16I 0x8233
+#define GL_R16UI 0x8234
+#define GL_R32F 0x822E
+#define GL_R32I 0x8235
+#define GL_R32UI 0x8236
+#define GL_R8 0x8229
+#define GL_R8I 0x8231
+#define GL_R8UI 0x8232
+#define GL_RASTERIZER_DISCARD 0x8C89
+#define GL_READ_FRAMEBUFFER 0x8CA8
+#define GL_READ_FRAMEBUFFER_BINDING 0x8CAA
+#define GL_RED_INTEGER 0x8D94
+/*GL_RENDERBUFFER seen in ARB_internalformat_query2*/
+#define GL_RENDERBUFFER_ALPHA_SIZE 0x8D53
+#define GL_RENDERBUFFER_BINDING 0x8CA7
+#define GL_RENDERBUFFER_BLUE_SIZE 0x8D52
+#define GL_RENDERBUFFER_DEPTH_SIZE 0x8D54
+#define GL_RENDERBUFFER_GREEN_SIZE 0x8D51
+#define GL_RENDERBUFFER_HEIGHT 0x8D43
+#define GL_RENDERBUFFER_INTERNAL_FORMAT 0x8D44
+#define GL_RENDERBUFFER_RED_SIZE 0x8D50
+#define GL_RENDERBUFFER_SAMPLES 0x8CAB
+#define GL_RENDERBUFFER_STENCIL_SIZE 0x8D55
+#define GL_RENDERBUFFER_WIDTH 0x8D42
+#define GL_RG 0x8227
+#define GL_RG16 0x822C
+#define GL_RG16F 0x822F
+#define GL_RG16I 0x8239
+#define GL_RG16UI 0x823A
+#define GL_RG32F 0x8230
+#define GL_RG32I 0x823B
+#define GL_RG32UI 0x823C
+#define GL_RG8 0x822B
+#define GL_RG8I 0x8237
+#define GL_RG8UI 0x8238
+#define GL_RGB16F 0x881B
+#define GL_RGB16I 0x8D89
+#define GL_RGB16UI 0x8D77
+#define GL_RGB32F 0x8815
+#define GL_RGB32I 0x8D83
+#define GL_RGB32UI 0x8D71
+#define GL_RGB8I 0x8D8F
+#define GL_RGB8UI 0x8D7D
+#define GL_RGB9_E5 0x8C3D
+#define GL_RGBA16F 0x881A
+#define GL_RGBA16I 0x8D88
+#define GL_RGBA16UI 0x8D76
+#define GL_RGBA32F 0x8814
+#define GL_RGBA32I 0x8D82
+#define GL_RGBA32UI 0x8D70
+#define GL_RGBA8I 0x8D8E
+#define GL_RGBA8UI 0x8D7C
+#define GL_RGBA_INTEGER 0x8D99
+#define GL_RGB_INTEGER 0x8D98
+#define GL_RG_INTEGER 0x8228
+#define GL_SAMPLER_1D_ARRAY 0x8DC0
+#define GL_SAMPLER_1D_ARRAY_SHADOW 0x8DC3
+#define GL_SAMPLER_2D_ARRAY 0x8DC1
+#define GL_SAMPLER_2D_ARRAY_SHADOW 0x8DC4
+#define GL_SAMPLER_CUBE_SHADOW 0x8DC5
+#define GL_SEPARATE_ATTRIBS 0x8C8D
+#define GL_STENCIL_ATTACHMENT 0x8D20
+#define GL_STENCIL_INDEX1 0x8D46
+#define GL_STENCIL_INDEX16 0x8D49
+#define GL_STENCIL_INDEX4 0x8D47
+/*GL_STENCIL_INDEX8 seen in ARB_texture_stencil8*/
+/*GL_TEXTURE_1D_ARRAY seen in ARB_internalformat_query2*/
+/*GL_TEXTURE_2D_ARRAY seen in ARB_internalformat_query2*/
+#define GL_TEXTURE_ALPHA_TYPE 0x8C13
+/*GL_TEXTURE_BINDING_1D_ARRAY seen in ARB_direct_state_access*/
+/*GL_TEXTURE_BINDING_2D_ARRAY seen in ARB_direct_state_access*/
+#define GL_TEXTURE_BLUE_TYPE 0x8C12
+#define GL_TEXTURE_DEPTH_TYPE 0x8C16
+#define GL_TEXTURE_GREEN_TYPE 0x8C11
+#define GL_TEXTURE_RED_TYPE 0x8C10
+#define GL_TEXTURE_SHARED_SIZE 0x8C3F
+#define GL_TEXTURE_STENCIL_SIZE 0x88F1
+/*GL_TRANSFORM_FEEDBACK_BUFFER seen in ARB_enhanced_layouts*/
+#define GL_TRANSFORM_FEEDBACK_BUFFER_BINDING 0x8C8F
+#define GL_TRANSFORM_FEEDBACK_BUFFER_MODE 0x8C7F
+#define GL_TRANSFORM_FEEDBACK_BUFFER_SIZE 0x8C85
+#define GL_TRANSFORM_FEEDBACK_BUFFER_START 0x8C84
+#define GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN 0x8C88
+#define GL_TRANSFORM_FEEDBACK_VARYINGS 0x8C83
+#define GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH 0x8C76
+/*GL_UNSIGNED_INT_10F_11F_11F_REV seen in ARB_vertex_type_10f_11f_11f_rev*/
+#define GL_UNSIGNED_INT_24_8 0x84FA
+#define GL_UNSIGNED_INT_5_9_9_9_REV 0x8C3E
+#define GL_UNSIGNED_INT_SAMPLER_1D 0x8DD1
+#define GL_UNSIGNED_INT_SAMPLER_1D_ARRAY 0x8DD6
+#define GL_UNSIGNED_INT_SAMPLER_2D 0x8DD2
+#define GL_UNSIGNED_INT_SAMPLER_2D_ARRAY 0x8DD7
+#define GL_UNSIGNED_INT_SAMPLER_3D 0x8DD3
+#define GL_UNSIGNED_INT_SAMPLER_CUBE 0x8DD4
+#define GL_UNSIGNED_INT_VEC2 0x8DC6
+#define GL_UNSIGNED_INT_VEC3 0x8DC7
+#define GL_UNSIGNED_INT_VEC4 0x8DC8
+#define GL_UNSIGNED_NORMALIZED 0x8C17
+#define GL_VERTEX_ARRAY_BINDING 0x85B5
+#define GL_VERTEX_ATTRIB_ARRAY_INTEGER 0x88FD
+
+/* Version: 3.1*/
+#define GL_ACTIVE_UNIFORM_BLOCKS 0x8A36
+#define GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH 0x8A35
+#define GL_COPY_READ_BUFFER 0x8F36
+#define GL_COPY_WRITE_BUFFER 0x8F37
+#define GL_INT_SAMPLER_2D_RECT 0x8DCD
+#define GL_INT_SAMPLER_BUFFER 0x8DD0
+#define GL_INVALID_INDEX 0xFFFFFFFF
+#define GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS 0x8A33
+#define GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS 0x8A32
+#define GL_MAX_COMBINED_UNIFORM_BLOCKS 0x8A2E
+#define GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS 0x8A31
+#define GL_MAX_FRAGMENT_UNIFORM_BLOCKS 0x8A2D
+#define GL_MAX_GEOMETRY_UNIFORM_BLOCKS 0x8A2C
+#define GL_MAX_RECTANGLE_TEXTURE_SIZE 0x84F8
+#define GL_MAX_TEXTURE_BUFFER_SIZE 0x8C2B
+#define GL_MAX_UNIFORM_BLOCK_SIZE 0x8A30
+#define GL_MAX_UNIFORM_BUFFER_BINDINGS 0x8A2F
+#define GL_MAX_VERTEX_UNIFORM_BLOCKS 0x8A2B
+#define GL_PRIMITIVE_RESTART 0x8F9D
+#define GL_PRIMITIVE_RESTART_INDEX 0x8F9E
+#define GL_PROXY_TEXTURE_RECTANGLE 0x84F7
+#define GL_R16_SNORM 0x8F98
+#define GL_R8_SNORM 0x8F94
+#define GL_RG16_SNORM 0x8F99
+#define GL_RG8_SNORM 0x8F95
+#define GL_RGB16_SNORM 0x8F9A
+#define GL_RGB8_SNORM 0x8F96
+#define GL_RGBA16_SNORM 0x8F9B
+#define GL_RGBA8_SNORM 0x8F97
+#define GL_SAMPLER_2D_RECT 0x8B63
+#define GL_SAMPLER_2D_RECT_SHADOW 0x8B64
+#define GL_SAMPLER_BUFFER 0x8DC2
+#define GL_SIGNED_NORMALIZED 0x8F9C
+/*GL_TEXTURE_BINDING_BUFFER seen in ARB_direct_state_access*/
+/*GL_TEXTURE_BINDING_RECTANGLE seen in ARB_direct_state_access*/
+/*GL_TEXTURE_BUFFER seen in ARB_internalformat_query2*/
+#define GL_TEXTURE_BUFFER_DATA_STORE_BINDING 0x8C2D
+/*GL_TEXTURE_RECTANGLE seen in ARB_internalformat_query2*/
+#define GL_UNIFORM_ARRAY_STRIDE 0x8A3C
+#define GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS 0x8A42
+#define GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES 0x8A43
+#define GL_UNIFORM_BLOCK_BINDING 0x8A3F
+#define GL_UNIFORM_BLOCK_DATA_SIZE 0x8A40
+#define GL_UNIFORM_BLOCK_INDEX 0x8A3A
+#define GL_UNIFORM_BLOCK_NAME_LENGTH 0x8A41
+#define GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER 0x8A46
+#define GL_UNIFORM_BLOCK_REFERENCED_BY_GEOMETRY_SHADER 0x8A45
+#define GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER 0x8A44
+#define GL_UNIFORM_BUFFER 0x8A11
+#define GL_UNIFORM_BUFFER_BINDING 0x8A28
+#define GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT 0x8A34
+#define GL_UNIFORM_BUFFER_SIZE 0x8A2A
+#define GL_UNIFORM_BUFFER_START 0x8A29
+#define GL_UNIFORM_IS_ROW_MAJOR 0x8A3E
+#define GL_UNIFORM_MATRIX_STRIDE 0x8A3D
+#define GL_UNIFORM_NAME_LENGTH 0x8A39
+#define GL_UNIFORM_OFFSET 0x8A3B
+#define GL_UNIFORM_SIZE 0x8A38
+#define GL_UNIFORM_TYPE 0x8A37
+#define GL_UNSIGNED_INT_SAMPLER_2D_RECT 0x8DD5
+#define GL_UNSIGNED_INT_SAMPLER_BUFFER 0x8DD8
+
+/* Version: 3.2*/
+#define GL_ALREADY_SIGNALED 0x911A
+#define GL_CONDITION_SATISFIED 0x911C
+#define GL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
+#define GL_CONTEXT_CORE_PROFILE_BIT 0x00000001
+#define GL_CONTEXT_PROFILE_MASK 0x9126
+#define GL_DEPTH_CLAMP 0x864F
+/*GL_FIRST_VERTEX_CONVENTION seen in ARB_viewport_array*/
+#define GL_FRAMEBUFFER_ATTACHMENT_LAYERED 0x8DA7
+#define GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS 0x8DA8
+#define GL_GEOMETRY_INPUT_TYPE 0x8917
+#define GL_GEOMETRY_OUTPUT_TYPE 0x8918
+#define GL_GEOMETRY_SHADER 0x8DD9
+#define GL_GEOMETRY_VERTICES_OUT 0x8916
+#define GL_INT_SAMPLER_2D_MULTISAMPLE 0x9109
+#define GL_INT_SAMPLER_2D_MULTISAMPLE_ARRAY 0x910C
+/*GL_LAST_VERTEX_CONVENTION seen in ARB_viewport_array*/
+#define GL_LINES_ADJACENCY 0x000A
+#define GL_LINE_STRIP_ADJACENCY 0x000B
+#define GL_MAX_COLOR_TEXTURE_SAMPLES 0x910E
+#define GL_MAX_DEPTH_TEXTURE_SAMPLES 0x910F
+#define GL_MAX_FRAGMENT_INPUT_COMPONENTS 0x9125
+#define GL_MAX_GEOMETRY_INPUT_COMPONENTS 0x9123
+#define GL_MAX_GEOMETRY_OUTPUT_COMPONENTS 0x9124
+#define GL_MAX_GEOMETRY_OUTPUT_VERTICES 0x8DE0
+#define GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS 0x8C29
+#define GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS 0x8DE1
+#define GL_MAX_GEOMETRY_UNIFORM_COMPONENTS 0x8DDF
+#define GL_MAX_INTEGER_SAMPLES 0x9110
+#define GL_MAX_SAMPLE_MASK_WORDS 0x8E59
+#define GL_MAX_SERVER_WAIT_TIMEOUT 0x9111
+#define GL_MAX_VERTEX_OUTPUT_COMPONENTS 0x9122
+#define GL_OBJECT_TYPE 0x9112
+#define GL_PROGRAM_POINT_SIZE 0x8642
+/*GL_PROVOKING_VERTEX seen in ARB_viewport_array*/
+#define GL_PROXY_TEXTURE_2D_MULTISAMPLE 0x9101
+#define GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY 0x9103
+#define GL_QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION 0x8E4C
+#define GL_SAMPLER_2D_MULTISAMPLE 0x9108
+#define GL_SAMPLER_2D_MULTISAMPLE_ARRAY 0x910B
+#define GL_SAMPLE_MASK 0x8E51
+#define GL_SAMPLE_MASK_VALUE 0x8E52
+#define GL_SAMPLE_POSITION 0x8E50
+#define GL_SIGNALED 0x9119
+#define GL_SYNC_CONDITION 0x9113
+#define GL_SYNC_FENCE 0x9116
+#define GL_SYNC_FLAGS 0x9115
+#define GL_SYNC_FLUSH_COMMANDS_BIT 0x00000001
+#define GL_SYNC_GPU_COMMANDS_COMPLETE 0x9117
+#define GL_SYNC_STATUS 0x9114
+/*GL_TEXTURE_2D_MULTISAMPLE seen in ARB_internalformat_query2*/
+/*GL_TEXTURE_2D_MULTISAMPLE_ARRAY seen in ARB_internalformat_query2*/
+/*GL_TEXTURE_BINDING_2D_MULTISAMPLE seen in ARB_direct_state_access*/
+/*GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY seen in ARB_direct_state_access*/
+/*GL_TEXTURE_CUBE_MAP_SEAMLESS seen in ARB_seamless_cubemap_per_texture*/
+#define GL_TEXTURE_FIXED_SAMPLE_LOCATIONS 0x9107
+#define GL_TEXTURE_SAMPLES 0x9106
+#define GL_TIMEOUT_EXPIRED 0x911B
+#define GL_TIMEOUT_IGNORED 0xFFFFFFFFFFFFFFFF
+#define GL_TRIANGLES_ADJACENCY 0x000C
+#define GL_TRIANGLE_STRIP_ADJACENCY 0x000D
+#define GL_UNSIGNALED 0x9118
+#define GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE 0x910A
+#define GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY 0x910D
+#define GL_WAIT_FAILED 0x911D
+
+/* Version: 3.3*/
+#define GL_ANY_SAMPLES_PASSED 0x8C2F
+#define GL_INT_2_10_10_10_REV 0x8D9F
+#define GL_MAX_DUAL_SOURCE_DRAW_BUFFERS 0x88FC
+#define GL_ONE_MINUS_SRC1_ALPHA 0x88FB
+#define GL_ONE_MINUS_SRC1_COLOR 0x88FA
+#define GL_RGB10_A2UI 0x906F
+#define GL_SAMPLER_BINDING 0x8919
+#define GL_SRC1_COLOR 0x88F9
+#define GL_TEXTURE_SWIZZLE_A 0x8E45
+#define GL_TEXTURE_SWIZZLE_B 0x8E44
+#define GL_TEXTURE_SWIZZLE_G 0x8E43
+#define GL_TEXTURE_SWIZZLE_R 0x8E42
+#define GL_TEXTURE_SWIZZLE_RGBA 0x8E46
+#define GL_TIMESTAMP 0x8E28
+#define GL_TIME_ELAPSED 0x88BF
+#define GL_VERTEX_ATTRIB_ARRAY_DIVISOR 0x88FE
+
+/* Extension: ARB_ES2_compatibility*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearDepthf)(GLfloat d);
+#define glClearDepthf _ptrc_glClearDepthf
+extern void(CODEGEN_FUNCPTR *_ptrc_glDepthRangef)(GLfloat n, GLfloat f);
+#define glDepthRangef _ptrc_glDepthRangef
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetShaderPrecisionFormat)(
+    GLenum shadertype, GLenum precisiontype, GLint *range, GLint *precision);
+#define glGetShaderPrecisionFormat _ptrc_glGetShaderPrecisionFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glReleaseShaderCompiler)(void);
+#define glReleaseShaderCompiler _ptrc_glReleaseShaderCompiler
+extern void(CODEGEN_FUNCPTR *_ptrc_glShaderBinary)(
+    GLsizei count, const GLuint *shaders, GLenum binaryformat,
+    const void *binary, GLsizei length);
+#define glShaderBinary _ptrc_glShaderBinary
+
+/* Extension: ARB_get_program_binary*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramBinary)(
+    GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat,
+    void *binary);
+#define glGetProgramBinary _ptrc_glGetProgramBinary
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramBinary)(
+    GLuint program, GLenum binaryFormat, const void *binary, GLsizei length);
+#define glProgramBinary _ptrc_glProgramBinary
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramParameteri)(
+    GLuint program, GLenum pname, GLint value);
+#define glProgramParameteri _ptrc_glProgramParameteri
+
+/* Extension: ARB_internalformat_query*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetInternalformativ)(
+    GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize,
+    GLint *params);
+#define glGetInternalformativ _ptrc_glGetInternalformativ
+
+/* Extension: ARB_internalformat_query2*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetInternalformati64v)(
+    GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize,
+    GLint64 *params);
+#define glGetInternalformati64v _ptrc_glGetInternalformati64v
+
+/* Extension: ARB_program_interface_query*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramInterfaceiv)(
+    GLuint program, GLenum programInterface, GLenum pname, GLint *params);
+#define glGetProgramInterfaceiv _ptrc_glGetProgramInterfaceiv
+extern GLuint(CODEGEN_FUNCPTR *_ptrc_glGetProgramResourceIndex)(
+    GLuint program, GLenum programInterface, const GLchar *name);
+#define glGetProgramResourceIndex _ptrc_glGetProgramResourceIndex
+extern GLint(CODEGEN_FUNCPTR *_ptrc_glGetProgramResourceLocation)(
+    GLuint program, GLenum programInterface, const GLchar *name);
+#define glGetProgramResourceLocation _ptrc_glGetProgramResourceLocation
+extern GLint(CODEGEN_FUNCPTR *_ptrc_glGetProgramResourceLocationIndex)(
+    GLuint program, GLenum programInterface, const GLchar *name);
+#define glGetProgramResourceLocationIndex                                      \
+    _ptrc_glGetProgramResourceLocationIndex
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramResourceName)(
+    GLuint program, GLenum programInterface, GLuint index, GLsizei bufSize,
+    GLsizei *length, GLchar *name);
+#define glGetProgramResourceName _ptrc_glGetProgramResourceName
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramResourceiv)(
+    GLuint program, GLenum programInterface, GLuint index, GLsizei propCount,
+    const GLenum *props, GLsizei bufSize, GLsizei *length, GLint *params);
+#define glGetProgramResourceiv _ptrc_glGetProgramResourceiv
+
+/* Extension: ARB_separate_shader_objects*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glActiveShaderProgram)(
+    GLuint pipeline, GLuint program);
+#define glActiveShaderProgram _ptrc_glActiveShaderProgram
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindProgramPipeline)(GLuint pipeline);
+#define glBindProgramPipeline _ptrc_glBindProgramPipeline
+extern GLuint(CODEGEN_FUNCPTR *_ptrc_glCreateShaderProgramv)(
+    GLenum type, GLsizei count, const GLchar *const *strings);
+#define glCreateShaderProgramv _ptrc_glCreateShaderProgramv
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteProgramPipelines)(
+    GLsizei n, const GLuint *pipelines);
+#define glDeleteProgramPipelines _ptrc_glDeleteProgramPipelines
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenProgramPipelines)(
+    GLsizei n, GLuint *pipelines);
+#define glGenProgramPipelines _ptrc_glGenProgramPipelines
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramPipelineInfoLog)(
+    GLuint pipeline, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+#define glGetProgramPipelineInfoLog _ptrc_glGetProgramPipelineInfoLog
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramPipelineiv)(
+    GLuint pipeline, GLenum pname, GLint *params);
+#define glGetProgramPipelineiv _ptrc_glGetProgramPipelineiv
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsProgramPipeline)(GLuint pipeline);
+#define glIsProgramPipeline _ptrc_glIsProgramPipeline
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1d)(
+    GLuint program, GLint location, GLdouble v0);
+#define glProgramUniform1d _ptrc_glProgramUniform1d
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1dv)(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+#define glProgramUniform1dv _ptrc_glProgramUniform1dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1f)(
+    GLuint program, GLint location, GLfloat v0);
+#define glProgramUniform1f _ptrc_glProgramUniform1f
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1fv)(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+#define glProgramUniform1fv _ptrc_glProgramUniform1fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1i)(
+    GLuint program, GLint location, GLint v0);
+#define glProgramUniform1i _ptrc_glProgramUniform1i
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1iv)(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+#define glProgramUniform1iv _ptrc_glProgramUniform1iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1ui)(
+    GLuint program, GLint location, GLuint v0);
+#define glProgramUniform1ui _ptrc_glProgramUniform1ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform1uiv)(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+#define glProgramUniform1uiv _ptrc_glProgramUniform1uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2d)(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1);
+#define glProgramUniform2d _ptrc_glProgramUniform2d
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2dv)(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+#define glProgramUniform2dv _ptrc_glProgramUniform2dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2f)(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1);
+#define glProgramUniform2f _ptrc_glProgramUniform2f
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2fv)(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+#define glProgramUniform2fv _ptrc_glProgramUniform2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2i)(
+    GLuint program, GLint location, GLint v0, GLint v1);
+#define glProgramUniform2i _ptrc_glProgramUniform2i
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2iv)(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+#define glProgramUniform2iv _ptrc_glProgramUniform2iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2ui)(
+    GLuint program, GLint location, GLuint v0, GLuint v1);
+#define glProgramUniform2ui _ptrc_glProgramUniform2ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform2uiv)(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+#define glProgramUniform2uiv _ptrc_glProgramUniform2uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3d)(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1, GLdouble v2);
+#define glProgramUniform3d _ptrc_glProgramUniform3d
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3dv)(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+#define glProgramUniform3dv _ptrc_glProgramUniform3dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3f)(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
+#define glProgramUniform3f _ptrc_glProgramUniform3f
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3fv)(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+#define glProgramUniform3fv _ptrc_glProgramUniform3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3i)(
+    GLuint program, GLint location, GLint v0, GLint v1, GLint v2);
+#define glProgramUniform3i _ptrc_glProgramUniform3i
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3iv)(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+#define glProgramUniform3iv _ptrc_glProgramUniform3iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3ui)(
+    GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2);
+#define glProgramUniform3ui _ptrc_glProgramUniform3ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform3uiv)(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+#define glProgramUniform3uiv _ptrc_glProgramUniform3uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4d)(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1, GLdouble v2,
+    GLdouble v3);
+#define glProgramUniform4d _ptrc_glProgramUniform4d
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4dv)(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+#define glProgramUniform4dv _ptrc_glProgramUniform4dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4f)(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2,
+    GLfloat v3);
+#define glProgramUniform4f _ptrc_glProgramUniform4f
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4fv)(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+#define glProgramUniform4fv _ptrc_glProgramUniform4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4i)(
+    GLuint program, GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
+#define glProgramUniform4i _ptrc_glProgramUniform4i
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4iv)(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+#define glProgramUniform4iv _ptrc_glProgramUniform4iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4ui)(
+    GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
+#define glProgramUniform4ui _ptrc_glProgramUniform4ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniform4uiv)(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+#define glProgramUniform4uiv _ptrc_glProgramUniform4uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix2dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix2dv _ptrc_glProgramUniformMatrix2dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix2fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix2fv _ptrc_glProgramUniformMatrix2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix2x3dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix2x3dv _ptrc_glProgramUniformMatrix2x3dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix2x3fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix2x3fv _ptrc_glProgramUniformMatrix2x3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix2x4dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix2x4dv _ptrc_glProgramUniformMatrix2x4dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix2x4fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix2x4fv _ptrc_glProgramUniformMatrix2x4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix3dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix3dv _ptrc_glProgramUniformMatrix3dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix3fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix3fv _ptrc_glProgramUniformMatrix3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix3x2dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix3x2dv _ptrc_glProgramUniformMatrix3x2dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix3x2fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix3x2fv _ptrc_glProgramUniformMatrix3x2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix3x4dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix3x4dv _ptrc_glProgramUniformMatrix3x4dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix3x4fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix3x4fv _ptrc_glProgramUniformMatrix3x4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix4dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix4dv _ptrc_glProgramUniformMatrix4dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix4fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix4fv _ptrc_glProgramUniformMatrix4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix4x2dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix4x2dv _ptrc_glProgramUniformMatrix4x2dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix4x2fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix4x2fv _ptrc_glProgramUniformMatrix4x2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix4x3dv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+#define glProgramUniformMatrix4x3dv _ptrc_glProgramUniformMatrix4x3dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glProgramUniformMatrix4x3fv)(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+#define glProgramUniformMatrix4x3fv _ptrc_glProgramUniformMatrix4x3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUseProgramStages)(
+    GLuint pipeline, GLbitfield stages, GLuint program);
+#define glUseProgramStages _ptrc_glUseProgramStages
+extern void(CODEGEN_FUNCPTR *_ptrc_glValidateProgramPipeline)(GLuint pipeline);
+#define glValidateProgramPipeline _ptrc_glValidateProgramPipeline
+
+/* Extension: ARB_texture_buffer_range*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexBufferRange)(
+    GLenum target, GLenum internalformat, GLuint buffer, GLintptr offset,
+    GLsizeiptr size);
+#define glTexBufferRange _ptrc_glTexBufferRange
+
+/* Extension: ARB_texture_storage*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexStorage1D)(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+#define glTexStorage1D _ptrc_glTexStorage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexStorage2D)(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height);
+#define glTexStorage2D _ptrc_glTexStorage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexStorage3D)(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth);
+#define glTexStorage3D _ptrc_glTexStorage3D
+
+/* Extension: ARB_texture_view*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureView)(
+    GLuint texture, GLenum target, GLuint origtexture, GLenum internalformat,
+    GLuint minlevel, GLuint numlevels, GLuint minlayer, GLuint numlayers);
+#define glTextureView _ptrc_glTextureView
+
+/* Extension: ARB_vertex_attrib_binding*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindVertexBuffer)(
+    GLuint bindingindex, GLuint buffer, GLintptr offset, GLsizei stride);
+#define glBindVertexBuffer _ptrc_glBindVertexBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribBinding)(
+    GLuint attribindex, GLuint bindingindex);
+#define glVertexAttribBinding _ptrc_glVertexAttribBinding
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribFormat)(
+    GLuint attribindex, GLint size, GLenum type, GLboolean normalized,
+    GLuint relativeoffset);
+#define glVertexAttribFormat _ptrc_glVertexAttribFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribIFormat)(
+    GLuint attribindex, GLint size, GLenum type, GLuint relativeoffset);
+#define glVertexAttribIFormat _ptrc_glVertexAttribIFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribLFormat)(
+    GLuint attribindex, GLint size, GLenum type, GLuint relativeoffset);
+#define glVertexAttribLFormat _ptrc_glVertexAttribLFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexBindingDivisor)(
+    GLuint bindingindex, GLuint divisor);
+#define glVertexBindingDivisor _ptrc_glVertexBindingDivisor
+
+/* Extension: ARB_viewport_array*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glDepthRangeArrayv)(
+    GLuint first, GLsizei count, const GLdouble *v);
+#define glDepthRangeArrayv _ptrc_glDepthRangeArrayv
+extern void(CODEGEN_FUNCPTR *_ptrc_glDepthRangeIndexed)(
+    GLuint index, GLdouble n, GLdouble f);
+#define glDepthRangeIndexed _ptrc_glDepthRangeIndexed
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetDoublei_v)(
+    GLenum target, GLuint index, GLdouble *data);
+#define glGetDoublei_v _ptrc_glGetDoublei_v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetFloati_v)(
+    GLenum target, GLuint index, GLfloat *data);
+#define glGetFloati_v _ptrc_glGetFloati_v
+extern void(CODEGEN_FUNCPTR *_ptrc_glScissorArrayv)(
+    GLuint first, GLsizei count, const GLint *v);
+#define glScissorArrayv _ptrc_glScissorArrayv
+extern void(CODEGEN_FUNCPTR *_ptrc_glScissorIndexed)(
+    GLuint index, GLint left, GLint bottom, GLsizei width, GLsizei height);
+#define glScissorIndexed _ptrc_glScissorIndexed
+extern void(CODEGEN_FUNCPTR *_ptrc_glScissorIndexedv)(
+    GLuint index, const GLint *v);
+#define glScissorIndexedv _ptrc_glScissorIndexedv
+extern void(CODEGEN_FUNCPTR *_ptrc_glViewportArrayv)(
+    GLuint first, GLsizei count, const GLfloat *v);
+#define glViewportArrayv _ptrc_glViewportArrayv
+extern void(CODEGEN_FUNCPTR *_ptrc_glViewportIndexedf)(
+    GLuint index, GLfloat x, GLfloat y, GLfloat w, GLfloat h);
+#define glViewportIndexedf _ptrc_glViewportIndexedf
+extern void(CODEGEN_FUNCPTR *_ptrc_glViewportIndexedfv)(
+    GLuint index, const GLfloat *v);
+#define glViewportIndexedfv _ptrc_glViewportIndexedfv
+
+/* Extension: ARB_clear_buffer_object*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearBufferData)(
+    GLenum target, GLenum internalformat, GLenum format, GLenum type,
+    const void *data);
+#define glClearBufferData _ptrc_glClearBufferData
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearBufferSubData)(
+    GLenum target, GLenum internalformat, GLintptr offset, GLsizeiptr size,
+    GLenum format, GLenum type, const void *data);
+#define glClearBufferSubData _ptrc_glClearBufferSubData
+
+/* Extension: ARB_copy_image*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyImageSubData)(
+    GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY,
+    GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX,
+    GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight,
+    GLsizei srcDepth);
+#define glCopyImageSubData _ptrc_glCopyImageSubData
+
+/* Extension: ARB_framebuffer_no_attachments*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferParameteri)(
+    GLenum target, GLenum pname, GLint param);
+#define glFramebufferParameteri _ptrc_glFramebufferParameteri
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetFramebufferParameteriv)(
+    GLenum target, GLenum pname, GLint *params);
+#define glGetFramebufferParameteriv _ptrc_glGetFramebufferParameteriv
+
+/* Extension: ARB_invalidate_subdata*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateBufferData)(GLuint buffer);
+#define glInvalidateBufferData _ptrc_glInvalidateBufferData
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateBufferSubData)(
+    GLuint buffer, GLintptr offset, GLsizeiptr length);
+#define glInvalidateBufferSubData _ptrc_glInvalidateBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateFramebuffer)(
+    GLenum target, GLsizei numAttachments, const GLenum *attachments);
+#define glInvalidateFramebuffer _ptrc_glInvalidateFramebuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateSubFramebuffer)(
+    GLenum target, GLsizei numAttachments, const GLenum *attachments, GLint x,
+    GLint y, GLsizei width, GLsizei height);
+#define glInvalidateSubFramebuffer _ptrc_glInvalidateSubFramebuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateTexImage)(
+    GLuint texture, GLint level);
+#define glInvalidateTexImage _ptrc_glInvalidateTexImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateTexSubImage)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth);
+#define glInvalidateTexSubImage _ptrc_glInvalidateTexSubImage
+
+/* Extension: ARB_texture_storage_multisample*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexStorage2DMultisample)(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations);
+#define glTexStorage2DMultisample _ptrc_glTexStorage2DMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexStorage3DMultisample)(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
+#define glTexStorage3DMultisample _ptrc_glTexStorage3DMultisample
+
+/* Extension: KHR_debug*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glDebugMessageCallback)(
+    GLDEBUGPROC callback, const void *userParam);
+#define glDebugMessageCallback _ptrc_glDebugMessageCallback
+extern void(CODEGEN_FUNCPTR *_ptrc_glDebugMessageControl)(
+    GLenum source, GLenum type, GLenum severity, GLsizei count,
+    const GLuint *ids, GLboolean enabled);
+#define glDebugMessageControl _ptrc_glDebugMessageControl
+extern void(CODEGEN_FUNCPTR *_ptrc_glDebugMessageInsert)(
+    GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+    const GLchar *buf);
+#define glDebugMessageInsert _ptrc_glDebugMessageInsert
+extern GLuint(CODEGEN_FUNCPTR *_ptrc_glGetDebugMessageLog)(
+    GLuint count, GLsizei bufSize, GLenum *sources, GLenum *types, GLuint *ids,
+    GLenum *severities, GLsizei *lengths, GLchar *messageLog);
+#define glGetDebugMessageLog _ptrc_glGetDebugMessageLog
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetObjectLabel)(
+    GLenum identifier, GLuint name, GLsizei bufSize, GLsizei *length,
+    GLchar *label);
+#define glGetObjectLabel _ptrc_glGetObjectLabel
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetObjectPtrLabel)(
+    const void *ptr, GLsizei bufSize, GLsizei *length, GLchar *label);
+#define glGetObjectPtrLabel _ptrc_glGetObjectPtrLabel
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetPointerv)(GLenum pname, void **params);
+#define glGetPointerv _ptrc_glGetPointerv
+extern void(CODEGEN_FUNCPTR *_ptrc_glObjectLabel)(
+    GLenum identifier, GLuint name, GLsizei length, const GLchar *label);
+#define glObjectLabel _ptrc_glObjectLabel
+extern void(CODEGEN_FUNCPTR *_ptrc_glObjectPtrLabel)(
+    const void *ptr, GLsizei length, const GLchar *label);
+#define glObjectPtrLabel _ptrc_glObjectPtrLabel
+extern void(CODEGEN_FUNCPTR *_ptrc_glPopDebugGroup)(void);
+#define glPopDebugGroup _ptrc_glPopDebugGroup
+extern void(CODEGEN_FUNCPTR *_ptrc_glPushDebugGroup)(
+    GLenum source, GLuint id, GLsizei length, const GLchar *message);
+#define glPushDebugGroup _ptrc_glPushDebugGroup
+
+/* Extension: ARB_buffer_storage*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBufferStorage)(
+    GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
+#define glBufferStorage _ptrc_glBufferStorage
+
+/* Extension: ARB_clear_texture*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearTexImage)(
+    GLuint texture, GLint level, GLenum format, GLenum type, const void *data);
+#define glClearTexImage _ptrc_glClearTexImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearTexSubImage)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *data);
+#define glClearTexSubImage _ptrc_glClearTexSubImage
+
+/* Extension: ARB_multi_bind*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindBuffersBase)(
+    GLenum target, GLuint first, GLsizei count, const GLuint *buffers);
+#define glBindBuffersBase _ptrc_glBindBuffersBase
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindBuffersRange)(
+    GLenum target, GLuint first, GLsizei count, const GLuint *buffers,
+    const GLintptr *offsets, const GLsizeiptr *sizes);
+#define glBindBuffersRange _ptrc_glBindBuffersRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindImageTextures)(
+    GLuint first, GLsizei count, const GLuint *textures);
+#define glBindImageTextures _ptrc_glBindImageTextures
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindSamplers)(
+    GLuint first, GLsizei count, const GLuint *samplers);
+#define glBindSamplers _ptrc_glBindSamplers
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindTextures)(
+    GLuint first, GLsizei count, const GLuint *textures);
+#define glBindTextures _ptrc_glBindTextures
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindVertexBuffers)(
+    GLuint first, GLsizei count, const GLuint *buffers, const GLintptr *offsets,
+    const GLsizei *strides);
+#define glBindVertexBuffers _ptrc_glBindVertexBuffers
+
+/* Extension: ARB_clip_control*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glClipControl)(GLenum origin, GLenum depth);
+#define glClipControl _ptrc_glClipControl
+
+/* Extension: ARB_direct_state_access*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindTextureUnit)(
+    GLuint unit, GLuint texture);
+#define glBindTextureUnit _ptrc_glBindTextureUnit
+extern void(CODEGEN_FUNCPTR *_ptrc_glBlitNamedFramebuffer)(
+    GLuint readFramebuffer, GLuint drawFramebuffer, GLint srcX0, GLint srcY0,
+    GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1,
+    GLint dstY1, GLbitfield mask, GLenum filter);
+#define glBlitNamedFramebuffer _ptrc_glBlitNamedFramebuffer
+extern GLenum(CODEGEN_FUNCPTR *_ptrc_glCheckNamedFramebufferStatus)(
+    GLuint framebuffer, GLenum target);
+#define glCheckNamedFramebufferStatus _ptrc_glCheckNamedFramebufferStatus
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearNamedBufferData)(
+    GLuint buffer, GLenum internalformat, GLenum format, GLenum type,
+    const void *data);
+#define glClearNamedBufferData _ptrc_glClearNamedBufferData
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearNamedBufferSubData)(
+    GLuint buffer, GLenum internalformat, GLintptr offset, GLsizeiptr size,
+    GLenum format, GLenum type, const void *data);
+#define glClearNamedBufferSubData _ptrc_glClearNamedBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearNamedFramebufferfi)(
+    GLuint framebuffer, GLenum buffer, const GLfloat depth, GLint stencil);
+#define glClearNamedFramebufferfi _ptrc_glClearNamedFramebufferfi
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearNamedFramebufferfv)(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLfloat *value);
+#define glClearNamedFramebufferfv _ptrc_glClearNamedFramebufferfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearNamedFramebufferiv)(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLint *value);
+#define glClearNamedFramebufferiv _ptrc_glClearNamedFramebufferiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearNamedFramebufferuiv)(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLuint *value);
+#define glClearNamedFramebufferuiv _ptrc_glClearNamedFramebufferuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTextureSubImage1D)(
+    GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLsizei imageSize, const void *data);
+#define glCompressedTextureSubImage1D _ptrc_glCompressedTextureSubImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTextureSubImage2D)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLsizei imageSize, const void *data);
+#define glCompressedTextureSubImage2D _ptrc_glCompressedTextureSubImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTextureSubImage3D)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format,
+    GLsizei imageSize, const void *data);
+#define glCompressedTextureSubImage3D _ptrc_glCompressedTextureSubImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyNamedBufferSubData)(
+    GLuint readBuffer, GLuint writeBuffer, GLintptr readOffset,
+    GLintptr writeOffset, GLsizeiptr size);
+#define glCopyNamedBufferSubData _ptrc_glCopyNamedBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTextureSubImage1D)(
+    GLuint texture, GLint level, GLint xoffset, GLint x, GLint y,
+    GLsizei width);
+#define glCopyTextureSubImage1D _ptrc_glCopyTextureSubImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTextureSubImage2D)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+    GLsizei width, GLsizei height);
+#define glCopyTextureSubImage2D _ptrc_glCopyTextureSubImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTextureSubImage3D)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLint x, GLint y, GLsizei width, GLsizei height);
+#define glCopyTextureSubImage3D _ptrc_glCopyTextureSubImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateBuffers)(GLsizei n, GLuint *buffers);
+#define glCreateBuffers _ptrc_glCreateBuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateFramebuffers)(
+    GLsizei n, GLuint *framebuffers);
+#define glCreateFramebuffers _ptrc_glCreateFramebuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateProgramPipelines)(
+    GLsizei n, GLuint *pipelines);
+#define glCreateProgramPipelines _ptrc_glCreateProgramPipelines
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateQueries)(
+    GLenum target, GLsizei n, GLuint *ids);
+#define glCreateQueries _ptrc_glCreateQueries
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateRenderbuffers)(
+    GLsizei n, GLuint *renderbuffers);
+#define glCreateRenderbuffers _ptrc_glCreateRenderbuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateSamplers)(
+    GLsizei n, GLuint *samplers);
+#define glCreateSamplers _ptrc_glCreateSamplers
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateTextures)(
+    GLenum target, GLsizei n, GLuint *textures);
+#define glCreateTextures _ptrc_glCreateTextures
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateTransformFeedbacks)(
+    GLsizei n, GLuint *ids);
+#define glCreateTransformFeedbacks _ptrc_glCreateTransformFeedbacks
+extern void(CODEGEN_FUNCPTR *_ptrc_glCreateVertexArrays)(
+    GLsizei n, GLuint *arrays);
+#define glCreateVertexArrays _ptrc_glCreateVertexArrays
+extern void(CODEGEN_FUNCPTR *_ptrc_glDisableVertexArrayAttrib)(
+    GLuint vaobj, GLuint index);
+#define glDisableVertexArrayAttrib _ptrc_glDisableVertexArrayAttrib
+extern void(CODEGEN_FUNCPTR *_ptrc_glEnableVertexArrayAttrib)(
+    GLuint vaobj, GLuint index);
+#define glEnableVertexArrayAttrib _ptrc_glEnableVertexArrayAttrib
+extern void(CODEGEN_FUNCPTR *_ptrc_glFlushMappedNamedBufferRange)(
+    GLuint buffer, GLintptr offset, GLsizeiptr length);
+#define glFlushMappedNamedBufferRange _ptrc_glFlushMappedNamedBufferRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenerateTextureMipmap)(GLuint texture);
+#define glGenerateTextureMipmap _ptrc_glGenerateTextureMipmap
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetCompressedTextureImage)(
+    GLuint texture, GLint level, GLsizei bufSize, void *pixels);
+#define glGetCompressedTextureImage _ptrc_glGetCompressedTextureImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedBufferParameteri64v)(
+    GLuint buffer, GLenum pname, GLint64 *params);
+#define glGetNamedBufferParameteri64v _ptrc_glGetNamedBufferParameteri64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedBufferParameteriv)(
+    GLuint buffer, GLenum pname, GLint *params);
+#define glGetNamedBufferParameteriv _ptrc_glGetNamedBufferParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedBufferPointerv)(
+    GLuint buffer, GLenum pname, void **params);
+#define glGetNamedBufferPointerv _ptrc_glGetNamedBufferPointerv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedBufferSubData)(
+    GLuint buffer, GLintptr offset, GLsizeiptr size, void *data);
+#define glGetNamedBufferSubData _ptrc_glGetNamedBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedFramebufferAttachmentParameteriv)(
+    GLuint framebuffer, GLenum attachment, GLenum pname, GLint *params);
+#define glGetNamedFramebufferAttachmentParameteriv                             \
+    _ptrc_glGetNamedFramebufferAttachmentParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedFramebufferParameteriv)(
+    GLuint framebuffer, GLenum pname, GLint *param);
+#define glGetNamedFramebufferParameteriv _ptrc_glGetNamedFramebufferParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetNamedRenderbufferParameteriv)(
+    GLuint renderbuffer, GLenum pname, GLint *params);
+#define glGetNamedRenderbufferParameteriv                                      \
+    _ptrc_glGetNamedRenderbufferParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryBufferObjecti64v)(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+#define glGetQueryBufferObjecti64v _ptrc_glGetQueryBufferObjecti64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryBufferObjectiv)(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+#define glGetQueryBufferObjectiv _ptrc_glGetQueryBufferObjectiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryBufferObjectui64v)(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+#define glGetQueryBufferObjectui64v _ptrc_glGetQueryBufferObjectui64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryBufferObjectuiv)(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+#define glGetQueryBufferObjectuiv _ptrc_glGetQueryBufferObjectuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureImage)(
+    GLuint texture, GLint level, GLenum format, GLenum type, GLsizei bufSize,
+    void *pixels);
+#define glGetTextureImage _ptrc_glGetTextureImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureLevelParameterfv)(
+    GLuint texture, GLint level, GLenum pname, GLfloat *params);
+#define glGetTextureLevelParameterfv _ptrc_glGetTextureLevelParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureLevelParameteriv)(
+    GLuint texture, GLint level, GLenum pname, GLint *params);
+#define glGetTextureLevelParameteriv _ptrc_glGetTextureLevelParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureParameterIiv)(
+    GLuint texture, GLenum pname, GLint *params);
+#define glGetTextureParameterIiv _ptrc_glGetTextureParameterIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureParameterIuiv)(
+    GLuint texture, GLenum pname, GLuint *params);
+#define glGetTextureParameterIuiv _ptrc_glGetTextureParameterIuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureParameterfv)(
+    GLuint texture, GLenum pname, GLfloat *params);
+#define glGetTextureParameterfv _ptrc_glGetTextureParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureParameteriv)(
+    GLuint texture, GLenum pname, GLint *params);
+#define glGetTextureParameteriv _ptrc_glGetTextureParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTransformFeedbacki64_v)(
+    GLuint xfb, GLenum pname, GLuint index, GLint64 *param);
+#define glGetTransformFeedbacki64_v _ptrc_glGetTransformFeedbacki64_v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTransformFeedbacki_v)(
+    GLuint xfb, GLenum pname, GLuint index, GLint *param);
+#define glGetTransformFeedbacki_v _ptrc_glGetTransformFeedbacki_v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTransformFeedbackiv)(
+    GLuint xfb, GLenum pname, GLint *param);
+#define glGetTransformFeedbackiv _ptrc_glGetTransformFeedbackiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexArrayIndexed64iv)(
+    GLuint vaobj, GLuint index, GLenum pname, GLint64 *param);
+#define glGetVertexArrayIndexed64iv _ptrc_glGetVertexArrayIndexed64iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexArrayIndexediv)(
+    GLuint vaobj, GLuint index, GLenum pname, GLint *param);
+#define glGetVertexArrayIndexediv _ptrc_glGetVertexArrayIndexediv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexArrayiv)(
+    GLuint vaobj, GLenum pname, GLint *param);
+#define glGetVertexArrayiv _ptrc_glGetVertexArrayiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateNamedFramebufferData)(
+    GLuint framebuffer, GLsizei numAttachments, const GLenum *attachments);
+#define glInvalidateNamedFramebufferData _ptrc_glInvalidateNamedFramebufferData
+extern void(CODEGEN_FUNCPTR *_ptrc_glInvalidateNamedFramebufferSubData)(
+    GLuint framebuffer, GLsizei numAttachments, const GLenum *attachments,
+    GLint x, GLint y, GLsizei width, GLsizei height);
+#define glInvalidateNamedFramebufferSubData                                    \
+    _ptrc_glInvalidateNamedFramebufferSubData
+extern void *(CODEGEN_FUNCPTR *_ptrc_glMapNamedBuffer)(
+    GLuint buffer, GLenum access);
+#define glMapNamedBuffer _ptrc_glMapNamedBuffer
+extern void *(CODEGEN_FUNCPTR *_ptrc_glMapNamedBufferRange)(
+    GLuint buffer, GLintptr offset, GLsizeiptr length, GLbitfield access);
+#define glMapNamedBufferRange _ptrc_glMapNamedBufferRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedBufferData)(
+    GLuint buffer, GLsizeiptr size, const void *data, GLenum usage);
+#define glNamedBufferData _ptrc_glNamedBufferData
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedBufferStorage)(
+    GLuint buffer, GLsizeiptr size, const void *data, GLbitfield flags);
+#define glNamedBufferStorage _ptrc_glNamedBufferStorage
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedBufferSubData)(
+    GLuint buffer, GLintptr offset, GLsizeiptr size, const void *data);
+#define glNamedBufferSubData _ptrc_glNamedBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferDrawBuffer)(
+    GLuint framebuffer, GLenum buf);
+#define glNamedFramebufferDrawBuffer _ptrc_glNamedFramebufferDrawBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferDrawBuffers)(
+    GLuint framebuffer, GLsizei n, const GLenum *bufs);
+#define glNamedFramebufferDrawBuffers _ptrc_glNamedFramebufferDrawBuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferParameteri)(
+    GLuint framebuffer, GLenum pname, GLint param);
+#define glNamedFramebufferParameteri _ptrc_glNamedFramebufferParameteri
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferReadBuffer)(
+    GLuint framebuffer, GLenum src);
+#define glNamedFramebufferReadBuffer _ptrc_glNamedFramebufferReadBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferRenderbuffer)(
+    GLuint framebuffer, GLenum attachment, GLenum renderbuffertarget,
+    GLuint renderbuffer);
+#define glNamedFramebufferRenderbuffer _ptrc_glNamedFramebufferRenderbuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferTexture)(
+    GLuint framebuffer, GLenum attachment, GLuint texture, GLint level);
+#define glNamedFramebufferTexture _ptrc_glNamedFramebufferTexture
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedFramebufferTextureLayer)(
+    GLuint framebuffer, GLenum attachment, GLuint texture, GLint level,
+    GLint layer);
+#define glNamedFramebufferTextureLayer _ptrc_glNamedFramebufferTextureLayer
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedRenderbufferStorage)(
+    GLuint renderbuffer, GLenum internalformat, GLsizei width, GLsizei height);
+#define glNamedRenderbufferStorage _ptrc_glNamedRenderbufferStorage
+extern void(CODEGEN_FUNCPTR *_ptrc_glNamedRenderbufferStorageMultisample)(
+    GLuint renderbuffer, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height);
+#define glNamedRenderbufferStorageMultisample                                  \
+    _ptrc_glNamedRenderbufferStorageMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureBuffer)(
+    GLuint texture, GLenum internalformat, GLuint buffer);
+#define glTextureBuffer _ptrc_glTextureBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureBufferRange)(
+    GLuint texture, GLenum internalformat, GLuint buffer, GLintptr offset,
+    GLsizeiptr size);
+#define glTextureBufferRange _ptrc_glTextureBufferRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureParameterIiv)(
+    GLuint texture, GLenum pname, const GLint *params);
+#define glTextureParameterIiv _ptrc_glTextureParameterIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureParameterIuiv)(
+    GLuint texture, GLenum pname, const GLuint *params);
+#define glTextureParameterIuiv _ptrc_glTextureParameterIuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureParameterf)(
+    GLuint texture, GLenum pname, GLfloat param);
+#define glTextureParameterf _ptrc_glTextureParameterf
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureParameterfv)(
+    GLuint texture, GLenum pname, const GLfloat *param);
+#define glTextureParameterfv _ptrc_glTextureParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureParameteri)(
+    GLuint texture, GLenum pname, GLint param);
+#define glTextureParameteri _ptrc_glTextureParameteri
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureParameteriv)(
+    GLuint texture, GLenum pname, const GLint *param);
+#define glTextureParameteriv _ptrc_glTextureParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureStorage1D)(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width);
+#define glTextureStorage1D _ptrc_glTextureStorage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureStorage2D)(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height);
+#define glTextureStorage2D _ptrc_glTextureStorage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureStorage2DMultisample)(
+    GLuint texture, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations);
+#define glTextureStorage2DMultisample _ptrc_glTextureStorage2DMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureStorage3D)(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth);
+#define glTextureStorage3D _ptrc_glTextureStorage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureStorage3DMultisample)(
+    GLuint texture, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
+#define glTextureStorage3DMultisample _ptrc_glTextureStorage3DMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureSubImage1D)(
+    GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLenum type, const void *pixels);
+#define glTextureSubImage1D _ptrc_glTextureSubImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureSubImage2D)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLenum type, const void *pixels);
+#define glTextureSubImage2D _ptrc_glTextureSubImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureSubImage3D)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *pixels);
+#define glTextureSubImage3D _ptrc_glTextureSubImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTransformFeedbackBufferBase)(
+    GLuint xfb, GLuint index, GLuint buffer);
+#define glTransformFeedbackBufferBase _ptrc_glTransformFeedbackBufferBase
+extern void(CODEGEN_FUNCPTR *_ptrc_glTransformFeedbackBufferRange)(
+    GLuint xfb, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size);
+#define glTransformFeedbackBufferRange _ptrc_glTransformFeedbackBufferRange
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glUnmapNamedBuffer)(GLuint buffer);
+#define glUnmapNamedBuffer _ptrc_glUnmapNamedBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayAttribBinding)(
+    GLuint vaobj, GLuint attribindex, GLuint bindingindex);
+#define glVertexArrayAttribBinding _ptrc_glVertexArrayAttribBinding
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayAttribFormat)(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLboolean normalized, GLuint relativeoffset);
+#define glVertexArrayAttribFormat _ptrc_glVertexArrayAttribFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayAttribIFormat)(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLuint relativeoffset);
+#define glVertexArrayAttribIFormat _ptrc_glVertexArrayAttribIFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayAttribLFormat)(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLuint relativeoffset);
+#define glVertexArrayAttribLFormat _ptrc_glVertexArrayAttribLFormat
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayBindingDivisor)(
+    GLuint vaobj, GLuint bindingindex, GLuint divisor);
+#define glVertexArrayBindingDivisor _ptrc_glVertexArrayBindingDivisor
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayElementBuffer)(
+    GLuint vaobj, GLuint buffer);
+#define glVertexArrayElementBuffer _ptrc_glVertexArrayElementBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayVertexBuffer)(
+    GLuint vaobj, GLuint bindingindex, GLuint buffer, GLintptr offset,
+    GLsizei stride);
+#define glVertexArrayVertexBuffer _ptrc_glVertexArrayVertexBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexArrayVertexBuffers)(
+    GLuint vaobj, GLuint first, GLsizei count, const GLuint *buffers,
+    const GLintptr *offsets, const GLsizei *strides);
+#define glVertexArrayVertexBuffers _ptrc_glVertexArrayVertexBuffers
+
+/* Extension: ARB_get_texture_sub_image*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetCompressedTextureSubImage)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLsizei bufSize,
+    void *pixels);
+#define glGetCompressedTextureSubImage _ptrc_glGetCompressedTextureSubImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTextureSubImage)(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    GLsizei bufSize, void *pixels);
+#define glGetTextureSubImage _ptrc_glGetTextureSubImage
+
+/* Extension: ARB_texture_barrier*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glTextureBarrier)(void);
+#define glTextureBarrier _ptrc_glTextureBarrier
+
+/* Extension: KHR_robustness*/
+extern GLenum(CODEGEN_FUNCPTR *_ptrc_glGetGraphicsResetStatus)(void);
+#define glGetGraphicsResetStatus _ptrc_glGetGraphicsResetStatus
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetnUniformfv)(
+    GLuint program, GLint location, GLsizei bufSize, GLfloat *params);
+#define glGetnUniformfv _ptrc_glGetnUniformfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetnUniformiv)(
+    GLuint program, GLint location, GLsizei bufSize, GLint *params);
+#define glGetnUniformiv _ptrc_glGetnUniformiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetnUniformuiv)(
+    GLuint program, GLint location, GLsizei bufSize, GLuint *params);
+#define glGetnUniformuiv _ptrc_glGetnUniformuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glReadnPixels)(
+    GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    GLsizei bufSize, void *data);
+#define glReadnPixels _ptrc_glReadnPixels
+
+/* Extension: 1.0*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBlendFunc)(GLenum sfactor, GLenum dfactor);
+#define glBlendFunc _ptrc_glBlendFunc
+extern void(CODEGEN_FUNCPTR *_ptrc_glClear)(GLbitfield mask);
+#define glClear _ptrc_glClear
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearColor)(
+    GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+#define glClearColor _ptrc_glClearColor
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearDepth)(GLdouble depth);
+#define glClearDepth _ptrc_glClearDepth
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearStencil)(GLint s);
+#define glClearStencil _ptrc_glClearStencil
+extern void(CODEGEN_FUNCPTR *_ptrc_glColorMask)(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
+#define glColorMask _ptrc_glColorMask
+extern void(CODEGEN_FUNCPTR *_ptrc_glCullFace)(GLenum mode);
+#define glCullFace _ptrc_glCullFace
+extern void(CODEGEN_FUNCPTR *_ptrc_glDepthFunc)(GLenum func);
+#define glDepthFunc _ptrc_glDepthFunc
+extern void(CODEGEN_FUNCPTR *_ptrc_glDepthMask)(GLboolean flag);
+#define glDepthMask _ptrc_glDepthMask
+extern void(CODEGEN_FUNCPTR *_ptrc_glDepthRange)(
+    GLdouble ren_near, GLdouble ren_far);
+#define glDepthRange _ptrc_glDepthRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glDisable)(GLenum cap);
+#define glDisable _ptrc_glDisable
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawBuffer)(GLenum buf);
+#define glDrawBuffer _ptrc_glDrawBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glEnable)(GLenum cap);
+#define glEnable _ptrc_glEnable
+extern void(CODEGEN_FUNCPTR *_ptrc_glFinish)(void);
+#define glFinish _ptrc_glFinish
+extern void(CODEGEN_FUNCPTR *_ptrc_glFlush)(void);
+#define glFlush _ptrc_glFlush
+extern void(CODEGEN_FUNCPTR *_ptrc_glFrontFace)(GLenum mode);
+#define glFrontFace _ptrc_glFrontFace
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetBooleanv)(
+    GLenum pname, GLboolean *data);
+#define glGetBooleanv _ptrc_glGetBooleanv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetDoublev)(GLenum pname, GLdouble *data);
+#define glGetDoublev _ptrc_glGetDoublev
+extern GLenum(CODEGEN_FUNCPTR *_ptrc_glGetError)(void);
+#define glGetError _ptrc_glGetError
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetFloatv)(GLenum pname, GLfloat *data);
+#define glGetFloatv _ptrc_glGetFloatv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetIntegerv)(GLenum pname, GLint *data);
+#define glGetIntegerv _ptrc_glGetIntegerv
+extern const GLubyte *(CODEGEN_FUNCPTR *_ptrc_glGetString)(GLenum name);
+#define glGetString _ptrc_glGetString
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexImage)(
+    GLenum target, GLint level, GLenum format, GLenum type, void *pixels);
+#define glGetTexImage _ptrc_glGetTexImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexLevelParameterfv)(
+    GLenum target, GLint level, GLenum pname, GLfloat *params);
+#define glGetTexLevelParameterfv _ptrc_glGetTexLevelParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexLevelParameteriv)(
+    GLenum target, GLint level, GLenum pname, GLint *params);
+#define glGetTexLevelParameteriv _ptrc_glGetTexLevelParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexParameterfv)(
+    GLenum target, GLenum pname, GLfloat *params);
+#define glGetTexParameterfv _ptrc_glGetTexParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexParameteriv)(
+    GLenum target, GLenum pname, GLint *params);
+#define glGetTexParameteriv _ptrc_glGetTexParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glHint)(GLenum target, GLenum mode);
+#define glHint _ptrc_glHint
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsEnabled)(GLenum cap);
+#define glIsEnabled _ptrc_glIsEnabled
+extern void(CODEGEN_FUNCPTR *_ptrc_glLineWidth)(GLfloat width);
+#define glLineWidth _ptrc_glLineWidth
+extern void(CODEGEN_FUNCPTR *_ptrc_glLogicOp)(GLenum opcode);
+#define glLogicOp _ptrc_glLogicOp
+extern void(CODEGEN_FUNCPTR *_ptrc_glPixelStoref)(GLenum pname, GLfloat param);
+#define glPixelStoref _ptrc_glPixelStoref
+extern void(CODEGEN_FUNCPTR *_ptrc_glPixelStorei)(GLenum pname, GLint param);
+#define glPixelStorei _ptrc_glPixelStorei
+extern void(CODEGEN_FUNCPTR *_ptrc_glPointSize)(GLfloat size);
+#define glPointSize _ptrc_glPointSize
+extern void(CODEGEN_FUNCPTR *_ptrc_glPolygonMode)(GLenum face, GLenum mode);
+#define glPolygonMode _ptrc_glPolygonMode
+extern void(CODEGEN_FUNCPTR *_ptrc_glReadBuffer)(GLenum src);
+#define glReadBuffer _ptrc_glReadBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glReadPixels)(
+    GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    void *pixels);
+#define glReadPixels _ptrc_glReadPixels
+extern void(CODEGEN_FUNCPTR *_ptrc_glScissor)(
+    GLint x, GLint y, GLsizei width, GLsizei height);
+#define glScissor _ptrc_glScissor
+extern void(CODEGEN_FUNCPTR *_ptrc_glStencilFunc)(
+    GLenum func, GLint ref, GLuint mask);
+#define glStencilFunc _ptrc_glStencilFunc
+extern void(CODEGEN_FUNCPTR *_ptrc_glStencilMask)(GLuint mask);
+#define glStencilMask _ptrc_glStencilMask
+extern void(CODEGEN_FUNCPTR *_ptrc_glStencilOp)(
+    GLenum fail, GLenum zfail, GLenum zpass);
+#define glStencilOp _ptrc_glStencilOp
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexImage1D)(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLint border, GLenum format, GLenum type, const void *pixels);
+#define glTexImage1D _ptrc_glTexImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexImage2D)(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLsizei height, GLint border, GLenum format, GLenum type,
+    const void *pixels);
+#define glTexImage2D _ptrc_glTexImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexParameterf)(
+    GLenum target, GLenum pname, GLfloat param);
+#define glTexParameterf _ptrc_glTexParameterf
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexParameterfv)(
+    GLenum target, GLenum pname, const GLfloat *params);
+#define glTexParameterfv _ptrc_glTexParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexParameteri)(
+    GLenum target, GLenum pname, GLint param);
+#define glTexParameteri _ptrc_glTexParameteri
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexParameteriv)(
+    GLenum target, GLenum pname, const GLint *params);
+#define glTexParameteriv _ptrc_glTexParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glViewport)(
+    GLint x, GLint y, GLsizei width, GLsizei height);
+#define glViewport _ptrc_glViewport
+
+/* Extension: 1.1*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindTexture)(
+    GLenum target, GLuint texture);
+#define glBindTexture _ptrc_glBindTexture
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTexImage1D)(
+    GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+    GLsizei width, GLint border);
+#define glCopyTexImage1D _ptrc_glCopyTexImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTexImage2D)(
+    GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+    GLsizei width, GLsizei height, GLint border);
+#define glCopyTexImage2D _ptrc_glCopyTexImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTexSubImage1D)(
+    GLenum target, GLint level, GLint xoffset, GLint x, GLint y, GLsizei width);
+#define glCopyTexSubImage1D _ptrc_glCopyTexSubImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTexSubImage2D)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+    GLsizei width, GLsizei height);
+#define glCopyTexSubImage2D _ptrc_glCopyTexSubImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteTextures)(
+    GLsizei n, const GLuint *textures);
+#define glDeleteTextures _ptrc_glDeleteTextures
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawArrays)(
+    GLenum mode, GLint first, GLsizei count);
+#define glDrawArrays _ptrc_glDrawArrays
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawElements)(
+    GLenum mode, GLsizei count, GLenum type, const void *indices);
+#define glDrawElements _ptrc_glDrawElements
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenTextures)(GLsizei n, GLuint *textures);
+#define glGenTextures _ptrc_glGenTextures
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsTexture)(GLuint texture);
+#define glIsTexture _ptrc_glIsTexture
+extern void(CODEGEN_FUNCPTR *_ptrc_glPolygonOffset)(
+    GLfloat factor, GLfloat units);
+#define glPolygonOffset _ptrc_glPolygonOffset
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexSubImage1D)(
+    GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLenum type, const void *pixels);
+#define glTexSubImage1D _ptrc_glTexSubImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexSubImage2D)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLenum type, const void *pixels);
+#define glTexSubImage2D _ptrc_glTexSubImage2D
+
+/* Extension: 1.2*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyTexSubImage3D)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLint x, GLint y, GLsizei width, GLsizei height);
+#define glCopyTexSubImage3D _ptrc_glCopyTexSubImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawRangeElements)(
+    GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type,
+    const void *indices);
+#define glDrawRangeElements _ptrc_glDrawRangeElements
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexImage3D)(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
+    const void *pixels);
+#define glTexImage3D _ptrc_glTexImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexSubImage3D)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *pixels);
+#define glTexSubImage3D _ptrc_glTexSubImage3D
+
+/* Extension: 1.3*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glActiveTexture)(GLenum texture);
+#define glActiveTexture _ptrc_glActiveTexture
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTexImage1D)(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLint border, GLsizei imageSize, const void *data);
+#define glCompressedTexImage1D _ptrc_glCompressedTexImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTexImage2D)(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLsizei height, GLint border, GLsizei imageSize, const void *data);
+#define glCompressedTexImage2D _ptrc_glCompressedTexImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTexImage3D)(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLint border, GLsizei imageSize,
+    const void *data);
+#define glCompressedTexImage3D _ptrc_glCompressedTexImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTexSubImage1D)(
+    GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLsizei imageSize, const void *data);
+#define glCompressedTexSubImage1D _ptrc_glCompressedTexSubImage1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTexSubImage2D)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLsizei imageSize, const void *data);
+#define glCompressedTexSubImage2D _ptrc_glCompressedTexSubImage2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompressedTexSubImage3D)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format,
+    GLsizei imageSize, const void *data);
+#define glCompressedTexSubImage3D _ptrc_glCompressedTexSubImage3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetCompressedTexImage)(
+    GLenum target, GLint level, void *img);
+#define glGetCompressedTexImage _ptrc_glGetCompressedTexImage
+extern void(CODEGEN_FUNCPTR *_ptrc_glSampleCoverage)(
+    GLfloat value, GLboolean invert);
+#define glSampleCoverage _ptrc_glSampleCoverage
+
+/* Extension: 1.4*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBlendFuncSeparate)(
+    GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha,
+    GLenum dfactorAlpha);
+#define glBlendFuncSeparate _ptrc_glBlendFuncSeparate
+extern void(CODEGEN_FUNCPTR *_ptrc_glMultiDrawArrays)(
+    GLenum mode, const GLint *first, const GLsizei *count, GLsizei drawcount);
+#define glMultiDrawArrays _ptrc_glMultiDrawArrays
+extern void(CODEGEN_FUNCPTR *_ptrc_glMultiDrawElements)(
+    GLenum mode, const GLsizei *count, GLenum type, const void *const *indices,
+    GLsizei drawcount);
+#define glMultiDrawElements _ptrc_glMultiDrawElements
+extern void(CODEGEN_FUNCPTR *_ptrc_glPointParameterf)(
+    GLenum pname, GLfloat param);
+#define glPointParameterf _ptrc_glPointParameterf
+extern void(CODEGEN_FUNCPTR *_ptrc_glPointParameterfv)(
+    GLenum pname, const GLfloat *params);
+#define glPointParameterfv _ptrc_glPointParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glPointParameteri)(
+    GLenum pname, GLint param);
+#define glPointParameteri _ptrc_glPointParameteri
+extern void(CODEGEN_FUNCPTR *_ptrc_glPointParameteriv)(
+    GLenum pname, const GLint *params);
+#define glPointParameteriv _ptrc_glPointParameteriv
+
+/* Extension: 1.5*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBeginQuery)(GLenum target, GLuint id);
+#define glBeginQuery _ptrc_glBeginQuery
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindBuffer)(GLenum target, GLuint buffer);
+#define glBindBuffer _ptrc_glBindBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glBufferData)(
+    GLenum target, GLsizeiptr size, const void *data, GLenum usage);
+#define glBufferData _ptrc_glBufferData
+extern void(CODEGEN_FUNCPTR *_ptrc_glBufferSubData)(
+    GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
+#define glBufferSubData _ptrc_glBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteBuffers)(
+    GLsizei n, const GLuint *buffers);
+#define glDeleteBuffers _ptrc_glDeleteBuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteQueries)(
+    GLsizei n, const GLuint *ids);
+#define glDeleteQueries _ptrc_glDeleteQueries
+extern void(CODEGEN_FUNCPTR *_ptrc_glEndQuery)(GLenum target);
+#define glEndQuery _ptrc_glEndQuery
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenBuffers)(GLsizei n, GLuint *buffers);
+#define glGenBuffers _ptrc_glGenBuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenQueries)(GLsizei n, GLuint *ids);
+#define glGenQueries _ptrc_glGenQueries
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetBufferParameteriv)(
+    GLenum target, GLenum pname, GLint *params);
+#define glGetBufferParameteriv _ptrc_glGetBufferParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetBufferPointerv)(
+    GLenum target, GLenum pname, void **params);
+#define glGetBufferPointerv _ptrc_glGetBufferPointerv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetBufferSubData)(
+    GLenum target, GLintptr offset, GLsizeiptr size, void *data);
+#define glGetBufferSubData _ptrc_glGetBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryObjectiv)(
+    GLuint id, GLenum pname, GLint *params);
+#define glGetQueryObjectiv _ptrc_glGetQueryObjectiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryObjectuiv)(
+    GLuint id, GLenum pname, GLuint *params);
+#define glGetQueryObjectuiv _ptrc_glGetQueryObjectuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryiv)(
+    GLenum target, GLenum pname, GLint *params);
+#define glGetQueryiv _ptrc_glGetQueryiv
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsBuffer)(GLuint buffer);
+#define glIsBuffer _ptrc_glIsBuffer
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsQuery)(GLuint id);
+#define glIsQuery _ptrc_glIsQuery
+extern void *(CODEGEN_FUNCPTR *_ptrc_glMapBuffer)(GLenum target, GLenum access);
+#define glMapBuffer _ptrc_glMapBuffer
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glUnmapBuffer)(GLenum target);
+#define glUnmapBuffer _ptrc_glUnmapBuffer
+
+/* Extension: 2.0*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glAttachShader)(
+    GLuint program, GLuint shader);
+#define glAttachShader _ptrc_glAttachShader
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindAttribLocation)(
+    GLuint program, GLuint index, const GLchar *name);
+#define glBindAttribLocation _ptrc_glBindAttribLocation
+extern void(CODEGEN_FUNCPTR *_ptrc_glBlendEquationSeparate)(
+    GLenum modeRGB, GLenum modeAlpha);
+#define glBlendEquationSeparate _ptrc_glBlendEquationSeparate
+extern void(CODEGEN_FUNCPTR *_ptrc_glCompileShader)(GLuint shader);
+#define glCompileShader _ptrc_glCompileShader
+extern GLuint(CODEGEN_FUNCPTR *_ptrc_glCreateProgram)(void);
+#define glCreateProgram _ptrc_glCreateProgram
+extern GLuint(CODEGEN_FUNCPTR *_ptrc_glCreateShader)(GLenum type);
+#define glCreateShader _ptrc_glCreateShader
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteProgram)(GLuint program);
+#define glDeleteProgram _ptrc_glDeleteProgram
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteShader)(GLuint shader);
+#define glDeleteShader _ptrc_glDeleteShader
+extern void(CODEGEN_FUNCPTR *_ptrc_glDetachShader)(
+    GLuint program, GLuint shader);
+#define glDetachShader _ptrc_glDetachShader
+extern void(CODEGEN_FUNCPTR *_ptrc_glDisableVertexAttribArray)(GLuint index);
+#define glDisableVertexAttribArray _ptrc_glDisableVertexAttribArray
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawBuffers)(
+    GLsizei n, const GLenum *bufs);
+#define glDrawBuffers _ptrc_glDrawBuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glEnableVertexAttribArray)(GLuint index);
+#define glEnableVertexAttribArray _ptrc_glEnableVertexAttribArray
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetActiveAttrib)(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+    GLenum *type, GLchar *name);
+#define glGetActiveAttrib _ptrc_glGetActiveAttrib
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetActiveUniform)(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+    GLenum *type, GLchar *name);
+#define glGetActiveUniform _ptrc_glGetActiveUniform
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetAttachedShaders)(
+    GLuint program, GLsizei maxCount, GLsizei *count, GLuint *shaders);
+#define glGetAttachedShaders _ptrc_glGetAttachedShaders
+extern GLint(CODEGEN_FUNCPTR *_ptrc_glGetAttribLocation)(
+    GLuint program, const GLchar *name);
+#define glGetAttribLocation _ptrc_glGetAttribLocation
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramInfoLog)(
+    GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+#define glGetProgramInfoLog _ptrc_glGetProgramInfoLog
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetProgramiv)(
+    GLuint program, GLenum pname, GLint *params);
+#define glGetProgramiv _ptrc_glGetProgramiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetShaderInfoLog)(
+    GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+#define glGetShaderInfoLog _ptrc_glGetShaderInfoLog
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetShaderSource)(
+    GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
+#define glGetShaderSource _ptrc_glGetShaderSource
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetShaderiv)(
+    GLuint shader, GLenum pname, GLint *params);
+#define glGetShaderiv _ptrc_glGetShaderiv
+extern GLint(CODEGEN_FUNCPTR *_ptrc_glGetUniformLocation)(
+    GLuint program, const GLchar *name);
+#define glGetUniformLocation _ptrc_glGetUniformLocation
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetUniformfv)(
+    GLuint program, GLint location, GLfloat *params);
+#define glGetUniformfv _ptrc_glGetUniformfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetUniformiv)(
+    GLuint program, GLint location, GLint *params);
+#define glGetUniformiv _ptrc_glGetUniformiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexAttribPointerv)(
+    GLuint index, GLenum pname, void **pointer);
+#define glGetVertexAttribPointerv _ptrc_glGetVertexAttribPointerv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexAttribdv)(
+    GLuint index, GLenum pname, GLdouble *params);
+#define glGetVertexAttribdv _ptrc_glGetVertexAttribdv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexAttribfv)(
+    GLuint index, GLenum pname, GLfloat *params);
+#define glGetVertexAttribfv _ptrc_glGetVertexAttribfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexAttribiv)(
+    GLuint index, GLenum pname, GLint *params);
+#define glGetVertexAttribiv _ptrc_glGetVertexAttribiv
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsProgram)(GLuint program);
+#define glIsProgram _ptrc_glIsProgram
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsShader)(GLuint shader);
+#define glIsShader _ptrc_glIsShader
+extern void(CODEGEN_FUNCPTR *_ptrc_glLinkProgram)(GLuint program);
+#define glLinkProgram _ptrc_glLinkProgram
+extern void(CODEGEN_FUNCPTR *_ptrc_glShaderSource)(
+    GLuint shader, GLsizei count, const GLchar *const *string,
+    const GLint *length);
+#define glShaderSource _ptrc_glShaderSource
+extern void(CODEGEN_FUNCPTR *_ptrc_glStencilFuncSeparate)(
+    GLenum face, GLenum func, GLint ref, GLuint mask);
+#define glStencilFuncSeparate _ptrc_glStencilFuncSeparate
+extern void(CODEGEN_FUNCPTR *_ptrc_glStencilMaskSeparate)(
+    GLenum face, GLuint mask);
+#define glStencilMaskSeparate _ptrc_glStencilMaskSeparate
+extern void(CODEGEN_FUNCPTR *_ptrc_glStencilOpSeparate)(
+    GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
+#define glStencilOpSeparate _ptrc_glStencilOpSeparate
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform1f)(GLint location, GLfloat v0);
+#define glUniform1f _ptrc_glUniform1f
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform1fv)(
+    GLint location, GLsizei count, const GLfloat *value);
+#define glUniform1fv _ptrc_glUniform1fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform1i)(GLint location, GLint v0);
+#define glUniform1i _ptrc_glUniform1i
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform1iv)(
+    GLint location, GLsizei count, const GLint *value);
+#define glUniform1iv _ptrc_glUniform1iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform2f)(
+    GLint location, GLfloat v0, GLfloat v1);
+#define glUniform2f _ptrc_glUniform2f
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform2fv)(
+    GLint location, GLsizei count, const GLfloat *value);
+#define glUniform2fv _ptrc_glUniform2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform2i)(
+    GLint location, GLint v0, GLint v1);
+#define glUniform2i _ptrc_glUniform2i
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform2iv)(
+    GLint location, GLsizei count, const GLint *value);
+#define glUniform2iv _ptrc_glUniform2iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform3f)(
+    GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
+#define glUniform3f _ptrc_glUniform3f
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform3fv)(
+    GLint location, GLsizei count, const GLfloat *value);
+#define glUniform3fv _ptrc_glUniform3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform3i)(
+    GLint location, GLint v0, GLint v1, GLint v2);
+#define glUniform3i _ptrc_glUniform3i
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform3iv)(
+    GLint location, GLsizei count, const GLint *value);
+#define glUniform3iv _ptrc_glUniform3iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform4f)(
+    GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3);
+#define glUniform4f _ptrc_glUniform4f
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform4fv)(
+    GLint location, GLsizei count, const GLfloat *value);
+#define glUniform4fv _ptrc_glUniform4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform4i)(
+    GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
+#define glUniform4i _ptrc_glUniform4i
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform4iv)(
+    GLint location, GLsizei count, const GLint *value);
+#define glUniform4iv _ptrc_glUniform4iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix2fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix2fv _ptrc_glUniformMatrix2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix3fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix3fv _ptrc_glUniformMatrix3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix4fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix4fv _ptrc_glUniformMatrix4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUseProgram)(GLuint program);
+#define glUseProgram _ptrc_glUseProgram
+extern void(CODEGEN_FUNCPTR *_ptrc_glValidateProgram)(GLuint program);
+#define glValidateProgram _ptrc_glValidateProgram
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib1d)(GLuint index, GLdouble x);
+#define glVertexAttrib1d _ptrc_glVertexAttrib1d
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib1dv)(
+    GLuint index, const GLdouble *v);
+#define glVertexAttrib1dv _ptrc_glVertexAttrib1dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib1f)(GLuint index, GLfloat x);
+#define glVertexAttrib1f _ptrc_glVertexAttrib1f
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib1fv)(
+    GLuint index, const GLfloat *v);
+#define glVertexAttrib1fv _ptrc_glVertexAttrib1fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib1s)(GLuint index, GLshort x);
+#define glVertexAttrib1s _ptrc_glVertexAttrib1s
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib1sv)(
+    GLuint index, const GLshort *v);
+#define glVertexAttrib1sv _ptrc_glVertexAttrib1sv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib2d)(
+    GLuint index, GLdouble x, GLdouble y);
+#define glVertexAttrib2d _ptrc_glVertexAttrib2d
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib2dv)(
+    GLuint index, const GLdouble *v);
+#define glVertexAttrib2dv _ptrc_glVertexAttrib2dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib2f)(
+    GLuint index, GLfloat x, GLfloat y);
+#define glVertexAttrib2f _ptrc_glVertexAttrib2f
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib2fv)(
+    GLuint index, const GLfloat *v);
+#define glVertexAttrib2fv _ptrc_glVertexAttrib2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib2s)(
+    GLuint index, GLshort x, GLshort y);
+#define glVertexAttrib2s _ptrc_glVertexAttrib2s
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib2sv)(
+    GLuint index, const GLshort *v);
+#define glVertexAttrib2sv _ptrc_glVertexAttrib2sv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib3d)(
+    GLuint index, GLdouble x, GLdouble y, GLdouble z);
+#define glVertexAttrib3d _ptrc_glVertexAttrib3d
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib3dv)(
+    GLuint index, const GLdouble *v);
+#define glVertexAttrib3dv _ptrc_glVertexAttrib3dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib3f)(
+    GLuint index, GLfloat x, GLfloat y, GLfloat z);
+#define glVertexAttrib3f _ptrc_glVertexAttrib3f
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib3fv)(
+    GLuint index, const GLfloat *v);
+#define glVertexAttrib3fv _ptrc_glVertexAttrib3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib3s)(
+    GLuint index, GLshort x, GLshort y, GLshort z);
+#define glVertexAttrib3s _ptrc_glVertexAttrib3s
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib3sv)(
+    GLuint index, const GLshort *v);
+#define glVertexAttrib3sv _ptrc_glVertexAttrib3sv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Nbv)(
+    GLuint index, const GLbyte *v);
+#define glVertexAttrib4Nbv _ptrc_glVertexAttrib4Nbv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Niv)(
+    GLuint index, const GLint *v);
+#define glVertexAttrib4Niv _ptrc_glVertexAttrib4Niv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Nsv)(
+    GLuint index, const GLshort *v);
+#define glVertexAttrib4Nsv _ptrc_glVertexAttrib4Nsv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Nub)(
+    GLuint index, GLubyte x, GLubyte y, GLubyte z, GLubyte w);
+#define glVertexAttrib4Nub _ptrc_glVertexAttrib4Nub
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Nubv)(
+    GLuint index, const GLubyte *v);
+#define glVertexAttrib4Nubv _ptrc_glVertexAttrib4Nubv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Nuiv)(
+    GLuint index, const GLuint *v);
+#define glVertexAttrib4Nuiv _ptrc_glVertexAttrib4Nuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4Nusv)(
+    GLuint index, const GLushort *v);
+#define glVertexAttrib4Nusv _ptrc_glVertexAttrib4Nusv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4bv)(
+    GLuint index, const GLbyte *v);
+#define glVertexAttrib4bv _ptrc_glVertexAttrib4bv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4d)(
+    GLuint index, GLdouble x, GLdouble y, GLdouble z, GLdouble w);
+#define glVertexAttrib4d _ptrc_glVertexAttrib4d
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4dv)(
+    GLuint index, const GLdouble *v);
+#define glVertexAttrib4dv _ptrc_glVertexAttrib4dv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4f)(
+    GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+#define glVertexAttrib4f _ptrc_glVertexAttrib4f
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4fv)(
+    GLuint index, const GLfloat *v);
+#define glVertexAttrib4fv _ptrc_glVertexAttrib4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4iv)(
+    GLuint index, const GLint *v);
+#define glVertexAttrib4iv _ptrc_glVertexAttrib4iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4s)(
+    GLuint index, GLshort x, GLshort y, GLshort z, GLshort w);
+#define glVertexAttrib4s _ptrc_glVertexAttrib4s
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4sv)(
+    GLuint index, const GLshort *v);
+#define glVertexAttrib4sv _ptrc_glVertexAttrib4sv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4ubv)(
+    GLuint index, const GLubyte *v);
+#define glVertexAttrib4ubv _ptrc_glVertexAttrib4ubv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4uiv)(
+    GLuint index, const GLuint *v);
+#define glVertexAttrib4uiv _ptrc_glVertexAttrib4uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttrib4usv)(
+    GLuint index, const GLushort *v);
+#define glVertexAttrib4usv _ptrc_glVertexAttrib4usv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribPointer)(
+    GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride,
+    const void *pointer);
+#define glVertexAttribPointer _ptrc_glVertexAttribPointer
+
+/* Extension: 2.1*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix2x3fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix2x3fv _ptrc_glUniformMatrix2x3fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix2x4fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix2x4fv _ptrc_glUniformMatrix2x4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix3x2fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix3x2fv _ptrc_glUniformMatrix3x2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix3x4fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix3x4fv _ptrc_glUniformMatrix3x4fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix4x2fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix4x2fv _ptrc_glUniformMatrix4x2fv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformMatrix4x3fv)(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+#define glUniformMatrix4x3fv _ptrc_glUniformMatrix4x3fv
+
+/* Extension: 3.0*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBeginConditionalRender)(
+    GLuint id, GLenum mode);
+#define glBeginConditionalRender _ptrc_glBeginConditionalRender
+extern void(CODEGEN_FUNCPTR *_ptrc_glBeginTransformFeedback)(
+    GLenum primitiveMode);
+#define glBeginTransformFeedback _ptrc_glBeginTransformFeedback
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindBufferBase)(
+    GLenum target, GLuint index, GLuint buffer);
+#define glBindBufferBase _ptrc_glBindBufferBase
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindBufferRange)(
+    GLenum target, GLuint index, GLuint buffer, GLintptr offset,
+    GLsizeiptr size);
+#define glBindBufferRange _ptrc_glBindBufferRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindFragDataLocation)(
+    GLuint program, GLuint color, const GLchar *name);
+#define glBindFragDataLocation _ptrc_glBindFragDataLocation
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindFramebuffer)(
+    GLenum target, GLuint framebuffer);
+#define glBindFramebuffer _ptrc_glBindFramebuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindRenderbuffer)(
+    GLenum target, GLuint renderbuffer);
+#define glBindRenderbuffer _ptrc_glBindRenderbuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindVertexArray)(GLuint ren_array);
+#define glBindVertexArray _ptrc_glBindVertexArray
+extern void(CODEGEN_FUNCPTR *_ptrc_glBlitFramebuffer)(
+    GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0,
+    GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+#define glBlitFramebuffer _ptrc_glBlitFramebuffer
+extern GLenum(CODEGEN_FUNCPTR *_ptrc_glCheckFramebufferStatus)(GLenum target);
+#define glCheckFramebufferStatus _ptrc_glCheckFramebufferStatus
+extern void(CODEGEN_FUNCPTR *_ptrc_glClampColor)(GLenum target, GLenum clamp);
+#define glClampColor _ptrc_glClampColor
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearBufferfi)(
+    GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
+#define glClearBufferfi _ptrc_glClearBufferfi
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearBufferfv)(
+    GLenum buffer, GLint drawbuffer, const GLfloat *value);
+#define glClearBufferfv _ptrc_glClearBufferfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearBufferiv)(
+    GLenum buffer, GLint drawbuffer, const GLint *value);
+#define glClearBufferiv _ptrc_glClearBufferiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glClearBufferuiv)(
+    GLenum buffer, GLint drawbuffer, const GLuint *value);
+#define glClearBufferuiv _ptrc_glClearBufferuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glColorMaski)(
+    GLuint index, GLboolean r, GLboolean g, GLboolean b, GLboolean a);
+#define glColorMaski _ptrc_glColorMaski
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteFramebuffers)(
+    GLsizei n, const GLuint *framebuffers);
+#define glDeleteFramebuffers _ptrc_glDeleteFramebuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteRenderbuffers)(
+    GLsizei n, const GLuint *renderbuffers);
+#define glDeleteRenderbuffers _ptrc_glDeleteRenderbuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteVertexArrays)(
+    GLsizei n, const GLuint *arrays);
+#define glDeleteVertexArrays _ptrc_glDeleteVertexArrays
+extern void(CODEGEN_FUNCPTR *_ptrc_glDisablei)(GLenum target, GLuint index);
+#define glDisablei _ptrc_glDisablei
+extern void(CODEGEN_FUNCPTR *_ptrc_glEnablei)(GLenum target, GLuint index);
+#define glEnablei _ptrc_glEnablei
+extern void(CODEGEN_FUNCPTR *_ptrc_glEndConditionalRender)(void);
+#define glEndConditionalRender _ptrc_glEndConditionalRender
+extern void(CODEGEN_FUNCPTR *_ptrc_glEndTransformFeedback)(void);
+#define glEndTransformFeedback _ptrc_glEndTransformFeedback
+extern void(CODEGEN_FUNCPTR *_ptrc_glFlushMappedBufferRange)(
+    GLenum target, GLintptr offset, GLsizeiptr length);
+#define glFlushMappedBufferRange _ptrc_glFlushMappedBufferRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferRenderbuffer)(
+    GLenum target, GLenum attachment, GLenum renderbuffertarget,
+    GLuint renderbuffer);
+#define glFramebufferRenderbuffer _ptrc_glFramebufferRenderbuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferTexture1D)(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level);
+#define glFramebufferTexture1D _ptrc_glFramebufferTexture1D
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferTexture2D)(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level);
+#define glFramebufferTexture2D _ptrc_glFramebufferTexture2D
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferTexture3D)(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level, GLint zoffset);
+#define glFramebufferTexture3D _ptrc_glFramebufferTexture3D
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferTextureLayer)(
+    GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
+#define glFramebufferTextureLayer _ptrc_glFramebufferTextureLayer
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenFramebuffers)(
+    GLsizei n, GLuint *framebuffers);
+#define glGenFramebuffers _ptrc_glGenFramebuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenRenderbuffers)(
+    GLsizei n, GLuint *renderbuffers);
+#define glGenRenderbuffers _ptrc_glGenRenderbuffers
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenVertexArrays)(
+    GLsizei n, GLuint *arrays);
+#define glGenVertexArrays _ptrc_glGenVertexArrays
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenerateMipmap)(GLenum target);
+#define glGenerateMipmap _ptrc_glGenerateMipmap
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetBooleani_v)(
+    GLenum target, GLuint index, GLboolean *data);
+#define glGetBooleani_v _ptrc_glGetBooleani_v
+extern GLint(CODEGEN_FUNCPTR *_ptrc_glGetFragDataLocation)(
+    GLuint program, const GLchar *name);
+#define glGetFragDataLocation _ptrc_glGetFragDataLocation
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetFramebufferAttachmentParameteriv)(
+    GLenum target, GLenum attachment, GLenum pname, GLint *params);
+#define glGetFramebufferAttachmentParameteriv                                  \
+    _ptrc_glGetFramebufferAttachmentParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetIntegeri_v)(
+    GLenum target, GLuint index, GLint *data);
+#define glGetIntegeri_v _ptrc_glGetIntegeri_v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetRenderbufferParameteriv)(
+    GLenum target, GLenum pname, GLint *params);
+#define glGetRenderbufferParameteriv _ptrc_glGetRenderbufferParameteriv
+extern const GLubyte *(CODEGEN_FUNCPTR *_ptrc_glGetStringi)(
+    GLenum name, GLuint index);
+#define glGetStringi _ptrc_glGetStringi
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexParameterIiv)(
+    GLenum target, GLenum pname, GLint *params);
+#define glGetTexParameterIiv _ptrc_glGetTexParameterIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTexParameterIuiv)(
+    GLenum target, GLenum pname, GLuint *params);
+#define glGetTexParameterIuiv _ptrc_glGetTexParameterIuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetTransformFeedbackVarying)(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length,
+    GLsizei *size, GLenum *type, GLchar *name);
+#define glGetTransformFeedbackVarying _ptrc_glGetTransformFeedbackVarying
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetUniformuiv)(
+    GLuint program, GLint location, GLuint *params);
+#define glGetUniformuiv _ptrc_glGetUniformuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexAttribIiv)(
+    GLuint index, GLenum pname, GLint *params);
+#define glGetVertexAttribIiv _ptrc_glGetVertexAttribIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetVertexAttribIuiv)(
+    GLuint index, GLenum pname, GLuint *params);
+#define glGetVertexAttribIuiv _ptrc_glGetVertexAttribIuiv
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsEnabledi)(
+    GLenum target, GLuint index);
+#define glIsEnabledi _ptrc_glIsEnabledi
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsFramebuffer)(GLuint framebuffer);
+#define glIsFramebuffer _ptrc_glIsFramebuffer
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsRenderbuffer)(GLuint renderbuffer);
+#define glIsRenderbuffer _ptrc_glIsRenderbuffer
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsVertexArray)(GLuint ren_array);
+#define glIsVertexArray _ptrc_glIsVertexArray
+extern void *(CODEGEN_FUNCPTR *_ptrc_glMapBufferRange)(
+    GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
+#define glMapBufferRange _ptrc_glMapBufferRange
+extern void(CODEGEN_FUNCPTR *_ptrc_glRenderbufferStorage)(
+    GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+#define glRenderbufferStorage _ptrc_glRenderbufferStorage
+extern void(CODEGEN_FUNCPTR *_ptrc_glRenderbufferStorageMultisample)(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height);
+#define glRenderbufferStorageMultisample _ptrc_glRenderbufferStorageMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexParameterIiv)(
+    GLenum target, GLenum pname, const GLint *params);
+#define glTexParameterIiv _ptrc_glTexParameterIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexParameterIuiv)(
+    GLenum target, GLenum pname, const GLuint *params);
+#define glTexParameterIuiv _ptrc_glTexParameterIuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glTransformFeedbackVaryings)(
+    GLuint program, GLsizei count, const GLchar *const *varyings,
+    GLenum bufferMode);
+#define glTransformFeedbackVaryings _ptrc_glTransformFeedbackVaryings
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform1ui)(GLint location, GLuint v0);
+#define glUniform1ui _ptrc_glUniform1ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform1uiv)(
+    GLint location, GLsizei count, const GLuint *value);
+#define glUniform1uiv _ptrc_glUniform1uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform2ui)(
+    GLint location, GLuint v0, GLuint v1);
+#define glUniform2ui _ptrc_glUniform2ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform2uiv)(
+    GLint location, GLsizei count, const GLuint *value);
+#define glUniform2uiv _ptrc_glUniform2uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform3ui)(
+    GLint location, GLuint v0, GLuint v1, GLuint v2);
+#define glUniform3ui _ptrc_glUniform3ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform3uiv)(
+    GLint location, GLsizei count, const GLuint *value);
+#define glUniform3uiv _ptrc_glUniform3uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform4ui)(
+    GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
+#define glUniform4ui _ptrc_glUniform4ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniform4uiv)(
+    GLint location, GLsizei count, const GLuint *value);
+#define glUniform4uiv _ptrc_glUniform4uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI1i)(GLuint index, GLint x);
+#define glVertexAttribI1i _ptrc_glVertexAttribI1i
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI1iv)(
+    GLuint index, const GLint *v);
+#define glVertexAttribI1iv _ptrc_glVertexAttribI1iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI1ui)(GLuint index, GLuint x);
+#define glVertexAttribI1ui _ptrc_glVertexAttribI1ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI1uiv)(
+    GLuint index, const GLuint *v);
+#define glVertexAttribI1uiv _ptrc_glVertexAttribI1uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI2i)(
+    GLuint index, GLint x, GLint y);
+#define glVertexAttribI2i _ptrc_glVertexAttribI2i
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI2iv)(
+    GLuint index, const GLint *v);
+#define glVertexAttribI2iv _ptrc_glVertexAttribI2iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI2ui)(
+    GLuint index, GLuint x, GLuint y);
+#define glVertexAttribI2ui _ptrc_glVertexAttribI2ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI2uiv)(
+    GLuint index, const GLuint *v);
+#define glVertexAttribI2uiv _ptrc_glVertexAttribI2uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI3i)(
+    GLuint index, GLint x, GLint y, GLint z);
+#define glVertexAttribI3i _ptrc_glVertexAttribI3i
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI3iv)(
+    GLuint index, const GLint *v);
+#define glVertexAttribI3iv _ptrc_glVertexAttribI3iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI3ui)(
+    GLuint index, GLuint x, GLuint y, GLuint z);
+#define glVertexAttribI3ui _ptrc_glVertexAttribI3ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI3uiv)(
+    GLuint index, const GLuint *v);
+#define glVertexAttribI3uiv _ptrc_glVertexAttribI3uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4bv)(
+    GLuint index, const GLbyte *v);
+#define glVertexAttribI4bv _ptrc_glVertexAttribI4bv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4i)(
+    GLuint index, GLint x, GLint y, GLint z, GLint w);
+#define glVertexAttribI4i _ptrc_glVertexAttribI4i
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4iv)(
+    GLuint index, const GLint *v);
+#define glVertexAttribI4iv _ptrc_glVertexAttribI4iv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4sv)(
+    GLuint index, const GLshort *v);
+#define glVertexAttribI4sv _ptrc_glVertexAttribI4sv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4ubv)(
+    GLuint index, const GLubyte *v);
+#define glVertexAttribI4ubv _ptrc_glVertexAttribI4ubv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4ui)(
+    GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
+#define glVertexAttribI4ui _ptrc_glVertexAttribI4ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4uiv)(
+    GLuint index, const GLuint *v);
+#define glVertexAttribI4uiv _ptrc_glVertexAttribI4uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribI4usv)(
+    GLuint index, const GLushort *v);
+#define glVertexAttribI4usv _ptrc_glVertexAttribI4usv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribIPointer)(
+    GLuint index, GLint size, GLenum type, GLsizei stride, const void *pointer);
+#define glVertexAttribIPointer _ptrc_glVertexAttribIPointer
+
+/* Extension: 3.1*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glCopyBufferSubData)(
+    GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
+    GLintptr writeOffset, GLsizeiptr size);
+#define glCopyBufferSubData _ptrc_glCopyBufferSubData
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawArraysInstanced)(
+    GLenum mode, GLint first, GLsizei count, GLsizei instancecount);
+#define glDrawArraysInstanced _ptrc_glDrawArraysInstanced
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawElementsInstanced)(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLsizei instancecount);
+#define glDrawElementsInstanced _ptrc_glDrawElementsInstanced
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetActiveUniformBlockName)(
+    GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length,
+    GLchar *uniformBlockName);
+#define glGetActiveUniformBlockName _ptrc_glGetActiveUniformBlockName
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetActiveUniformBlockiv)(
+    GLuint program, GLuint uniformBlockIndex, GLenum pname, GLint *params);
+#define glGetActiveUniformBlockiv _ptrc_glGetActiveUniformBlockiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetActiveUniformName)(
+    GLuint program, GLuint uniformIndex, GLsizei bufSize, GLsizei *length,
+    GLchar *uniformName);
+#define glGetActiveUniformName _ptrc_glGetActiveUniformName
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetActiveUniformsiv)(
+    GLuint program, GLsizei uniformCount, const GLuint *uniformIndices,
+    GLenum pname, GLint *params);
+#define glGetActiveUniformsiv _ptrc_glGetActiveUniformsiv
+extern GLuint(CODEGEN_FUNCPTR *_ptrc_glGetUniformBlockIndex)(
+    GLuint program, const GLchar *uniformBlockName);
+#define glGetUniformBlockIndex _ptrc_glGetUniformBlockIndex
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetUniformIndices)(
+    GLuint program, GLsizei uniformCount, const GLchar *const *uniformNames,
+    GLuint *uniformIndices);
+#define glGetUniformIndices _ptrc_glGetUniformIndices
+extern void(CODEGEN_FUNCPTR *_ptrc_glPrimitiveRestartIndex)(GLuint index);
+#define glPrimitiveRestartIndex _ptrc_glPrimitiveRestartIndex
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexBuffer)(
+    GLenum target, GLenum internalformat, GLuint buffer);
+#define glTexBuffer _ptrc_glTexBuffer
+extern void(CODEGEN_FUNCPTR *_ptrc_glUniformBlockBinding)(
+    GLuint program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
+#define glUniformBlockBinding _ptrc_glUniformBlockBinding
+
+/* Extension: 3.2*/
+extern GLenum(CODEGEN_FUNCPTR *_ptrc_glClientWaitSync)(
+    GLsync sync, GLbitfield flags, GLuint64 timeout);
+#define glClientWaitSync _ptrc_glClientWaitSync
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteSync)(GLsync sync);
+#define glDeleteSync _ptrc_glDeleteSync
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawElementsBaseVertex)(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLint basevertex);
+#define glDrawElementsBaseVertex _ptrc_glDrawElementsBaseVertex
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawElementsInstancedBaseVertex)(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLsizei instancecount, GLint basevertex);
+#define glDrawElementsInstancedBaseVertex                                      \
+    _ptrc_glDrawElementsInstancedBaseVertex
+extern void(CODEGEN_FUNCPTR *_ptrc_glDrawRangeElementsBaseVertex)(
+    GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type,
+    const void *indices, GLint basevertex);
+#define glDrawRangeElementsBaseVertex _ptrc_glDrawRangeElementsBaseVertex
+extern GLsync(CODEGEN_FUNCPTR *_ptrc_glFenceSync)(
+    GLenum condition, GLbitfield flags);
+#define glFenceSync _ptrc_glFenceSync
+extern void(CODEGEN_FUNCPTR *_ptrc_glFramebufferTexture)(
+    GLenum target, GLenum attachment, GLuint texture, GLint level);
+#define glFramebufferTexture _ptrc_glFramebufferTexture
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetBufferParameteri64v)(
+    GLenum target, GLenum pname, GLint64 *params);
+#define glGetBufferParameteri64v _ptrc_glGetBufferParameteri64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetInteger64i_v)(
+    GLenum target, GLuint index, GLint64 *data);
+#define glGetInteger64i_v _ptrc_glGetInteger64i_v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetInteger64v)(
+    GLenum pname, GLint64 *data);
+#define glGetInteger64v _ptrc_glGetInteger64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetMultisamplefv)(
+    GLenum pname, GLuint index, GLfloat *val);
+#define glGetMultisamplefv _ptrc_glGetMultisamplefv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetSynciv)(
+    GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values);
+#define glGetSynciv _ptrc_glGetSynciv
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsSync)(GLsync sync);
+#define glIsSync _ptrc_glIsSync
+extern void(CODEGEN_FUNCPTR *_ptrc_glMultiDrawElementsBaseVertex)(
+    GLenum mode, const GLsizei *count, GLenum type, const void *const *indices,
+    GLsizei drawcount, const GLint *basevertex);
+#define glMultiDrawElementsBaseVertex _ptrc_glMultiDrawElementsBaseVertex
+extern void(CODEGEN_FUNCPTR *_ptrc_glProvokingVertex)(GLenum mode);
+#define glProvokingVertex _ptrc_glProvokingVertex
+extern void(CODEGEN_FUNCPTR *_ptrc_glSampleMaski)(
+    GLuint maskNumber, GLbitfield mask);
+#define glSampleMaski _ptrc_glSampleMaski
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexImage2DMultisample)(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations);
+#define glTexImage2DMultisample _ptrc_glTexImage2DMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glTexImage3DMultisample)(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
+#define glTexImage3DMultisample _ptrc_glTexImage3DMultisample
+extern void(CODEGEN_FUNCPTR *_ptrc_glWaitSync)(
+    GLsync sync, GLbitfield flags, GLuint64 timeout);
+#define glWaitSync _ptrc_glWaitSync
+
+/* Extension: 3.3*/
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindFragDataLocationIndexed)(
+    GLuint program, GLuint colorNumber, GLuint index, const GLchar *name);
+#define glBindFragDataLocationIndexed _ptrc_glBindFragDataLocationIndexed
+extern void(CODEGEN_FUNCPTR *_ptrc_glBindSampler)(GLuint unit, GLuint sampler);
+#define glBindSampler _ptrc_glBindSampler
+extern void(CODEGEN_FUNCPTR *_ptrc_glDeleteSamplers)(
+    GLsizei count, const GLuint *samplers);
+#define glDeleteSamplers _ptrc_glDeleteSamplers
+extern void(CODEGEN_FUNCPTR *_ptrc_glGenSamplers)(
+    GLsizei count, GLuint *samplers);
+#define glGenSamplers _ptrc_glGenSamplers
+extern GLint(CODEGEN_FUNCPTR *_ptrc_glGetFragDataIndex)(
+    GLuint program, const GLchar *name);
+#define glGetFragDataIndex _ptrc_glGetFragDataIndex
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryObjecti64v)(
+    GLuint id, GLenum pname, GLint64 *params);
+#define glGetQueryObjecti64v _ptrc_glGetQueryObjecti64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetQueryObjectui64v)(
+    GLuint id, GLenum pname, GLuint64 *params);
+#define glGetQueryObjectui64v _ptrc_glGetQueryObjectui64v
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetSamplerParameterIiv)(
+    GLuint sampler, GLenum pname, GLint *params);
+#define glGetSamplerParameterIiv _ptrc_glGetSamplerParameterIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetSamplerParameterIuiv)(
+    GLuint sampler, GLenum pname, GLuint *params);
+#define glGetSamplerParameterIuiv _ptrc_glGetSamplerParameterIuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetSamplerParameterfv)(
+    GLuint sampler, GLenum pname, GLfloat *params);
+#define glGetSamplerParameterfv _ptrc_glGetSamplerParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glGetSamplerParameteriv)(
+    GLuint sampler, GLenum pname, GLint *params);
+#define glGetSamplerParameteriv _ptrc_glGetSamplerParameteriv
+extern GLboolean(CODEGEN_FUNCPTR *_ptrc_glIsSampler)(GLuint sampler);
+#define glIsSampler _ptrc_glIsSampler
+extern void(CODEGEN_FUNCPTR *_ptrc_glQueryCounter)(GLuint id, GLenum target);
+#define glQueryCounter _ptrc_glQueryCounter
+extern void(CODEGEN_FUNCPTR *_ptrc_glSamplerParameterIiv)(
+    GLuint sampler, GLenum pname, const GLint *param);
+#define glSamplerParameterIiv _ptrc_glSamplerParameterIiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glSamplerParameterIuiv)(
+    GLuint sampler, GLenum pname, const GLuint *param);
+#define glSamplerParameterIuiv _ptrc_glSamplerParameterIuiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glSamplerParameterf)(
+    GLuint sampler, GLenum pname, GLfloat param);
+#define glSamplerParameterf _ptrc_glSamplerParameterf
+extern void(CODEGEN_FUNCPTR *_ptrc_glSamplerParameterfv)(
+    GLuint sampler, GLenum pname, const GLfloat *param);
+#define glSamplerParameterfv _ptrc_glSamplerParameterfv
+extern void(CODEGEN_FUNCPTR *_ptrc_glSamplerParameteri)(
+    GLuint sampler, GLenum pname, GLint param);
+#define glSamplerParameteri _ptrc_glSamplerParameteri
+extern void(CODEGEN_FUNCPTR *_ptrc_glSamplerParameteriv)(
+    GLuint sampler, GLenum pname, const GLint *param);
+#define glSamplerParameteriv _ptrc_glSamplerParameteriv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribDivisor)(
+    GLuint index, GLuint divisor);
+#define glVertexAttribDivisor _ptrc_glVertexAttribDivisor
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP1ui)(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+#define glVertexAttribP1ui _ptrc_glVertexAttribP1ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP1uiv)(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+#define glVertexAttribP1uiv _ptrc_glVertexAttribP1uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP2ui)(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+#define glVertexAttribP2ui _ptrc_glVertexAttribP2ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP2uiv)(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+#define glVertexAttribP2uiv _ptrc_glVertexAttribP2uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP3ui)(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+#define glVertexAttribP3ui _ptrc_glVertexAttribP3ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP3uiv)(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+#define glVertexAttribP3uiv _ptrc_glVertexAttribP3uiv
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP4ui)(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+#define glVertexAttribP4ui _ptrc_glVertexAttribP4ui
+extern void(CODEGEN_FUNCPTR *_ptrc_glVertexAttribP4uiv)(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+#define glVertexAttribP4uiv _ptrc_glVertexAttribP4uiv
+
+void ogl_CheckExtensions(void);
+
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
+
+#endif /*OPENGL_NOLOAD_STYLE_H*/

--- a/include/libtrx/gfx/gl/program.h
+++ b/include/libtrx/gfx/gl/program.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../common.h"
+#include "../gl/gl_core_3_3.h"
+
+#include <stdbool.h>
+
+typedef struct GFX_GL_Program {
+    GLuint id;
+} GFX_GL_Program;
+
+bool GFX_GL_Program_Init(GFX_GL_Program *program);
+void GFX_GL_Program_Close(GFX_GL_Program *program);
+
+void GFX_GL_Program_Bind(GFX_GL_Program *program);
+char *GFX_GL_Program_PreprocessShader(
+    const char *content, GLenum type, GFX_GL_BACKEND backend);
+void GFX_GL_Program_AttachShader(
+    GFX_GL_Program *program, GLenum type, const char *path);
+void GFX_GL_Program_Link(GFX_GL_Program *program);
+void GFX_GL_Program_FragmentData(GFX_GL_Program *program, const char *name);
+GLint GFX_GL_Program_UniformLocation(GFX_GL_Program *program, const char *name);
+
+void GFX_GL_Program_Uniform3f(
+    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2);
+void GFX_GL_Program_Uniform4f(
+    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
+    GLfloat v3);
+void GFX_GL_Program_Uniform1i(GFX_GL_Program *program, GLint loc, GLint v0);
+void GFX_GL_Program_UniformMatrix4fv(
+    GFX_GL_Program *program, GLint loc, GLsizei count, GLboolean transpose,
+    const GLfloat *value);

--- a/include/libtrx/gfx/gl/sampler.h
+++ b/include/libtrx/gfx/gl/sampler.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../gl/gl_core_3_3.h"
+
+typedef struct GFX_GL_Sampler {
+    GLuint id;
+} GFX_GL_Sampler;
+
+void GFX_GL_Sampler_Init(GFX_GL_Sampler *sampler);
+void GFX_GL_Sampler_Close(GFX_GL_Sampler *sampler);
+
+void GFX_GL_Sampler_Bind(GFX_GL_Sampler *sampler, GLuint unit);
+void GFX_GL_Sampler_Parameteri(
+    GFX_GL_Sampler *sampler, GLenum pname, GLint param);
+void GFX_GL_Sampler_Parameterf(
+    GFX_GL_Sampler *sampler, GLenum pname, GLfloat param);

--- a/include/libtrx/gfx/gl/texture.h
+++ b/include/libtrx/gfx/gl/texture.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../gl/gl_core_3_3.h"
+
+typedef struct GFX_GL_Texture {
+    GLuint id;
+    GLenum target;
+} GFX_GL_Texture;
+
+GFX_GL_Texture *GFX_GL_Texture_Create(GLenum target);
+void GFX_GL_Texture_Free(GFX_GL_Texture *texture);
+
+void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target);
+void GFX_GL_Texture_Close(GFX_GL_Texture *texture);
+void GFX_GL_Texture_Bind(GFX_GL_Texture *texture);
+void GFX_GL_Texture_Load(
+    GFX_GL_Texture *texture, const void *data, int width, int height,
+    GLint internal_format, GLint format);
+void GFX_GL_Texture_LoadFromBackBuffer(GFX_GL_Texture *texture);

--- a/include/libtrx/gfx/gl/utils.h
+++ b/include/libtrx/gfx/gl/utils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../gl/gl_core_3_3.h"
+
+#include "../../log.h"
+
+#define GFX_GL_CheckError()                                                    \
+    {                                                                          \
+        for (GLenum err; (err = glGetError()) != GL_NO_ERROR;) {               \
+            LOG_ERROR("glGetError: (%s)", GFX_GL_GetErrorString(err));         \
+        }                                                                      \
+    }
+
+const char *GFX_GL_GetErrorString(GLenum err);

--- a/include/libtrx/gfx/gl/vertex_array.h
+++ b/include/libtrx/gfx/gl/vertex_array.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../gl/gl_core_3_3.h"
+
+typedef struct GFX_GL_VertexArray {
+    GLuint id;
+} GFX_GL_VertexArray;
+
+void GFX_GL_VertexArray_Init(GFX_GL_VertexArray *array);
+void GFX_GL_VertexArray_Close(GFX_GL_VertexArray *array);
+void GFX_GL_VertexArray_Bind(GFX_GL_VertexArray *array);
+void GFX_GL_VertexArray_Attribute(
+    GFX_GL_VertexArray *array, GLuint index, GLint size, GLenum type,
+    GLboolean normalized, GLsizei stride, GLsizei offset);

--- a/include/libtrx/gfx/renderer.h
+++ b/include/libtrx/gfx/renderer.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "config.h"
+
+typedef struct GFX_Renderer {
+    void (*init)(struct GFX_Renderer *renderer, const GFX_CONFIG *config);
+    void (*shutdown)(struct GFX_Renderer *renderer);
+    void (*reset)(struct GFX_Renderer *renderer);
+    void (*swap_buffers)(struct GFX_Renderer *renderer);
+    void *priv;
+} GFX_Renderer;

--- a/include/libtrx/gfx/renderers/fbo_renderer.h
+++ b/include/libtrx/gfx/renderers/fbo_renderer.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "../renderer.h"
+
+extern GFX_Renderer g_GFX_Renderer_FBO;

--- a/include/libtrx/gfx/renderers/legacy_renderer.h
+++ b/include/libtrx/gfx/renderers/legacy_renderer.h
@@ -1,0 +1,3 @@
+#include "../renderer.h"
+
+extern GFX_Renderer g_GFX_Renderer_Legacy;

--- a/include/libtrx/gfx/screenshot.h
+++ b/include/libtrx/gfx/screenshot.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "gl/gl_core_3_3.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool GFX_Screenshot_CaptureToFile(const char *path);
+
+void GFX_Screenshot_CaptureToBuffer(
+    uint8_t *out_buffer, GLint *out_width, GLint *out_height, GLint depth,
+    GLenum format, GLenum type, bool vflip);

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project(
 fs = import('fs')
 staticdeps = get_option('staticdeps')
 tr_version = get_option('tr_version')
+gfx_gl_default_backend = get_option('gfx_gl_default_backend')
 
 c_compiler = meson.get_compiler('c')
 relative_dir = fs.relative_to(meson.current_source_dir(), meson.global_build_root())
@@ -21,8 +22,10 @@ build_opts = [
   '-DPCRE2_STATIC',
   '-DPCRE2_CODE_UNIT_WIDTH=8',
   '-DTR_VERSION=' + tr_version.to_string(),
+  '-DGFX_GL_DEFAULT_BACKEND=' + gfx_gl_default_backend,
 ]
 set_variable('defines', ['-DTR_VERSION=' + tr_version.to_string()])
+
 add_project_arguments(build_opts, language: 'c')
 
 # Always dynamically link on macOS
@@ -54,8 +57,23 @@ sources = [
   'src/engine/audio_stream.c',
   'src/engine/image.c',
   'src/enum_str.c',
-  'src/game/items.c',
   'src/filesystem.c',
+  'src/game/items.c',
+  'src/gfx/2d/2d_renderer.c',
+  'src/gfx/2d/2d_surface.c',
+  'src/gfx/3d/3d_renderer.c',
+  'src/gfx/3d/vertex_stream.c',
+  'src/gfx/context.c',
+  'src/gfx/gl/buffer.c',
+  'src/gfx/gl/gl_core_3_3.c',
+  'src/gfx/gl/program.c',
+  'src/gfx/gl/sampler.c',
+  'src/gfx/gl/texture.c',
+  'src/gfx/gl/utils.c',
+  'src/gfx/gl/vertex_array.c',
+  'src/gfx/renderers/fbo_renderer.c',
+  'src/gfx/renderers/legacy_renderer.c',
+  'src/gfx/screenshot.c',
   'src/json/bson_parse.c',
   'src/json/bson_write.c',
   'src/json/json_base.c',

--- a/meson.options
+++ b/meson.options
@@ -12,3 +12,9 @@ option(
   max: 2,
   description: 'Which engine version to compile for'
 )
+
+option(
+  'gfx_gl_default_backend',
+  type: 'string',
+  description: 'Which OpenGL version to target'
+)

--- a/src/gfx/2d/2d_renderer.c
+++ b/src/gfx/2d/2d_renderer.c
@@ -1,0 +1,118 @@
+#include "gfx/2d/2d_renderer.h"
+
+#include "gfx/gl/gl_core_3_3.h"
+#include "gfx/gl/utils.h"
+#include "log.h"
+
+#include <assert.h>
+
+void GFX_2D_Renderer_Init(GFX_2D_Renderer *renderer)
+{
+    LOG_INFO("");
+    assert(renderer);
+
+    GFX_GL_Buffer_Init(&renderer->surface_buffer, GL_ARRAY_BUFFER);
+    GFX_GL_Buffer_Bind(&renderer->surface_buffer);
+    GLfloat verts[] = { 0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+                        0.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+    GFX_GL_Buffer_Data(
+        &renderer->surface_buffer, sizeof(verts), verts, GL_STATIC_DRAW);
+
+    GFX_GL_VertexArray_Init(&renderer->surface_format);
+    GFX_GL_VertexArray_Bind(&renderer->surface_format);
+    GFX_GL_VertexArray_Attribute(
+        &renderer->surface_format, 0, 2, GL_FLOAT, GL_FALSE, 0, 0);
+
+    GFX_GL_Texture_Init(&renderer->surface_texture, GL_TEXTURE_2D);
+
+    GFX_GL_Sampler_Init(&renderer->sampler);
+    GFX_GL_Sampler_Bind(&renderer->sampler, 0);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+
+    GFX_GL_Program_Init(&renderer->program);
+    GFX_GL_Program_AttachShader(
+        &renderer->program, GL_VERTEX_SHADER, "shaders/2d.glsl");
+    GFX_GL_Program_AttachShader(
+        &renderer->program, GL_FRAGMENT_SHADER, "shaders/2d.glsl");
+    GFX_GL_Program_Link(&renderer->program);
+    GFX_GL_Program_FragmentData(&renderer->program, "fragColor");
+
+    GFX_GL_CheckError();
+}
+
+void GFX_2D_Renderer_Close(GFX_2D_Renderer *renderer)
+{
+    LOG_INFO("");
+    assert(renderer);
+
+    GFX_GL_VertexArray_Close(&renderer->surface_format);
+    GFX_GL_Buffer_Close(&renderer->surface_buffer);
+    GFX_GL_Texture_Close(&renderer->surface_texture);
+    GFX_GL_Sampler_Close(&renderer->sampler);
+    GFX_GL_Program_Close(&renderer->program);
+}
+
+void GFX_2D_Renderer_Upload(
+    GFX_2D_Renderer *renderer, GFX_2D_SurfaceDesc *desc, const uint8_t *data)
+{
+    const uint32_t width = desc->width;
+    const uint32_t height = desc->height;
+
+    GFX_GL_Texture_Bind(&renderer->surface_texture);
+
+    // TODO: implement texture packs
+
+    // update buffer if the size is unchanged, otherwise create a new one
+    if (width != renderer->width || height != renderer->height) {
+        renderer->width = width;
+        renderer->height = height;
+        glTexImage2D(
+            GL_TEXTURE_2D, 0, GL_RGBA, renderer->width, renderer->height, 0,
+            desc->tex_format, desc->tex_type, data);
+        GFX_GL_CheckError();
+    } else {
+        glTexSubImage2D(
+            GL_TEXTURE_2D, 0, 0, 0, renderer->width, renderer->height,
+            desc->tex_format, desc->tex_type, data);
+        GFX_GL_CheckError();
+    }
+}
+
+void GFX_2D_Renderer_Render(GFX_2D_Renderer *renderer)
+{
+    GFX_GL_Program_Bind(&renderer->program);
+    GFX_GL_Buffer_Bind(&renderer->surface_buffer);
+    GFX_GL_VertexArray_Bind(&renderer->surface_format);
+    GFX_GL_Texture_Bind(&renderer->surface_texture);
+    GFX_GL_Sampler_Bind(&renderer->sampler, 0);
+
+    GLboolean blend = glIsEnabled(GL_BLEND);
+    if (blend) {
+        glDisable(GL_BLEND);
+    }
+
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    GLboolean depth_test = glIsEnabled(GL_DEPTH_TEST);
+    if (depth_test) {
+        glDisable(GL_DEPTH_TEST);
+    }
+
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    GFX_GL_CheckError();
+
+    if (blend) {
+        glEnable(GL_BLEND);
+    }
+
+    if (depth_test) {
+        glEnable(GL_DEPTH_TEST);
+    }
+}

--- a/src/gfx/2d/2d_surface.c
+++ b/src/gfx/2d/2d_surface.c
@@ -1,0 +1,129 @@
+#include "gfx/2d/2d_surface.h"
+
+#include "gfx/context.h"
+#include "log.h"
+#include "memory.h"
+
+#include <assert.h>
+#include <string.h>
+
+GFX_2D_Surface *GFX_2D_Surface_Create(const GFX_2D_SurfaceDesc *desc)
+{
+    GFX_2D_Surface *surface = Memory_Alloc(sizeof(GFX_2D_Surface));
+    GFX_2D_Surface_Init(surface, desc);
+    return surface;
+}
+
+GFX_2D_Surface *GFX_2D_Surface_CreateFromImage(const IMAGE *image)
+{
+    GFX_2D_Surface *surface = Memory_Alloc(sizeof(GFX_2D_Surface));
+    surface->is_locked = false;
+    surface->is_dirty = true;
+    surface->desc.width = image->width;
+    surface->desc.height = image->height;
+    surface->desc.bit_count = 24;
+    surface->desc.tex_format = GL_RGB;
+    surface->desc.tex_type = GL_UNSIGNED_BYTE;
+    surface->desc.pitch = surface->desc.width * (surface->desc.bit_count / 8);
+    surface->desc.pixels = NULL;
+    surface->buffer = Memory_Alloc(surface->desc.pitch * surface->desc.height);
+    memcpy(
+        surface->buffer, image->data,
+        surface->desc.pitch * surface->desc.height);
+    return surface;
+}
+
+void GFX_2D_Surface_Free(GFX_2D_Surface *surface)
+{
+    if (surface) {
+        GFX_2D_Surface_Close(surface);
+        Memory_FreePointer(&surface);
+    }
+}
+
+void GFX_2D_Surface_Init(
+    GFX_2D_Surface *surface, const GFX_2D_SurfaceDesc *desc)
+{
+    surface->is_locked = false;
+    surface->is_dirty = false;
+    surface->desc = *desc;
+
+    GFX_2D_SurfaceDesc display_desc = {
+        .bit_count = 32,
+        .width = GFX_Context_GetDisplayWidth(),
+        .height = GFX_Context_GetDisplayHeight(),
+    };
+
+    if (!surface->desc.width || !surface->desc.height) {
+        surface->desc.width = display_desc.width;
+        surface->desc.height = display_desc.height;
+    }
+
+    if (!surface->desc.bit_count) {
+        surface->desc.bit_count = display_desc.bit_count;
+    }
+
+    if (!surface->desc.tex_format) {
+        surface->desc.tex_format = GL_BGRA;
+    }
+    if (!surface->desc.tex_type) {
+        surface->desc.tex_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+    }
+
+    surface->desc.pitch = surface->desc.width * (surface->desc.bit_count / 8);
+
+    surface->buffer = Memory_Alloc(surface->desc.pitch * surface->desc.height);
+    surface->desc.pixels = NULL;
+}
+
+void GFX_2D_Surface_Close(GFX_2D_Surface *surface)
+{
+    Memory_FreePointer(&surface->buffer);
+}
+
+bool GFX_2D_Surface_Clear(GFX_2D_Surface *surface)
+{
+    if (surface->is_locked) {
+        LOG_ERROR("Surface is locked");
+        return false;
+    }
+
+    surface->is_dirty = true;
+    memset(surface->buffer, 0, surface->desc.pitch * surface->desc.height);
+    return true;
+}
+
+bool GFX_2D_Surface_Lock(GFX_2D_Surface *surface, GFX_2D_SurfaceDesc *out_desc)
+{
+    assert(surface != NULL);
+    if (surface->is_locked) {
+        LOG_ERROR("Surface is busy");
+        return false;
+    }
+
+    // assign pixels
+    surface->desc.pixels = surface->buffer;
+
+    surface->is_locked = true;
+    surface->is_dirty = true;
+
+    *out_desc = surface->desc;
+
+    return true;
+}
+
+bool GFX_2D_Surface_Unlock(GFX_2D_Surface *surface)
+{
+    // ensure that the surface is actually locked
+    if (!surface->is_locked) {
+        LOG_ERROR("Surface is not locked");
+        return false;
+    }
+
+    // unassign pixels
+    surface->desc.pixels = NULL;
+
+    surface->is_locked = false;
+
+    return true;
+}

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -1,0 +1,361 @@
+#include "gfx/3d/3d_renderer.h"
+
+#include "gfx/context.h"
+#include "gfx/gl/utils.h"
+#include "log.h"
+
+#include <assert.h>
+#include <stddef.h>
+
+static void GFX_3D_Renderer_SelectTextureImpl(
+    GFX_3D_Renderer *renderer, int texture_num);
+
+static void GFX_3D_Renderer_SelectTextureImpl(
+    GFX_3D_Renderer *renderer, int texture_num)
+{
+    assert(renderer);
+
+    GFX_GL_Texture *texture = NULL;
+    if (texture_num == GFX_ENV_MAP_TEXTURE) {
+        texture = renderer->env_map_texture;
+    } else if (texture_num != GFX_NO_TEXTURE) {
+        assert(texture_num >= 0);
+        assert(texture_num < GFX_MAX_TEXTURES);
+        texture = renderer->textures[texture_num];
+    }
+
+    if (texture == NULL) {
+        glBindTexture(GL_TEXTURE_2D, 0);
+        GFX_GL_CheckError();
+        return;
+    }
+
+    GFX_GL_Texture_Bind(texture);
+}
+
+void GFX_3D_Renderer_Init(
+    GFX_3D_Renderer *renderer, const GFX_CONFIG *const config)
+{
+    LOG_INFO("");
+    assert(renderer);
+
+    renderer->config = config;
+
+    renderer->selected_texture_num = GFX_NO_TEXTURE;
+    for (int i = 0; i < GFX_MAX_TEXTURES; i++) {
+        renderer->textures[i] = NULL;
+    }
+
+    GFX_GL_Sampler_Init(&renderer->sampler);
+    GFX_GL_Sampler_Bind(&renderer->sampler, 0);
+    GFX_GL_Sampler_Parameterf(
+        &renderer->sampler, GL_TEXTURE_MAX_ANISOTROPY_EXT, 0);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    GFX_GL_Program_Init(&renderer->program);
+    GFX_GL_Program_AttachShader(
+        &renderer->program, GL_VERTEX_SHADER, "shaders/3d.glsl");
+    GFX_GL_Program_AttachShader(
+        &renderer->program, GL_FRAGMENT_SHADER, "shaders/3d.glsl");
+    GFX_GL_Program_Link(&renderer->program);
+
+    renderer->loc_mat_projection =
+        GFX_GL_Program_UniformLocation(&renderer->program, "matProjection");
+    renderer->loc_mat_model_view =
+        GFX_GL_Program_UniformLocation(&renderer->program, "matModelView");
+    renderer->loc_texturing_enabled =
+        GFX_GL_Program_UniformLocation(&renderer->program, "texturingEnabled");
+    renderer->loc_smoothing_enabled =
+        GFX_GL_Program_UniformLocation(&renderer->program, "smoothingEnabled");
+
+    GFX_GL_Program_FragmentData(&renderer->program, "fragColor");
+    GFX_GL_Program_Bind(&renderer->program);
+
+    // negate Z axis so the model is rendered behind the viewport, which is
+    // better than having a negative z_near in the ortho matrix, which seems
+    // to mess up depth testing
+    GLfloat model_view[4][4] = {
+        { +1.0f, +0.0f, +0.0f, +0.0f },
+        { +0.0f, +1.0f, +0.0f, +0.0f },
+        { +0.0f, +0.0f, -1.0f, +0.0f },
+        { +0.0f, +0.0f, +0.0f, +1.0f },
+    };
+    GFX_GL_Program_UniformMatrix4fv(
+        &renderer->program, renderer->loc_mat_model_view, 1, GL_FALSE,
+        &model_view[0][0]);
+
+    GFX_3D_VertexStream_Init(&renderer->vertex_stream);
+
+    GFX_GL_CheckError();
+}
+
+void GFX_3D_Renderer_Close(GFX_3D_Renderer *renderer)
+{
+    LOG_INFO("");
+    assert(renderer);
+
+    GFX_3D_VertexStream_Close(&renderer->vertex_stream);
+    GFX_GL_Program_Close(&renderer->program);
+    GFX_GL_Sampler_Close(&renderer->sampler);
+}
+
+void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer)
+{
+    assert(renderer);
+    glEnable(GL_BLEND);
+
+    glLineWidth(renderer->config->line_width);
+    glPolygonMode(
+        GL_FRONT_AND_BACK,
+        renderer->config->enable_wireframe ? GL_LINE : GL_FILL);
+    GFX_GL_CheckError();
+
+    GFX_GL_Program_Bind(&renderer->program);
+    GFX_3D_VertexStream_Bind(&renderer->vertex_stream);
+    GFX_GL_Sampler_Bind(&renderer->sampler, 0);
+
+    GFX_3D_Renderer_RestoreTexture(renderer);
+
+    const float left = 0.0f;
+    const float top = 0.0f;
+    const float right = GFX_Context_GetDisplayWidth();
+    const float bottom = GFX_Context_GetDisplayHeight();
+    const float z_near = -1e6;
+    const float z_far = 1e6;
+    GLfloat projection[4][4] = {
+        { 2.0f / (right - left), 0.0f, 0.0f, 0.0f },
+        { 0.0f, 2.0f / (top - bottom), 0.0f, 0.0f },
+        { 0.0f, 0.0f, -2.0f / (z_far - z_near), 0.0f },
+        { -(right + left) / (right - left), -(top + bottom) / (top - bottom),
+          -(z_far + z_near) / (z_far - z_near), 1.0f }
+    };
+
+    GFX_GL_Program_UniformMatrix4fv(
+        &renderer->program, renderer->loc_mat_projection, 1, GL_FALSE,
+        &projection[0][0]);
+
+    glDepthFunc(GL_LEQUAL);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_DEPTH_TEST);
+    GFX_GL_CheckError();
+}
+
+void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+
+    GFX_GL_CheckError();
+}
+
+void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer)
+{
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    glClear(GL_DEPTH_BUFFER_BIT);
+    GFX_GL_CheckError();
+}
+
+int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_Renderer *const renderer)
+{
+    assert(renderer != NULL);
+    assert(renderer->env_map_texture == NULL);
+
+    GFX_GL_Texture *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
+    renderer->env_map_texture = texture;
+
+    GFX_3D_Renderer_RestoreTexture(renderer);
+    GFX_GL_CheckError();
+    return GFX_ENV_MAP_TEXTURE;
+}
+
+bool GFX_3D_Renderer_UnregisterEnvironmentMap(
+    GFX_3D_Renderer *const renderer, const int texture_num)
+{
+    assert(renderer != NULL);
+
+    GFX_GL_Texture *const texture = renderer->env_map_texture;
+    if (texture == NULL) {
+        LOG_ERROR("No environment map registered");
+        return false;
+    }
+
+    if (texture_num != GFX_ENV_MAP_TEXTURE) {
+        LOG_ERROR("Invalid environment map texture ID");
+        return false;
+    }
+
+    // unbind texture if currently bound
+    if (renderer->selected_texture_num == texture_num) {
+        GFX_3D_Renderer_SelectTextureImpl(renderer, GFX_NO_TEXTURE);
+        renderer->selected_texture_num = GFX_NO_TEXTURE;
+    }
+
+    GFX_GL_Texture_Free(texture);
+    renderer->env_map_texture = NULL;
+    return true;
+}
+
+void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_Renderer *const renderer)
+{
+    assert(renderer != NULL);
+
+    GFX_GL_Texture *const env_map = renderer->env_map_texture;
+    if (env_map != NULL) {
+        GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+        GFX_GL_Texture_LoadFromBackBuffer(env_map);
+        GFX_3D_Renderer_RestoreTexture(renderer);
+    }
+}
+
+int GFX_3D_Renderer_RegisterTexturePage(
+    GFX_3D_Renderer *renderer, const void *data, int width, int height)
+{
+    assert(renderer);
+    assert(data);
+    GFX_GL_Texture *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
+    GFX_GL_Texture_Load(texture, data, width, height, GL_RGBA, GL_RGBA);
+
+    int texture_num = GFX_NO_TEXTURE;
+    for (int i = 0; i < GFX_MAX_TEXTURES; i++) {
+        if (!renderer->textures[i]) {
+            renderer->textures[i] = texture;
+            texture_num = i;
+            break;
+        }
+    }
+
+    GFX_3D_Renderer_RestoreTexture(renderer);
+
+    GFX_GL_CheckError();
+    return texture_num;
+}
+
+bool GFX_3D_Renderer_UnregisterTexturePage(
+    GFX_3D_Renderer *renderer, int texture_num)
+{
+    assert(renderer);
+    assert(texture_num >= 0);
+    assert(texture_num < GFX_MAX_TEXTURES);
+
+    GFX_GL_Texture *texture = renderer->textures[texture_num];
+    if (!texture) {
+        LOG_ERROR("Invalid texture handle");
+        return false;
+    }
+
+    // unbind texture if currently bound
+    if (texture_num == renderer->selected_texture_num) {
+        GFX_3D_Renderer_SelectTextureImpl(renderer, GFX_NO_TEXTURE);
+        renderer->selected_texture_num = GFX_NO_TEXTURE;
+    }
+
+    GFX_GL_Texture_Free(texture);
+    renderer->textures[texture_num] = NULL;
+    return true;
+}
+
+void GFX_3D_Renderer_RenderPrimStrip(
+    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count)
+{
+    assert(renderer);
+    assert(vertices);
+    GFX_3D_VertexStream_PushPrimStrip(
+        &renderer->vertex_stream, vertices, count);
+}
+
+void GFX_3D_Renderer_RenderPrimFan(
+    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count)
+{
+    assert(renderer);
+    assert(vertices);
+    GFX_3D_VertexStream_PushPrimFan(&renderer->vertex_stream, vertices, count);
+}
+
+void GFX_3D_Renderer_RenderPrimList(
+    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count)
+{
+    assert(renderer);
+    assert(vertices);
+    GFX_3D_VertexStream_PushPrimList(&renderer->vertex_stream, vertices, count);
+}
+
+void GFX_3D_Renderer_SelectTexture(GFX_3D_Renderer *renderer, int texture_num)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    renderer->selected_texture_num = texture_num;
+    GFX_3D_Renderer_SelectTextureImpl(renderer, texture_num);
+}
+
+void GFX_3D_Renderer_RestoreTexture(GFX_3D_Renderer *renderer)
+{
+    assert(renderer);
+    GFX_3D_Renderer_SelectTextureImpl(renderer, renderer->selected_texture_num);
+}
+
+void GFX_3D_Renderer_SetPrimType(
+    GFX_3D_Renderer *renderer, GFX_3D_PrimType value)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    GFX_3D_VertexStream_SetPrimType(&renderer->vertex_stream, value);
+}
+
+void GFX_3D_Renderer_SetTextureFilter(
+    GFX_3D_Renderer *renderer, GFX_TEXTURE_FILTER filter)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MAG_FILTER,
+        filter == GFX_TF_BILINEAR ? GL_LINEAR : GL_NEAREST);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MIN_FILTER,
+        filter == GFX_TF_BILINEAR ? GL_LINEAR : GL_NEAREST);
+    GFX_GL_Program_Uniform1i(
+        &renderer->program, renderer->loc_smoothing_enabled,
+        filter == GFX_TF_BILINEAR);
+}
+
+void GFX_3D_Renderer_SetDepthTestEnabled(
+    GFX_3D_Renderer *renderer, bool is_enabled)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    if (is_enabled) {
+        glEnable(GL_DEPTH_TEST);
+    } else {
+        glDisable(GL_DEPTH_TEST);
+    }
+}
+
+void GFX_3D_Renderer_SetBlendingMode(
+    GFX_3D_Renderer *const renderer, const GFX_BlendMode blend_mode)
+{
+    assert(renderer != NULL);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+
+    switch (blend_mode) {
+    case GFX_BlendMode_Off:
+        glBlendFunc(GL_ONE, GL_ZERO);
+        break;
+    case GFX_BlendMode_Normal:
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        break;
+    case GFX_BlendMode_Multiply:
+        glBlendFunc(GL_DST_COLOR, GL_SRC_COLOR);
+        break;
+    }
+}
+
+void GFX_3D_Renderer_SetTexturingEnabled(
+    GFX_3D_Renderer *renderer, bool is_enabled)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    GFX_GL_Program_Uniform1i(
+        &renderer->program, renderer->loc_texturing_enabled, is_enabled);
+}

--- a/src/gfx/3d/vertex_stream.c
+++ b/src/gfx/3d/vertex_stream.c
@@ -1,0 +1,160 @@
+#include "gfx/3d/vertex_stream.h"
+
+#include "gfx/gl/gl_core_3_3.h"
+#include "gfx/gl/utils.h"
+#include "log.h"
+#include "memory.h"
+
+static const GLenum GL_PRIM_MODES[] = {
+    GL_LINES, // GFX_3D_PRIM_LINE
+    GL_TRIANGLES, // GFX_3D_PRIM_TRI
+};
+
+static void GFX_3D_VertexStream_PushVertex(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertex);
+
+static void GFX_3D_VertexStream_PushVertex(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertex)
+{
+    if (vertex_stream->pending_vertices.count + 1
+        >= vertex_stream->pending_vertices.capacity) {
+        vertex_stream->pending_vertices.capacity += 1000;
+        vertex_stream->pending_vertices.data = Memory_Realloc(
+            vertex_stream->pending_vertices.data,
+            vertex_stream->pending_vertices.capacity * sizeof(GFX_3D_Vertex));
+    }
+
+    vertex_stream->pending_vertices
+        .data[vertex_stream->pending_vertices.count++] = *vertex;
+}
+
+void GFX_3D_VertexStream_Init(GFX_3D_VertexStream *vertex_stream)
+{
+    vertex_stream->prim_type = GFX_3D_PRIM_TRI;
+    vertex_stream->buffer_size = 0;
+    vertex_stream->pending_vertices.data = NULL;
+    vertex_stream->pending_vertices.count = 0;
+    vertex_stream->pending_vertices.capacity = 0;
+
+    GFX_GL_Buffer_Init(&vertex_stream->buffer, GL_ARRAY_BUFFER);
+    GFX_GL_Buffer_Bind(&vertex_stream->buffer);
+
+    GFX_GL_VertexArray_Init(&vertex_stream->vtc_format);
+    GFX_GL_VertexArray_Bind(&vertex_stream->vtc_format);
+    GFX_GL_VertexArray_Attribute(
+        &vertex_stream->vtc_format, 0, 3, GL_FLOAT, GL_FALSE, 40, 0);
+    GFX_GL_VertexArray_Attribute(
+        &vertex_stream->vtc_format, 1, 3, GL_FLOAT, GL_FALSE, 40, 12);
+    GFX_GL_VertexArray_Attribute(
+        &vertex_stream->vtc_format, 2, 4, GL_FLOAT, GL_FALSE, 40, 24);
+
+    GFX_GL_CheckError();
+}
+
+void GFX_3D_VertexStream_Close(GFX_3D_VertexStream *vertex_stream)
+{
+    GFX_GL_VertexArray_Close(&vertex_stream->vtc_format);
+    GFX_GL_Buffer_Close(&vertex_stream->buffer);
+
+    Memory_FreePointer(&vertex_stream->pending_vertices.data);
+}
+
+void GFX_3D_VertexStream_Bind(GFX_3D_VertexStream *vertex_stream)
+{
+    GFX_GL_Buffer_Bind(&vertex_stream->buffer);
+}
+
+void GFX_3D_VertexStream_SetPrimType(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_PrimType prim_type)
+{
+    vertex_stream->prim_type = prim_type;
+}
+
+bool GFX_3D_VertexStream_PushPrimStrip(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
+{
+    if (vertex_stream->prim_type != GFX_3D_PRIM_TRI) {
+        LOG_ERROR("Unsupported prim type: %d", vertex_stream->prim_type);
+        return false;
+    }
+
+    if (count <= 2) {
+        for (int i = 0; i < count; i++) {
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+        }
+    } else {
+        // convert strip to raw triangles
+        for (int i = 2; i < count; i++) {
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i - 2]);
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i - 1]);
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+        }
+    }
+
+    return true;
+}
+
+bool GFX_3D_VertexStream_PushPrimFan(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
+{
+    if (vertex_stream->prim_type != GFX_3D_PRIM_TRI) {
+        LOG_ERROR("Unsupported prim type: %d", vertex_stream->prim_type);
+        return false;
+    }
+
+    if (count <= 2) {
+        for (int i = 0; i < count; i++) {
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+        }
+    } else {
+        // convert fan to raw triangles
+        for (int i = 2; i < count; i++) {
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[0]);
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i - 1]);
+            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+        }
+    }
+
+    return true;
+}
+
+bool GFX_3D_VertexStream_PushPrimList(
+    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
+{
+    for (int i = 0; i < count; i++) {
+        GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+    }
+    return true;
+}
+
+void GFX_3D_VertexStream_RenderPending(GFX_3D_VertexStream *vertex_stream)
+{
+    if (!vertex_stream->pending_vertices.count) {
+        return;
+    }
+
+    GFX_GL_VertexArray_Bind(&vertex_stream->vtc_format);
+
+    // resize GPU buffer if required
+    size_t buffer_size =
+        sizeof(GFX_3D_Vertex) * vertex_stream->pending_vertices.count;
+    if (buffer_size > vertex_stream->buffer_size) {
+        LOG_INFO(
+            "Vertex buffer resize: %d -> %d", vertex_stream->buffer_size,
+            buffer_size);
+        GFX_GL_Buffer_Data(
+            &vertex_stream->buffer, buffer_size, NULL, GL_STREAM_DRAW);
+        vertex_stream->buffer_size = buffer_size;
+    }
+
+    GFX_GL_Buffer_SubData(
+        &vertex_stream->buffer, 0, buffer_size,
+        vertex_stream->pending_vertices.data);
+
+    glDrawArrays(
+        GL_PRIM_MODES[vertex_stream->prim_type], 0,
+        vertex_stream->pending_vertices.count);
+    GFX_GL_CheckError();
+
+    vertex_stream->pending_vertices.count = 0;
+}

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -1,0 +1,330 @@
+#include "gfx/context.h"
+
+#include "game/shell.h"
+#include "gfx/gl/gl_core_3_3.h"
+#include "gfx/gl/utils.h"
+#include "gfx/renderers/fbo_renderer.h"
+#include "gfx/renderers/legacy_renderer.h"
+#include "gfx/screenshot.h"
+#include "log.h"
+#include "memory.h"
+
+#include <SDL2/SDL_video.h>
+#include <string.h>
+
+typedef struct GFX_CONTEXT {
+    SDL_GLContext context;
+    SDL_Window *window_handle;
+
+    GFX_CONFIG config;
+    GFX_RENDER_MODE render_mode;
+    int32_t display_width;
+    int32_t display_height;
+    int32_t window_width;
+    int32_t window_height;
+
+    char *scheduled_screenshot_path;
+    GFX_Renderer *renderer;
+    GFX_2D_Renderer renderer_2d;
+    GFX_3D_Renderer renderer_3d;
+} GFX_CONTEXT;
+
+static GFX_CONTEXT m_Context = { 0 };
+
+static bool GFX_Context_IsExtensionSupported(const char *name);
+static void GFX_Context_CheckExtensionSupport(const char *name);
+
+static bool GFX_Context_IsExtensionSupported(const char *name)
+{
+    int number_of_extensions;
+
+    glGetIntegerv(GL_NUM_EXTENSIONS, &number_of_extensions);
+    GFX_GL_CheckError();
+
+    for (int i = 0; i < number_of_extensions; i++) {
+        const char *gl_ext = (const char *)glGetStringi(GL_EXTENSIONS, i);
+        GFX_GL_CheckError();
+
+        if (gl_ext && !strcmp(gl_ext, name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void GFX_Context_CheckExtensionSupport(const char *name)
+{
+    LOG_INFO(
+        "%s supported: %s", name,
+        GFX_Context_IsExtensionSupported(name) ? "yes" : "no");
+}
+
+void GFX_Context_SwitchToWindowViewport(void)
+{
+    glViewport(0, 0, m_Context.window_width, m_Context.window_height);
+    GFX_GL_CheckError();
+}
+
+void GFX_Context_SwitchToWindowViewportAR(void)
+{
+    // switch to window viewport at the aspect ratio of the display viewport
+    int vp_width = m_Context.window_width;
+    int vp_height = m_Context.window_height;
+
+    // default to bottom left corner of the window
+    int vp_x = 0;
+    int vp_y = 0;
+
+    int hw = m_Context.display_height * vp_width;
+    int wh = m_Context.display_width * vp_height;
+
+    // create viewport offset if the window has a different
+    // aspect ratio than the current display mode
+    if (hw > wh) {
+        int max_w = wh / m_Context.display_height;
+        vp_x = (vp_width - max_w) / 2;
+        vp_width = max_w;
+    } else if (hw < wh) {
+        int max_h = hw / m_Context.display_width;
+        vp_y = (vp_height - max_h) / 2;
+        vp_height = max_h;
+    }
+
+    glViewport(vp_x, vp_y, vp_width, vp_height);
+    GFX_GL_CheckError();
+}
+
+void GFX_Context_SwitchToDisplayViewport(void)
+{
+    glViewport(0, 0, m_Context.display_width, m_Context.display_height);
+    GFX_GL_CheckError();
+}
+
+void GFX_Context_Attach(void *window_handle)
+{
+    const char *shading_ver;
+
+    if (m_Context.window_handle) {
+        return;
+    }
+
+    LOG_INFO("Attaching to window %p", window_handle);
+
+    m_Context.config.line_width = 1;
+    m_Context.config.enable_wireframe = false;
+    m_Context.render_mode = -1;
+    SDL_GetWindowSize(
+        window_handle, &m_Context.window_width, &m_Context.window_height);
+    m_Context.display_width = m_Context.window_width;
+    m_Context.display_height = m_Context.window_height;
+
+    m_Context.window_handle = window_handle;
+
+    if (GFX_GL_DEFAULT_BACKEND == GFX_GL_33C) {
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+        SDL_GL_SetAttribute(
+            SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    }
+
+    m_Context.context = SDL_GL_CreateContext(m_Context.window_handle);
+
+    if (!m_Context.context) {
+        Shell_ExitSystem("Can't create OpenGL context");
+    }
+
+    if (SDL_GL_MakeCurrent(m_Context.window_handle, m_Context.context)) {
+        Shell_ExitSystem("Can't activate OpenGL context");
+    }
+
+    LOG_INFO("OpenGL vendor string:   %s", glGetString(GL_VENDOR));
+    LOG_INFO("OpenGL renderer string: %s", glGetString(GL_RENDERER));
+    LOG_INFO("OpenGL version string:  %s", glGetString(GL_VERSION));
+
+    shading_ver = (const char *)glGetString(GL_SHADING_LANGUAGE_VERSION);
+    if (shading_ver != NULL) {
+        LOG_INFO("Shading version string: %s", shading_ver);
+    } else {
+        GFX_GL_CheckError();
+    }
+
+    // Check the availability of non-Core Profile extensions for OpenGL 2.1
+    if (GFX_GL_DEFAULT_BACKEND == GFX_GL_21) {
+        GFX_Context_CheckExtensionSupport("GL_ARB_explicit_attrib_location");
+        GFX_Context_CheckExtensionSupport("GL_EXT_gpu_shader4");
+    }
+
+    glClearColor(0, 0, 0, 0);
+    glClearDepth(1);
+    GFX_GL_CheckError();
+
+    // VSync defaults to on unless user disabled it in runtime json
+    SDL_GL_SetSwapInterval(1);
+
+    GFX_2D_Renderer_Init(&m_Context.renderer_2d);
+    GFX_3D_Renderer_Init(&m_Context.renderer_3d, &m_Context.config);
+}
+
+void GFX_Context_Detach(void)
+{
+    if (!m_Context.window_handle) {
+        return;
+    }
+
+    if (m_Context.renderer != NULL && m_Context.renderer->shutdown != NULL) {
+        m_Context.renderer->shutdown(m_Context.renderer);
+    }
+
+    GFX_2D_Renderer_Close(&m_Context.renderer_2d);
+    GFX_3D_Renderer_Close(&m_Context.renderer_3d);
+
+    SDL_GL_MakeCurrent(NULL, NULL);
+
+    if (m_Context.context != NULL) {
+        SDL_GL_DeleteContext(m_Context.context);
+        m_Context.context = NULL;
+    }
+    m_Context.window_handle = NULL;
+}
+
+void GFX_Context_SetDisplayFilter(const GFX_TEXTURE_FILTER filter)
+{
+    m_Context.config.display_filter = filter;
+}
+
+void GFX_Context_SetWireframeMode(const bool enable)
+{
+    m_Context.config.enable_wireframe = enable;
+}
+
+void GFX_Context_SetLineWidth(const int32_t line_width)
+{
+    m_Context.config.line_width = line_width;
+}
+
+void GFX_Context_SetAnisotropyFilter(float value)
+{
+    GFX_GL_Sampler_Bind(&m_Context.renderer_3d.sampler, 0);
+    GFX_GL_Sampler_Parameterf(
+        &m_Context.renderer_3d.sampler, GL_TEXTURE_MAX_ANISOTROPY_EXT, value);
+}
+
+void GFX_Context_SetVSync(bool vsync)
+{
+    SDL_GL_SetSwapInterval(vsync);
+}
+
+void GFX_Context_SetWindowSize(int32_t width, int32_t height)
+{
+    LOG_INFO("Window size: %dx%d", width, height);
+    m_Context.window_width = width;
+    m_Context.window_height = height;
+}
+
+void GFX_Context_SetDisplaySize(int32_t width, int32_t height)
+{
+    if (width == m_Context.display_width
+        && height == m_Context.display_height) {
+        return;
+    }
+
+    LOG_INFO("Display size: %dx%d", width, height);
+    if (width <= 0 || height <= 0) {
+        LOG_INFO("invalid size, ignoring");
+        return;
+    }
+
+    m_Context.display_width = width;
+    m_Context.display_height = height;
+
+    if (m_Context.renderer != NULL && m_Context.renderer->reset != NULL) {
+        m_Context.renderer->reset(m_Context.renderer);
+    }
+}
+
+void GFX_Context_SetRenderingMode(GFX_RENDER_MODE target_mode)
+{
+    GFX_RENDER_MODE current_mode = m_Context.render_mode;
+    if (current_mode == target_mode) {
+        return;
+    }
+
+    LOG_INFO("Render mode: %d", target_mode);
+    if (m_Context.renderer != NULL && m_Context.renderer->shutdown != NULL) {
+        m_Context.renderer->shutdown(m_Context.renderer);
+    }
+    switch (target_mode) {
+    case GFX_RM_FRAMEBUFFER:
+        m_Context.renderer = &g_GFX_Renderer_FBO;
+        break;
+    case GFX_RM_LEGACY:
+        m_Context.renderer = &g_GFX_Renderer_Legacy;
+        break;
+    }
+    if (m_Context.renderer != NULL && m_Context.renderer->init != NULL) {
+        m_Context.renderer->init(m_Context.renderer, &m_Context.config);
+    }
+    m_Context.render_mode = target_mode;
+}
+
+void *GFX_Context_GetWindowHandle(void)
+{
+    return m_Context.window_handle;
+}
+
+int32_t GFX_Context_GetDisplayWidth(void)
+{
+    return m_Context.display_width;
+}
+
+int32_t GFX_Context_GetDisplayHeight(void)
+{
+    return m_Context.display_height;
+}
+
+void GFX_Context_Clear(void)
+{
+    if (m_Context.config.enable_wireframe) {
+        glClearColor(1.0, 1.0, 1.0, 0.0);
+    } else {
+        glClearColor(0.0, 0.0, 0.0, 0.0);
+    }
+    glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void GFX_Context_SwapBuffers(void)
+{
+    glFinish();
+    GFX_GL_CheckError();
+
+    if (m_Context.renderer != NULL
+        && m_Context.renderer->swap_buffers != NULL) {
+        m_Context.renderer->swap_buffers(m_Context.renderer);
+    }
+}
+
+void GFX_Context_ScheduleScreenshot(const char *path)
+{
+    Memory_FreePointer(&m_Context.scheduled_screenshot_path);
+    m_Context.scheduled_screenshot_path = Memory_DupStr(path);
+}
+
+const char *GFX_Context_GetScheduledScreenshotPath(void)
+{
+    return m_Context.scheduled_screenshot_path;
+}
+
+void GFX_Context_ClearScheduledScreenshotPath(void)
+{
+    Memory_FreePointer(&m_Context.scheduled_screenshot_path);
+}
+
+GFX_2D_Renderer *GFX_Context_GetRenderer2D(void)
+{
+    return &m_Context.renderer_2d;
+}
+
+GFX_3D_Renderer *GFX_Context_GetRenderer3D(void)
+{
+    return &m_Context.renderer_3d;
+}

--- a/src/gfx/gl/buffer.c
+++ b/src/gfx/gl/buffer.c
@@ -1,0 +1,67 @@
+#include "gfx/gl/buffer.h"
+
+#include "gfx/gl/utils.h"
+
+#include <assert.h>
+
+void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target)
+{
+    assert(buf);
+    buf->target = target;
+    glGenBuffers(1, &buf->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Buffer_Close(GFX_GL_Buffer *buf)
+{
+    assert(buf);
+    glDeleteBuffers(1, &buf->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Buffer_Bind(GFX_GL_Buffer *buf)
+{
+    assert(buf);
+    glBindBuffer(buf->target, buf->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Buffer_Data(
+    GFX_GL_Buffer *buf, GLsizei size, const void *data, GLenum usage)
+{
+    assert(buf);
+    glBufferData(buf->target, size, data, usage);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Buffer_SubData(
+    GFX_GL_Buffer *buf, GLsizei offset, GLsizei size, const void *data)
+{
+    assert(buf);
+    glBufferSubData(buf->target, offset, size, data);
+    GFX_GL_CheckError();
+}
+
+void *GFX_GL_Buffer_Map(GFX_GL_Buffer *buf, GLenum access)
+{
+    assert(buf);
+    void *ret = glMapBuffer(buf->target, access);
+    GFX_GL_CheckError();
+    return ret;
+}
+
+void GFX_GL_Buffer_Unmap(GFX_GL_Buffer *buf)
+{
+    assert(buf);
+    glUnmapBuffer(buf->target);
+    GFX_GL_CheckError();
+}
+
+GLint GFX_GL_Buffer_Parameter(GFX_GL_Buffer *buf, GLenum pname)
+{
+    assert(buf);
+    GLint params = 0;
+    glGetBufferParameteriv(buf->target, pname, &params);
+    GFX_GL_CheckError();
+    return params;
+}

--- a/src/gfx/gl/gl_core_3_3.c
+++ b/src/gfx/gl/gl_core_3_3.c
@@ -1,0 +1,8745 @@
+#include "gfx/gl/gl_core_3_3.h"
+
+#include <string.h>
+
+#if __GNUC__ || __MINGW32__
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+
+#if defined(__APPLE__)
+    #include <dlfcn.h>
+
+static void *AppleGLGetProcAddress(const char *name)
+{
+    static void *image = NULL;
+
+    if (NULL == image)
+        image = dlopen(
+            "/System/Library/Frameworks/OpenGL.framework/Versions/"
+            "Current/OpenGL",
+            RTLD_LAZY);
+
+    return (image ? dlsym(image, name) : NULL);
+}
+#endif /* __APPLE__ */
+
+#if defined(__sgi) || defined(__sun)
+    #include <dlfcn.h>
+    #include <stdio.h>
+
+static void *SunGetProcAddress(const GLubyte *name)
+{
+    static void *h = NULL;
+    static void *gpa;
+
+    if (h == NULL) {
+        if ((h = dlopen(NULL, RTLD_LAZY | RTLD_LOCAL)) == NULL)
+            return NULL;
+        gpa = dlsym(h, "glXGetProcAddress");
+    }
+
+    if (gpa != NULL)
+        return ((void *(*)(const GLubyte *))gpa)(name);
+    else
+        return dlsym(h, (const char *)name);
+}
+#endif /* __sgi || __sun */
+
+#if defined(_WIN32)
+
+    #ifdef _MSC_VER
+        #pragma warning(disable : 4055)
+        #pragma warning(disable : 4054)
+        #pragma warning(disable : 4996)
+    #endif
+
+static int TestPointer(const PROC pTest)
+{
+    ptrdiff_t iTest;
+    if (!pTest)
+        return 0;
+    iTest = (ptrdiff_t)pTest;
+
+    if (iTest == 1 || iTest == 2 || iTest == 3 || iTest == -1)
+        return 0;
+
+    return 1;
+}
+
+static PROC WinGetProcAddress(const char *name)
+{
+    HMODULE glMod = NULL;
+    PROC pFunc = wglGetProcAddress((LPCSTR)name);
+    if (TestPointer(pFunc)) {
+        return pFunc;
+    }
+    glMod = GetModuleHandleA("OpenGL32.dll");
+    return (PROC)GetProcAddress(glMod, (LPCSTR)name);
+}
+
+    #define IntGetProcAddress(name) WinGetProcAddress(name)
+#else
+    #if defined(__APPLE__)
+        #define IntGetProcAddress(name) AppleGLGetProcAddress(name)
+    #else
+        #if defined(__sgi) || defined(__sun)
+            #define IntGetProcAddress(name) SunGetProcAddress(name)
+        #else /* GLX */
+            #include <GL/glx.h>
+
+            #define IntGetProcAddress(name)                                    \
+                (*glXGetProcAddressARB)((const GLubyte *)name)
+        #endif
+    #endif
+#endif
+
+int ogl_ext_EXT_texture_compression_s3tc = 0;
+int ogl_ext_EXT_texture_sRGB = 0;
+int ogl_ext_EXT_texture_filter_anisotropic = 0;
+int ogl_ext_ARB_compressed_texture_pixel_storage = 0;
+int ogl_ext_ARB_conservative_depth = 0;
+int ogl_ext_ARB_ES2_compatibility = 0;
+int ogl_ext_ARB_get_program_binary = 0;
+int ogl_ext_ARB_explicit_uniform_location = 0;
+int ogl_ext_ARB_internalformat_query = 0;
+int ogl_ext_ARB_internalformat_query2 = 0;
+int ogl_ext_ARB_map_buffer_alignment = 0;
+int ogl_ext_ARB_program_interface_query = 0;
+int ogl_ext_ARB_separate_shader_objects = 0;
+int ogl_ext_ARB_shading_language_420pack = 0;
+int ogl_ext_ARB_shading_language_packing = 0;
+int ogl_ext_ARB_texture_buffer_range = 0;
+int ogl_ext_ARB_texture_storage = 0;
+int ogl_ext_ARB_texture_view = 0;
+int ogl_ext_ARB_vertex_attrib_binding = 0;
+int ogl_ext_ARB_viewport_array = 0;
+int ogl_ext_ARB_arrays_of_arrays = 0;
+int ogl_ext_ARB_clear_buffer_object = 0;
+int ogl_ext_ARB_copy_image = 0;
+int ogl_ext_ARB_ES3_compatibility = 0;
+int ogl_ext_ARB_fragment_layer_viewport = 0;
+int ogl_ext_ARB_framebuffer_no_attachments = 0;
+int ogl_ext_ARB_invalidate_subdata = 0;
+int ogl_ext_ARB_robust_buffer_access_behavior = 0;
+int ogl_ext_ARB_stencil_texturing = 0;
+int ogl_ext_ARB_texture_query_levels = 0;
+int ogl_ext_ARB_texture_storage_multisample = 0;
+int ogl_ext_KHR_debug = 0;
+int ogl_ext_ARB_buffer_storage = 0;
+int ogl_ext_ARB_clear_texture = 0;
+int ogl_ext_ARB_enhanced_layouts = 0;
+int ogl_ext_ARB_multi_bind = 0;
+int ogl_ext_ARB_query_buffer_object = 0;
+int ogl_ext_ARB_texture_mirror_clamp_to_edge = 0;
+int ogl_ext_ARB_texture_stencil8 = 0;
+int ogl_ext_ARB_vertex_type_10f_11f_11f_rev = 0;
+int ogl_ext_ARB_seamless_cubemap_per_texture = 0;
+int ogl_ext_ARB_clip_control = 0;
+int ogl_ext_ARB_conditional_render_inverted = 0;
+int ogl_ext_ARB_cull_distance = 0;
+int ogl_ext_ARB_derivative_control = 0;
+int ogl_ext_ARB_direct_state_access = 0;
+int ogl_ext_ARB_get_texture_sub_image = 0;
+int ogl_ext_ARB_shader_texture_image_samples = 0;
+int ogl_ext_ARB_texture_barrier = 0;
+int ogl_ext_KHR_context_flush_control = 0;
+int ogl_ext_KHR_robust_buffer_access_behavior = 0;
+int ogl_ext_KHR_robustness = 0;
+
+/* Extension: ARB_ES2_compatibility*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARDEPTHFPROC)(GLfloat);
+static void CODEGEN_FUNCPTR Switch_ClearDepthf(GLfloat d);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEPTHRANGEFPROC)(GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR Switch_DepthRangef(GLfloat n, GLfloat f);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSHADERPRECISIONFORMATPROC)(
+    GLenum, GLenum, GLint *, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetShaderPrecisionFormat(
+    GLenum shadertype, GLenum precisiontype, GLint *range, GLint *precision);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLRELEASESHADERCOMPILERPROC)(void);
+static void CODEGEN_FUNCPTR Switch_ReleaseShaderCompiler(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSHADERBINARYPROC)(
+    GLsizei, const GLuint *, GLenum, const void *, GLsizei);
+static void CODEGEN_FUNCPTR Switch_ShaderBinary(
+    GLsizei count, const GLuint *shaders, GLenum binaryformat,
+    const void *binary, GLsizei length);
+
+/* Extension: ARB_get_program_binary*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMBINARYPROC)(
+    GLuint, GLsizei, GLsizei *, GLenum *, void *);
+static void CODEGEN_FUNCPTR Switch_GetProgramBinary(
+    GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat,
+    void *binary);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMBINARYPROC)(
+    GLuint, GLenum, const void *, GLsizei);
+static void CODEGEN_FUNCPTR Switch_ProgramBinary(
+    GLuint program, GLenum binaryFormat, const void *binary, GLsizei length);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMPARAMETERIPROC)(
+    GLuint, GLenum, GLint);
+static void CODEGEN_FUNCPTR
+Switch_ProgramParameteri(GLuint program, GLenum pname, GLint value);
+
+/* Extension: ARB_internalformat_query*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETINTERNALFORMATIVPROC)(
+    GLenum, GLenum, GLenum, GLsizei, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetInternalformativ(
+    GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize,
+    GLint *params);
+
+/* Extension: ARB_internalformat_query2*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETINTERNALFORMATI64VPROC)(
+    GLenum, GLenum, GLenum, GLsizei, GLint64 *);
+static void CODEGEN_FUNCPTR Switch_GetInternalformati64v(
+    GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize,
+    GLint64 *params);
+
+/* Extension: ARB_program_interface_query*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMINTERFACEIVPROC)(
+    GLuint, GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetProgramInterfaceiv(
+    GLuint program, GLenum programInterface, GLenum pname, GLint *params);
+typedef GLuint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMRESOURCEINDEXPROC)(
+    GLuint, GLenum, const GLchar *);
+static GLuint CODEGEN_FUNCPTR Switch_GetProgramResourceIndex(
+    GLuint program, GLenum programInterface, const GLchar *name);
+typedef GLint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMRESOURCELOCATIONPROC)(
+    GLuint, GLenum, const GLchar *);
+static GLint CODEGEN_FUNCPTR Switch_GetProgramResourceLocation(
+    GLuint program, GLenum programInterface, const GLchar *name);
+typedef GLint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMRESOURCELOCATIONINDEXPROC)(
+    GLuint, GLenum, const GLchar *);
+static GLint CODEGEN_FUNCPTR Switch_GetProgramResourceLocationIndex(
+    GLuint program, GLenum programInterface, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMRESOURCENAMEPROC)(
+    GLuint, GLenum, GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetProgramResourceName(
+    GLuint program, GLenum programInterface, GLuint index, GLsizei bufSize,
+    GLsizei *length, GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMRESOURCEIVPROC)(
+    GLuint, GLenum, GLuint, GLsizei, const GLenum *, GLsizei, GLsizei *,
+    GLint *);
+static void CODEGEN_FUNCPTR Switch_GetProgramResourceiv(
+    GLuint program, GLenum programInterface, GLuint index, GLsizei propCount,
+    const GLenum *props, GLsizei bufSize, GLsizei *length, GLint *params);
+
+/* Extension: ARB_separate_shader_objects*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLACTIVESHADERPROGRAMPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_ActiveShaderProgram(GLuint pipeline, GLuint program);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDPROGRAMPIPELINEPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_BindProgramPipeline(GLuint pipeline);
+typedef GLuint(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATESHADERPROGRAMVPROC)(
+    GLenum, GLsizei, const GLchar *const *);
+static GLuint CODEGEN_FUNCPTR Switch_CreateShaderProgramv(
+    GLenum type, GLsizei count, const GLchar *const *strings);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETEPROGRAMPIPELINESPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteProgramPipelines(GLsizei n, const GLuint *pipelines);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENPROGRAMPIPELINESPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GenProgramPipelines(GLsizei n, GLuint *pipelines);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMPIPELINEINFOLOGPROC)(
+    GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetProgramPipelineInfoLog(
+    GLuint pipeline, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMPIPELINEIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetProgramPipelineiv(GLuint pipeline, GLenum pname, GLint *params);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISPROGRAMPIPELINEPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsProgramPipeline(GLuint pipeline);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1DPROC)(
+    GLuint, GLint, GLdouble);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1d(GLuint program, GLint location, GLdouble v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1DVPROC)(
+    GLuint, GLint, GLsizei, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1FPROC)(
+    GLuint, GLint, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1f(GLuint program, GLint location, GLfloat v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1FVPROC)(
+    GLuint, GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1IPROC)(
+    GLuint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1i(GLuint program, GLint location, GLint v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1IVPROC)(
+    GLuint, GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1UIPROC)(
+    GLuint, GLint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1ui(GLuint program, GLint location, GLuint v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM1UIVPROC)(
+    GLuint, GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2DPROC)(
+    GLuint, GLint, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2d(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2DVPROC)(
+    GLuint, GLint, GLsizei, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2FPROC)(
+    GLuint, GLint, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform2f(GLuint program, GLint location, GLfloat v0, GLfloat v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2FVPROC)(
+    GLuint, GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2IPROC)(
+    GLuint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform2i(GLuint program, GLint location, GLint v0, GLint v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2IVPROC)(
+    GLuint, GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2UIPROC)(
+    GLuint, GLint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform2ui(GLuint program, GLint location, GLuint v0, GLuint v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM2UIVPROC)(
+    GLuint, GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3DPROC)(
+    GLuint, GLint, GLdouble, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3d(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1, GLdouble v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3DVPROC)(
+    GLuint, GLint, GLsizei, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3FPROC)(
+    GLuint, GLint, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3f(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3FVPROC)(
+    GLuint, GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3IPROC)(
+    GLuint, GLint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3i(
+    GLuint program, GLint location, GLint v0, GLint v1, GLint v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3IVPROC)(
+    GLuint, GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3UIPROC)(
+    GLuint, GLint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3ui(
+    GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM3UIVPROC)(
+    GLuint, GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4DPROC)(
+    GLuint, GLint, GLdouble, GLdouble, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4d(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1, GLdouble v2,
+    GLdouble v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4DVPROC)(
+    GLuint, GLint, GLsizei, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4FPROC)(
+    GLuint, GLint, GLfloat, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4f(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2,
+    GLfloat v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4FVPROC)(
+    GLuint, GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4IPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4i(
+    GLuint program, GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4IVPROC)(
+    GLuint, GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4UIPROC)(
+    GLuint, GLint, GLuint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4ui(
+    GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORM4UIVPROC)(
+    GLuint, GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX2DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX2FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X3DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x3dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X3FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x3fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X4DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x4dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X4FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x4fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX3DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX3FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X2DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x2dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X2FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x2fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X4DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x4dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X4FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x4fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX4DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX4FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X2DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x2dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X2FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x2fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X3DVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLdouble *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x3dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X3FVPROC)(
+    GLuint, GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x3fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUSEPROGRAMSTAGESPROC)(
+    GLuint, GLbitfield, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_UseProgramStages(GLuint pipeline, GLbitfield stages, GLuint program);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVALIDATEPROGRAMPIPELINEPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_ValidateProgramPipeline(GLuint pipeline);
+
+/* Extension: ARB_texture_buffer_range*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXBUFFERRANGEPROC)(
+    GLenum, GLenum, GLuint, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_TexBufferRange(
+    GLenum target, GLenum internalformat, GLuint buffer, GLintptr offset,
+    GLsizeiptr size);
+
+/* Extension: ARB_texture_storage*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSTORAGE1DPROC)(
+    GLenum, GLsizei, GLenum, GLsizei);
+static void CODEGEN_FUNCPTR Switch_TexStorage1D(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSTORAGE2DPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_TexStorage2D(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSTORAGE3DPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_TexStorage3D(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth);
+
+/* Extension: ARB_texture_view*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREVIEWPROC)(
+    GLuint, GLenum, GLuint, GLenum, GLuint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_TextureView(
+    GLuint texture, GLenum target, GLuint origtexture, GLenum internalformat,
+    GLuint minlevel, GLuint numlevels, GLuint minlayer, GLuint numlayers);
+
+/* Extension: ARB_vertex_attrib_binding*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDVERTEXBUFFERPROC)(
+    GLuint, GLuint, GLintptr, GLsizei);
+static void CODEGEN_FUNCPTR Switch_BindVertexBuffer(
+    GLuint bindingindex, GLuint buffer, GLintptr offset, GLsizei stride);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBBINDINGPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribBinding(GLuint attribindex, GLuint bindingindex);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBFORMATPROC)(
+    GLuint, GLint, GLenum, GLboolean, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribFormat(
+    GLuint attribindex, GLint size, GLenum type, GLboolean normalized,
+    GLuint relativeoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBIFORMATPROC)(
+    GLuint, GLint, GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribIFormat(
+    GLuint attribindex, GLint size, GLenum type, GLuint relativeoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBLFORMATPROC)(
+    GLuint, GLint, GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribLFormat(
+    GLuint attribindex, GLint size, GLenum type, GLuint relativeoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXBINDINGDIVISORPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexBindingDivisor(GLuint bindingindex, GLuint divisor);
+
+/* Extension: ARB_viewport_array*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEPTHRANGEARRAYVPROC)(
+    GLuint, GLsizei, const GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_DepthRangeArrayv(GLuint first, GLsizei count, const GLdouble *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEPTHRANGEINDEXEDPROC)(
+    GLuint, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR
+Switch_DepthRangeIndexed(GLuint index, GLdouble n, GLdouble f);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETDOUBLEI_VPROC)(
+    GLenum, GLuint, GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_GetDoublei_v(GLenum target, GLuint index, GLdouble *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETFLOATI_VPROC)(
+    GLenum, GLuint, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetFloati_v(GLenum target, GLuint index, GLfloat *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSCISSORARRAYVPROC)(
+    GLuint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_ScissorArrayv(GLuint first, GLsizei count, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSCISSORINDEXEDPROC)(
+    GLuint, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_ScissorIndexed(
+    GLuint index, GLint left, GLint bottom, GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSCISSORINDEXEDVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_ScissorIndexedv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVIEWPORTARRAYVPROC)(
+    GLuint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_ViewportArrayv(GLuint first, GLsizei count, const GLfloat *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVIEWPORTINDEXEDFPROC)(
+    GLuint, GLfloat, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR Switch_ViewportIndexedf(
+    GLuint index, GLfloat x, GLfloat y, GLfloat w, GLfloat h);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVIEWPORTINDEXEDFVPROC)(
+    GLuint, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_ViewportIndexedfv(GLuint index, const GLfloat *v);
+
+/* Extension: ARB_clear_buffer_object*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARBUFFERDATAPROC)(
+    GLenum, GLenum, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_ClearBufferData(
+    GLenum target, GLenum internalformat, GLenum format, GLenum type,
+    const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARBUFFERSUBDATAPROC)(
+    GLenum, GLenum, GLintptr, GLsizeiptr, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_ClearBufferSubData(
+    GLenum target, GLenum internalformat, GLintptr offset, GLsizeiptr size,
+    GLenum format, GLenum type, const void *data);
+
+/* Extension: ARB_copy_image*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYIMAGESUBDATAPROC)(
+    GLuint, GLenum, GLint, GLint, GLint, GLint, GLuint, GLenum, GLint, GLint,
+    GLint, GLint, GLsizei, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyImageSubData(
+    GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY,
+    GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX,
+    GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight,
+    GLsizei srcDepth);
+
+/* Extension: ARB_framebuffer_no_attachments*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERPARAMETERIPROC)(
+    GLenum, GLenum, GLint);
+static void CODEGEN_FUNCPTR
+Switch_FramebufferParameteri(GLenum target, GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETFRAMEBUFFERPARAMETERIVPROC)(
+    GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetFramebufferParameteriv(GLenum target, GLenum pname, GLint *params);
+
+/* Extension: ARB_invalidate_subdata*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATEBUFFERDATAPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_InvalidateBufferData(GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATEBUFFERSUBDATAPROC)(
+    GLuint, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_InvalidateBufferSubData(
+    GLuint buffer, GLintptr offset, GLsizeiptr length);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATEFRAMEBUFFERPROC)(
+    GLenum, GLsizei, const GLenum *);
+static void CODEGEN_FUNCPTR Switch_InvalidateFramebuffer(
+    GLenum target, GLsizei numAttachments, const GLenum *attachments);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATESUBFRAMEBUFFERPROC)(
+    GLenum, GLsizei, const GLenum *, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_InvalidateSubFramebuffer(
+    GLenum target, GLsizei numAttachments, const GLenum *attachments, GLint x,
+    GLint y, GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATETEXIMAGEPROC)(GLuint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_InvalidateTexImage(GLuint texture, GLint level);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATETEXSUBIMAGEPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_InvalidateTexSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth);
+
+/* Extension: ARB_texture_storage_multisample*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSTORAGE2DMULTISAMPLEPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei, GLboolean);
+static void CODEGEN_FUNCPTR Switch_TexStorage2DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSTORAGE3DMULTISAMPLEPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei, GLsizei, GLboolean);
+static void CODEGEN_FUNCPTR Switch_TexStorage3DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
+
+/* Extension: KHR_debug*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEBUGMESSAGECALLBACKPROC)(
+    GLDEBUGPROC, const void *);
+static void CODEGEN_FUNCPTR
+Switch_DebugMessageCallback(GLDEBUGPROC callback, const void *userParam);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEBUGMESSAGECONTROLPROC)(
+    GLenum, GLenum, GLenum, GLsizei, const GLuint *, GLboolean);
+static void CODEGEN_FUNCPTR Switch_DebugMessageControl(
+    GLenum source, GLenum type, GLenum severity, GLsizei count,
+    const GLuint *ids, GLboolean enabled);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEBUGMESSAGEINSERTPROC)(
+    GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar *);
+static void CODEGEN_FUNCPTR Switch_DebugMessageInsert(
+    GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+    const GLchar *buf);
+typedef GLuint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETDEBUGMESSAGELOGPROC)(
+    GLuint, GLsizei, GLenum *, GLenum *, GLuint *, GLenum *, GLsizei *,
+    GLchar *);
+static GLuint CODEGEN_FUNCPTR Switch_GetDebugMessageLog(
+    GLuint count, GLsizei bufSize, GLenum *sources, GLenum *types, GLuint *ids,
+    GLenum *severities, GLsizei *lengths, GLchar *messageLog);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETOBJECTLABELPROC)(
+    GLenum, GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetObjectLabel(
+    GLenum identifier, GLuint name, GLsizei bufSize, GLsizei *length,
+    GLchar *label);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETOBJECTPTRLABELPROC)(
+    const void *, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetObjectPtrLabel(
+    const void *ptr, GLsizei bufSize, GLsizei *length, GLchar *label);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPOINTERVPROC)(GLenum, void **);
+static void CODEGEN_FUNCPTR Switch_GetPointerv(GLenum pname, void **params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLOBJECTLABELPROC)(
+    GLenum, GLuint, GLsizei, const GLchar *);
+static void CODEGEN_FUNCPTR Switch_ObjectLabel(
+    GLenum identifier, GLuint name, GLsizei length, const GLchar *label);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLOBJECTPTRLABELPROC)(
+    const void *, GLsizei, const GLchar *);
+static void CODEGEN_FUNCPTR
+Switch_ObjectPtrLabel(const void *ptr, GLsizei length, const GLchar *label);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOPDEBUGGROUPPROC)(void);
+static void CODEGEN_FUNCPTR Switch_PopDebugGroup(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPUSHDEBUGGROUPPROC)(
+    GLenum, GLuint, GLsizei, const GLchar *);
+static void CODEGEN_FUNCPTR Switch_PushDebugGroup(
+    GLenum source, GLuint id, GLsizei length, const GLchar *message);
+
+/* Extension: ARB_buffer_storage*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBUFFERSTORAGEPROC)(
+    GLenum, GLsizeiptr, const void *, GLbitfield);
+static void CODEGEN_FUNCPTR Switch_BufferStorage(
+    GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
+
+/* Extension: ARB_clear_texture*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARTEXIMAGEPROC)(
+    GLuint, GLint, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_ClearTexImage(
+    GLuint texture, GLint level, GLenum format, GLenum type, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARTEXSUBIMAGEPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum,
+    GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_ClearTexSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *data);
+
+/* Extension: ARB_multi_bind*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDBUFFERSBASEPROC)(
+    GLenum, GLuint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_BindBuffersBase(
+    GLenum target, GLuint first, GLsizei count, const GLuint *buffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDBUFFERSRANGEPROC)(
+    GLenum, GLuint, GLsizei, const GLuint *, const GLintptr *,
+    const GLsizeiptr *);
+static void CODEGEN_FUNCPTR Switch_BindBuffersRange(
+    GLenum target, GLuint first, GLsizei count, const GLuint *buffers,
+    const GLintptr *offsets, const GLsizeiptr *sizes);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDIMAGETEXTURESPROC)(
+    GLuint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_BindImageTextures(GLuint first, GLsizei count, const GLuint *textures);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDSAMPLERSPROC)(
+    GLuint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_BindSamplers(GLuint first, GLsizei count, const GLuint *samplers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDTEXTURESPROC)(
+    GLuint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_BindTextures(GLuint first, GLsizei count, const GLuint *textures);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDVERTEXBUFFERSPROC)(
+    GLuint, GLsizei, const GLuint *, const GLintptr *, const GLsizei *);
+static void CODEGEN_FUNCPTR Switch_BindVertexBuffers(
+    GLuint first, GLsizei count, const GLuint *buffers, const GLintptr *offsets,
+    const GLsizei *strides);
+
+/* Extension: ARB_clip_control*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLIPCONTROLPROC)(GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_ClipControl(GLenum origin, GLenum depth);
+
+/* Extension: ARB_direct_state_access*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDTEXTUREUNITPROC)(GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_BindTextureUnit(GLuint unit, GLuint texture);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBLITNAMEDFRAMEBUFFERPROC)(
+    GLuint, GLuint, GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLint,
+    GLbitfield, GLenum);
+static void CODEGEN_FUNCPTR Switch_BlitNamedFramebuffer(
+    GLuint readFramebuffer, GLuint drawFramebuffer, GLint srcX0, GLint srcY0,
+    GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1,
+    GLint dstY1, GLbitfield mask, GLenum filter);
+typedef GLenum(CODEGEN_FUNCPTR *PFN_PTRC_GLCHECKNAMEDFRAMEBUFFERSTATUSPROC)(
+    GLuint, GLenum);
+static GLenum CODEGEN_FUNCPTR
+Switch_CheckNamedFramebufferStatus(GLuint framebuffer, GLenum target);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARNAMEDBUFFERDATAPROC)(
+    GLuint, GLenum, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_ClearNamedBufferData(
+    GLuint buffer, GLenum internalformat, GLenum format, GLenum type,
+    const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARNAMEDBUFFERSUBDATAPROC)(
+    GLuint, GLenum, GLintptr, GLsizeiptr, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_ClearNamedBufferSubData(
+    GLuint buffer, GLenum internalformat, GLintptr offset, GLsizeiptr size,
+    GLenum format, GLenum type, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERFIPROC)(
+    GLuint, GLenum, const GLfloat, GLint);
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferfi(
+    GLuint framebuffer, GLenum buffer, const GLfloat depth, GLint stencil);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERFVPROC)(
+    GLuint, GLenum, GLint, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferfv(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERIVPROC)(
+    GLuint, GLenum, GLint, const GLint *);
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferiv(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERUIVPROC)(
+    GLuint, GLenum, GLint, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferuiv(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE1DPROC)(
+    GLuint, GLint, GLint, GLsizei, GLenum, GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTextureSubImage1D(
+    GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE2DPROC)(
+    GLuint, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLsizei,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTextureSubImage2D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE3DPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum,
+    GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTextureSubImage3D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format,
+    GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYNAMEDBUFFERSUBDATAPROC)(
+    GLuint, GLuint, GLintptr, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_CopyNamedBufferSubData(
+    GLuint readBuffer, GLuint writeBuffer, GLintptr readOffset,
+    GLintptr writeOffset, GLsizeiptr size);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXTURESUBIMAGE1DPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyTextureSubImage1D(
+    GLuint texture, GLint level, GLint xoffset, GLint x, GLint y,
+    GLsizei width);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXTURESUBIMAGE2DPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyTextureSubImage2D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+    GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXTURESUBIMAGE3DPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyTextureSubImage3D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLint x, GLint y, GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATEBUFFERSPROC)(GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_CreateBuffers(GLsizei n, GLuint *buffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATEFRAMEBUFFERSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateFramebuffers(GLsizei n, GLuint *framebuffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATEPROGRAMPIPELINESPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateProgramPipelines(GLsizei n, GLuint *pipelines);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATEQUERIESPROC)(
+    GLenum, GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateQueries(GLenum target, GLsizei n, GLuint *ids);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATERENDERBUFFERSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateRenderbuffers(GLsizei n, GLuint *renderbuffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATESAMPLERSPROC)(GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_CreateSamplers(GLsizei n, GLuint *samplers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATETEXTURESPROC)(
+    GLenum, GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateTextures(GLenum target, GLsizei n, GLuint *textures);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATETRANSFORMFEEDBACKSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateTransformFeedbacks(GLsizei n, GLuint *ids);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATEVERTEXARRAYSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_CreateVertexArrays(GLsizei n, GLuint *arrays);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDISABLEVERTEXARRAYATTRIBPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_DisableVertexArrayAttrib(GLuint vaobj, GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENABLEVERTEXARRAYATTRIBPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_EnableVertexArrayAttrib(GLuint vaobj, GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFLUSHMAPPEDNAMEDBUFFERRANGEPROC)(
+    GLuint, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_FlushMappedNamedBufferRange(
+    GLuint buffer, GLintptr offset, GLsizeiptr length);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENERATETEXTUREMIPMAPPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_GenerateTextureMipmap(GLuint texture);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETCOMPRESSEDTEXTUREIMAGEPROC)(
+    GLuint, GLint, GLsizei, void *);
+static void CODEGEN_FUNCPTR Switch_GetCompressedTextureImage(
+    GLuint texture, GLint level, GLsizei bufSize, void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDBUFFERPARAMETERI64VPROC)(
+    GLuint, GLenum, GLint64 *);
+static void CODEGEN_FUNCPTR Switch_GetNamedBufferParameteri64v(
+    GLuint buffer, GLenum pname, GLint64 *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDBUFFERPARAMETERIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetNamedBufferParameteriv(GLuint buffer, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDBUFFERPOINTERVPROC)(
+    GLuint, GLenum, void **);
+static void CODEGEN_FUNCPTR
+Switch_GetNamedBufferPointerv(GLuint buffer, GLenum pname, void **params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDBUFFERSUBDATAPROC)(
+    GLuint, GLintptr, GLsizeiptr, void *);
+static void CODEGEN_FUNCPTR Switch_GetNamedBufferSubData(
+    GLuint buffer, GLintptr offset, GLsizeiptr size, void *data);
+typedef void(
+    CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC)(
+    GLuint, GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetNamedFramebufferAttachmentParameteriv(
+    GLuint framebuffer, GLenum attachment, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDFRAMEBUFFERPARAMETERIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetNamedFramebufferParameteriv(
+    GLuint framebuffer, GLenum pname, GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNAMEDRENDERBUFFERPARAMETERIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetNamedRenderbufferParameteriv(
+    GLuint renderbuffer, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYBUFFEROBJECTI64VPROC)(
+    GLuint, GLuint, GLenum, GLintptr);
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjecti64v(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYBUFFEROBJECTIVPROC)(
+    GLuint, GLuint, GLenum, GLintptr);
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjectiv(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYBUFFEROBJECTUI64VPROC)(
+    GLuint, GLuint, GLenum, GLintptr);
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjectui64v(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYBUFFEROBJECTUIVPROC)(
+    GLuint, GLuint, GLenum, GLintptr);
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjectuiv(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTUREIMAGEPROC)(
+    GLuint, GLint, GLenum, GLenum, GLsizei, void *);
+static void CODEGEN_FUNCPTR Switch_GetTextureImage(
+    GLuint texture, GLint level, GLenum format, GLenum type, GLsizei bufSize,
+    void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTURELEVELPARAMETERFVPROC)(
+    GLuint, GLint, GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR Switch_GetTextureLevelParameterfv(
+    GLuint texture, GLint level, GLenum pname, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTURELEVELPARAMETERIVPROC)(
+    GLuint, GLint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetTextureLevelParameteriv(
+    GLuint texture, GLint level, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTUREPARAMETERIIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameterIiv(GLuint texture, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTUREPARAMETERIUIVPROC)(
+    GLuint, GLenum, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameterIuiv(GLuint texture, GLenum pname, GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTUREPARAMETERFVPROC)(
+    GLuint, GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameterfv(GLuint texture, GLenum pname, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTUREPARAMETERIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameteriv(GLuint texture, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTRANSFORMFEEDBACKI64_VPROC)(
+    GLuint, GLenum, GLuint, GLint64 *);
+static void CODEGEN_FUNCPTR Switch_GetTransformFeedbacki64_v(
+    GLuint xfb, GLenum pname, GLuint index, GLint64 *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTRANSFORMFEEDBACKI_VPROC)(
+    GLuint, GLenum, GLuint, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetTransformFeedbacki_v(
+    GLuint xfb, GLenum pname, GLuint index, GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTRANSFORMFEEDBACKIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTransformFeedbackiv(GLuint xfb, GLenum pname, GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXARRAYINDEXED64IVPROC)(
+    GLuint, GLuint, GLenum, GLint64 *);
+static void CODEGEN_FUNCPTR Switch_GetVertexArrayIndexed64iv(
+    GLuint vaobj, GLuint index, GLenum pname, GLint64 *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXARRAYINDEXEDIVPROC)(
+    GLuint, GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetVertexArrayIndexediv(
+    GLuint vaobj, GLuint index, GLenum pname, GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXARRAYIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexArrayiv(GLuint vaobj, GLenum pname, GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATENAMEDFRAMEBUFFERDATAPROC)(
+    GLuint, GLsizei, const GLenum *);
+static void CODEGEN_FUNCPTR Switch_InvalidateNamedFramebufferData(
+    GLuint framebuffer, GLsizei numAttachments, const GLenum *attachments);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLINVALIDATENAMEDFRAMEBUFFERSUBDATAPROC)(
+    GLuint, GLsizei, const GLenum *, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_InvalidateNamedFramebufferSubData(
+    GLuint framebuffer, GLsizei numAttachments, const GLenum *attachments,
+    GLint x, GLint y, GLsizei width, GLsizei height);
+typedef void *(CODEGEN_FUNCPTR *PFN_PTRC_GLMAPNAMEDBUFFERPROC)(GLuint, GLenum);
+static void *CODEGEN_FUNCPTR
+Switch_MapNamedBuffer(GLuint buffer, GLenum access);
+typedef void *(CODEGEN_FUNCPTR *PFN_PTRC_GLMAPNAMEDBUFFERRANGEPROC)(
+    GLuint, GLintptr, GLsizeiptr, GLbitfield);
+static void *CODEGEN_FUNCPTR Switch_MapNamedBufferRange(
+    GLuint buffer, GLintptr offset, GLsizeiptr length, GLbitfield access);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDBUFFERDATAPROC)(
+    GLuint, GLsizeiptr, const void *, GLenum);
+static void CODEGEN_FUNCPTR Switch_NamedBufferData(
+    GLuint buffer, GLsizeiptr size, const void *data, GLenum usage);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDBUFFERSTORAGEPROC)(
+    GLuint, GLsizeiptr, const void *, GLbitfield);
+static void CODEGEN_FUNCPTR Switch_NamedBufferStorage(
+    GLuint buffer, GLsizeiptr size, const void *data, GLbitfield flags);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDBUFFERSUBDATAPROC)(
+    GLuint, GLintptr, GLsizeiptr, const void *);
+static void CODEGEN_FUNCPTR Switch_NamedBufferSubData(
+    GLuint buffer, GLintptr offset, GLsizeiptr size, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERDRAWBUFFERPROC)(
+    GLuint, GLenum);
+static void CODEGEN_FUNCPTR
+Switch_NamedFramebufferDrawBuffer(GLuint framebuffer, GLenum buf);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERDRAWBUFFERSPROC)(
+    GLuint, GLsizei, const GLenum *);
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferDrawBuffers(
+    GLuint framebuffer, GLsizei n, const GLenum *bufs);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERPARAMETERIPROC)(
+    GLuint, GLenum, GLint);
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferParameteri(
+    GLuint framebuffer, GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERREADBUFFERPROC)(
+    GLuint, GLenum);
+static void CODEGEN_FUNCPTR
+Switch_NamedFramebufferReadBuffer(GLuint framebuffer, GLenum src);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERRENDERBUFFERPROC)(
+    GLuint, GLenum, GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferRenderbuffer(
+    GLuint framebuffer, GLenum attachment, GLenum renderbuffertarget,
+    GLuint renderbuffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERTEXTUREPROC)(
+    GLuint, GLenum, GLuint, GLint);
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferTexture(
+    GLuint framebuffer, GLenum attachment, GLuint texture, GLint level);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDFRAMEBUFFERTEXTURELAYERPROC)(
+    GLuint, GLenum, GLuint, GLint, GLint);
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferTextureLayer(
+    GLuint framebuffer, GLenum attachment, GLuint texture, GLint level,
+    GLint layer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDRENDERBUFFERSTORAGEPROC)(
+    GLuint, GLenum, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_NamedRenderbufferStorage(
+    GLuint renderbuffer, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void(
+    CODEGEN_FUNCPTR *PFN_PTRC_GLNAMEDRENDERBUFFERSTORAGEMULTISAMPLEPROC)(
+    GLuint, GLsizei, GLenum, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_NamedRenderbufferStorageMultisample(
+    GLuint renderbuffer, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREBUFFERPROC)(
+    GLuint, GLenum, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_TextureBuffer(GLuint texture, GLenum internalformat, GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREBUFFERRANGEPROC)(
+    GLuint, GLenum, GLuint, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_TextureBufferRange(
+    GLuint texture, GLenum internalformat, GLuint buffer, GLintptr offset,
+    GLsizeiptr size);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREPARAMETERIIVPROC)(
+    GLuint, GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterIiv(GLuint texture, GLenum pname, const GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREPARAMETERIUIVPROC)(
+    GLuint, GLenum, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterIuiv(GLuint texture, GLenum pname, const GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREPARAMETERFPROC)(
+    GLuint, GLenum, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterf(GLuint texture, GLenum pname, GLfloat param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREPARAMETERFVPROC)(
+    GLuint, GLenum, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterfv(GLuint texture, GLenum pname, const GLfloat *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREPARAMETERIPROC)(
+    GLuint, GLenum, GLint);
+static void CODEGEN_FUNCPTR
+Switch_TextureParameteri(GLuint texture, GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREPARAMETERIVPROC)(
+    GLuint, GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_TextureParameteriv(GLuint texture, GLenum pname, const GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESTORAGE1DPROC)(
+    GLuint, GLsizei, GLenum, GLsizei);
+static void CODEGEN_FUNCPTR Switch_TextureStorage1D(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESTORAGE2DPROC)(
+    GLuint, GLsizei, GLenum, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_TextureStorage2D(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESTORAGE2DMULTISAMPLEPROC)(
+    GLuint, GLsizei, GLenum, GLsizei, GLsizei, GLboolean);
+static void CODEGEN_FUNCPTR Switch_TextureStorage2DMultisample(
+    GLuint texture, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESTORAGE3DPROC)(
+    GLuint, GLsizei, GLenum, GLsizei, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_TextureStorage3D(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESTORAGE3DMULTISAMPLEPROC)(
+    GLuint, GLsizei, GLenum, GLsizei, GLsizei, GLsizei, GLboolean);
+static void CODEGEN_FUNCPTR Switch_TextureStorage3DMultisample(
+    GLuint texture, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESUBIMAGE1DPROC)(
+    GLuint, GLint, GLint, GLsizei, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_TextureSubImage1D(
+    GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLenum type, const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESUBIMAGE2DPROC)(
+    GLuint, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLenum,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_TextureSubImage2D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLenum type, const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTURESUBIMAGE3DPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum,
+    GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_TextureSubImage3D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTRANSFORMFEEDBACKBUFFERBASEPROC)(
+    GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_TransformFeedbackBufferBase(GLuint xfb, GLuint index, GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTRANSFORMFEEDBACKBUFFERRANGEPROC)(
+    GLuint, GLuint, GLuint, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_TransformFeedbackBufferRange(
+    GLuint xfb, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLUNMAPNAMEDBUFFERPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_UnmapNamedBuffer(GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYATTRIBBINDINGPROC)(
+    GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribBinding(
+    GLuint vaobj, GLuint attribindex, GLuint bindingindex);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYATTRIBFORMATPROC)(
+    GLuint, GLuint, GLint, GLenum, GLboolean, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribFormat(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLboolean normalized, GLuint relativeoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYATTRIBIFORMATPROC)(
+    GLuint, GLuint, GLint, GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribIFormat(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLuint relativeoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYATTRIBLFORMATPROC)(
+    GLuint, GLuint, GLint, GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribLFormat(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLuint relativeoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYBINDINGDIVISORPROC)(
+    GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexArrayBindingDivisor(
+    GLuint vaobj, GLuint bindingindex, GLuint divisor);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYELEMENTBUFFERPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexArrayElementBuffer(GLuint vaobj, GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYVERTEXBUFFERPROC)(
+    GLuint, GLuint, GLuint, GLintptr, GLsizei);
+static void CODEGEN_FUNCPTR Switch_VertexArrayVertexBuffer(
+    GLuint vaobj, GLuint bindingindex, GLuint buffer, GLintptr offset,
+    GLsizei stride);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXARRAYVERTEXBUFFERSPROC)(
+    GLuint, GLuint, GLsizei, const GLuint *, const GLintptr *, const GLsizei *);
+static void CODEGEN_FUNCPTR Switch_VertexArrayVertexBuffers(
+    GLuint vaobj, GLuint first, GLsizei count, const GLuint *buffers,
+    const GLintptr *offsets, const GLsizei *strides);
+
+/* Extension: ARB_get_texture_sub_image*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETCOMPRESSEDTEXTURESUBIMAGEPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLsizei,
+    void *);
+static void CODEGEN_FUNCPTR Switch_GetCompressedTextureSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLsizei bufSize,
+    void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXTURESUBIMAGEPROC)(
+    GLuint, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum,
+    GLenum, GLsizei, void *);
+static void CODEGEN_FUNCPTR Switch_GetTextureSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    GLsizei bufSize, void *pixels);
+
+/* Extension: ARB_texture_barrier*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXTUREBARRIERPROC)(void);
+static void CODEGEN_FUNCPTR Switch_TextureBarrier(void);
+
+/* Extension: KHR_robustness*/
+typedef GLenum(CODEGEN_FUNCPTR *PFN_PTRC_GLGETGRAPHICSRESETSTATUSPROC)(void);
+static GLenum CODEGEN_FUNCPTR Switch_GetGraphicsResetStatus(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNUNIFORMFVPROC)(
+    GLuint, GLint, GLsizei, GLfloat *);
+static void CODEGEN_FUNCPTR Switch_GetnUniformfv(
+    GLuint program, GLint location, GLsizei bufSize, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNUNIFORMIVPROC)(
+    GLuint, GLint, GLsizei, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetnUniformiv(
+    GLuint program, GLint location, GLsizei bufSize, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETNUNIFORMUIVPROC)(
+    GLuint, GLint, GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GetnUniformuiv(
+    GLuint program, GLint location, GLsizei bufSize, GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLREADNPIXELSPROC)(
+    GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, GLsizei, void *);
+static void CODEGEN_FUNCPTR Switch_ReadnPixels(
+    GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    GLsizei bufSize, void *data);
+
+/* Extension: 1.0*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBLENDFUNCPROC)(GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_BlendFunc(GLenum sfactor, GLenum dfactor);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARPROC)(GLbitfield);
+static void CODEGEN_FUNCPTR Switch_Clear(GLbitfield mask);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARCOLORPROC)(
+    GLfloat, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_ClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARDEPTHPROC)(GLdouble);
+static void CODEGEN_FUNCPTR Switch_ClearDepth(GLdouble depth);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARSTENCILPROC)(GLint);
+static void CODEGEN_FUNCPTR Switch_ClearStencil(GLint s);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOLORMASKPROC)(
+    GLboolean, GLboolean, GLboolean, GLboolean);
+static void CODEGEN_FUNCPTR Switch_ColorMask(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCULLFACEPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_CullFace(GLenum mode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEPTHFUNCPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_DepthFunc(GLenum func);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEPTHMASKPROC)(GLboolean);
+static void CODEGEN_FUNCPTR Switch_DepthMask(GLboolean flag);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDEPTHRANGEPROC)(GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR
+Switch_DepthRange(GLdouble ren_near, GLdouble ren_far);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDISABLEPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_Disable(GLenum cap);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWBUFFERPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_DrawBuffer(GLenum buf);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENABLEPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_Enable(GLenum cap);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFINISHPROC)(void);
+static void CODEGEN_FUNCPTR Switch_Finish(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFLUSHPROC)(void);
+static void CODEGEN_FUNCPTR Switch_Flush(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRONTFACEPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_FrontFace(GLenum mode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETBOOLEANVPROC)(GLenum, GLboolean *);
+static void CODEGEN_FUNCPTR Switch_GetBooleanv(GLenum pname, GLboolean *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETDOUBLEVPROC)(GLenum, GLdouble *);
+static void CODEGEN_FUNCPTR Switch_GetDoublev(GLenum pname, GLdouble *data);
+typedef GLenum(CODEGEN_FUNCPTR *PFN_PTRC_GLGETERRORPROC)(void);
+static GLenum CODEGEN_FUNCPTR Switch_GetError(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETFLOATVPROC)(GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR Switch_GetFloatv(GLenum pname, GLfloat *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETINTEGERVPROC)(GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetIntegerv(GLenum pname, GLint *data);
+typedef const GLubyte *(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSTRINGPROC)(GLenum);
+static const GLubyte *CODEGEN_FUNCPTR Switch_GetString(GLenum name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXIMAGEPROC)(
+    GLenum, GLint, GLenum, GLenum, void *);
+static void CODEGEN_FUNCPTR Switch_GetTexImage(
+    GLenum target, GLint level, GLenum format, GLenum type, void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXLEVELPARAMETERFVPROC)(
+    GLenum, GLint, GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR Switch_GetTexLevelParameterfv(
+    GLenum target, GLint level, GLenum pname, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXLEVELPARAMETERIVPROC)(
+    GLenum, GLint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetTexLevelParameteriv(
+    GLenum target, GLint level, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXPARAMETERFVPROC)(
+    GLenum, GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameterfv(GLenum target, GLenum pname, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXPARAMETERIVPROC)(
+    GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameteriv(GLenum target, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLHINTPROC)(GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_Hint(GLenum target, GLenum mode);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISENABLEDPROC)(GLenum);
+static GLboolean CODEGEN_FUNCPTR Switch_IsEnabled(GLenum cap);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLLINEWIDTHPROC)(GLfloat);
+static void CODEGEN_FUNCPTR Switch_LineWidth(GLfloat width);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLLOGICOPPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_LogicOp(GLenum opcode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPIXELSTOREFPROC)(GLenum, GLfloat);
+static void CODEGEN_FUNCPTR Switch_PixelStoref(GLenum pname, GLfloat param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPIXELSTOREIPROC)(GLenum, GLint);
+static void CODEGEN_FUNCPTR Switch_PixelStorei(GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOINTSIZEPROC)(GLfloat);
+static void CODEGEN_FUNCPTR Switch_PointSize(GLfloat size);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOLYGONMODEPROC)(GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_PolygonMode(GLenum face, GLenum mode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLREADBUFFERPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_ReadBuffer(GLenum src);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLREADPIXELSPROC)(
+    GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, void *);
+static void CODEGEN_FUNCPTR Switch_ReadPixels(
+    GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSCISSORPROC)(
+    GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR
+Switch_Scissor(GLint x, GLint y, GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSTENCILFUNCPROC)(
+    GLenum, GLint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_StencilFunc(GLenum func, GLint ref, GLuint mask);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSTENCILMASKPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_StencilMask(GLuint mask);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSTENCILOPPROC)(GLenum, GLenum, GLenum);
+static void CODEGEN_FUNCPTR
+Switch_StencilOp(GLenum fail, GLenum zfail, GLenum zpass);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXIMAGE1DPROC)(
+    GLenum, GLint, GLint, GLsizei, GLint, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_TexImage1D(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLint border, GLenum format, GLenum type, const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXIMAGE2DPROC)(
+    GLenum, GLint, GLint, GLsizei, GLsizei, GLint, GLenum, GLenum,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_TexImage2D(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLsizei height, GLint border, GLenum format, GLenum type,
+    const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXPARAMETERFPROC)(
+    GLenum, GLenum, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_TexParameterf(GLenum target, GLenum pname, GLfloat param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXPARAMETERFVPROC)(
+    GLenum, GLenum, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_TexParameterfv(GLenum target, GLenum pname, const GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXPARAMETERIPROC)(
+    GLenum, GLenum, GLint);
+static void CODEGEN_FUNCPTR
+Switch_TexParameteri(GLenum target, GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXPARAMETERIVPROC)(
+    GLenum, GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_TexParameteriv(GLenum target, GLenum pname, const GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVIEWPORTPROC)(
+    GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR
+Switch_Viewport(GLint x, GLint y, GLsizei width, GLsizei height);
+
+/* Extension: 1.1*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDTEXTUREPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_BindTexture(GLenum target, GLuint texture);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXIMAGE1DPROC)(
+    GLenum, GLint, GLenum, GLint, GLint, GLsizei, GLint);
+static void CODEGEN_FUNCPTR Switch_CopyTexImage1D(
+    GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+    GLsizei width, GLint border);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXIMAGE2DPROC)(
+    GLenum, GLint, GLenum, GLint, GLint, GLsizei, GLsizei, GLint);
+static void CODEGEN_FUNCPTR Switch_CopyTexImage2D(
+    GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+    GLsizei width, GLsizei height, GLint border);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXSUBIMAGE1DPROC)(
+    GLenum, GLint, GLint, GLint, GLint, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyTexSubImage1D(
+    GLenum target, GLint level, GLint xoffset, GLint x, GLint y, GLsizei width);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXSUBIMAGE2DPROC)(
+    GLenum, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyTexSubImage2D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+    GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETETEXTURESPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteTextures(GLsizei n, const GLuint *textures);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWARRAYSPROC)(
+    GLenum, GLint, GLsizei);
+static void CODEGEN_FUNCPTR
+Switch_DrawArrays(GLenum mode, GLint first, GLsizei count);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWELEMENTSPROC)(
+    GLenum, GLsizei, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_DrawElements(
+    GLenum mode, GLsizei count, GLenum type, const void *indices);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENTEXTURESPROC)(GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GenTextures(GLsizei n, GLuint *textures);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISTEXTUREPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsTexture(GLuint texture);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOLYGONOFFSETPROC)(GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR Switch_PolygonOffset(GLfloat factor, GLfloat units);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSUBIMAGE1DPROC)(
+    GLenum, GLint, GLint, GLsizei, GLenum, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_TexSubImage1D(
+    GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLenum type, const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSUBIMAGE2DPROC)(
+    GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLenum,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_TexSubImage2D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLenum type, const void *pixels);
+
+/* Extension: 1.2*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYTEXSUBIMAGE3DPROC)(
+    GLenum, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_CopyTexSubImage3D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLint x, GLint y, GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWRANGEELEMENTSPROC)(
+    GLenum, GLuint, GLuint, GLsizei, GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_DrawRangeElements(
+    GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type,
+    const void *indices);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXIMAGE3DPROC)(
+    GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_TexImage3D(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
+    const void *pixels);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXSUBIMAGE3DPROC)(
+    GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum,
+    GLenum, const void *);
+static void CODEGEN_FUNCPTR Switch_TexSubImage3D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *pixels);
+
+/* Extension: 1.3*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLACTIVETEXTUREPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_ActiveTexture(GLenum texture);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXIMAGE1DPROC)(
+    GLenum, GLint, GLenum, GLsizei, GLint, GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTexImage1D(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLint border, GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXIMAGE2DPROC)(
+    GLenum, GLint, GLenum, GLsizei, GLsizei, GLint, GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTexImage2D(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLsizei height, GLint border, GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXIMAGE3DPROC)(
+    GLenum, GLint, GLenum, GLsizei, GLsizei, GLsizei, GLint, GLsizei,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTexImage3D(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLint border, GLsizei imageSize,
+    const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE1DPROC)(
+    GLenum, GLint, GLint, GLsizei, GLenum, GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTexSubImage1D(
+    GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE2DPROC)(
+    GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLsizei,
+    const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTexSubImage2D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE3DPROC)(
+    GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum,
+    GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_CompressedTexSubImage3D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format,
+    GLsizei imageSize, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETCOMPRESSEDTEXIMAGEPROC)(
+    GLenum, GLint, void *);
+static void CODEGEN_FUNCPTR
+Switch_GetCompressedTexImage(GLenum target, GLint level, void *img);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLECOVERAGEPROC)(
+    GLfloat, GLboolean);
+static void CODEGEN_FUNCPTR
+Switch_SampleCoverage(GLfloat value, GLboolean invert);
+
+/* Extension: 1.4*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBLENDFUNCSEPARATEPROC)(
+    GLenum, GLenum, GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_BlendFuncSeparate(
+    GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha,
+    GLenum dfactorAlpha);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLMULTIDRAWARRAYSPROC)(
+    GLenum, const GLint *, const GLsizei *, GLsizei);
+static void CODEGEN_FUNCPTR Switch_MultiDrawArrays(
+    GLenum mode, const GLint *first, const GLsizei *count, GLsizei drawcount);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLMULTIDRAWELEMENTSPROC)(
+    GLenum, const GLsizei *, GLenum, const void *const *, GLsizei);
+static void CODEGEN_FUNCPTR Switch_MultiDrawElements(
+    GLenum mode, const GLsizei *count, GLenum type, const void *const *indices,
+    GLsizei drawcount);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOINTPARAMETERFPROC)(GLenum, GLfloat);
+static void CODEGEN_FUNCPTR Switch_PointParameterf(GLenum pname, GLfloat param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOINTPARAMETERFVPROC)(
+    GLenum, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_PointParameterfv(GLenum pname, const GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOINTPARAMETERIPROC)(GLenum, GLint);
+static void CODEGEN_FUNCPTR Switch_PointParameteri(GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPOINTPARAMETERIVPROC)(
+    GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_PointParameteriv(GLenum pname, const GLint *params);
+
+/* Extension: 1.5*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBEGINQUERYPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_BeginQuery(GLenum target, GLuint id);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDBUFFERPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_BindBuffer(GLenum target, GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBUFFERDATAPROC)(
+    GLenum, GLsizeiptr, const void *, GLenum);
+static void CODEGEN_FUNCPTR Switch_BufferData(
+    GLenum target, GLsizeiptr size, const void *data, GLenum usage);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBUFFERSUBDATAPROC)(
+    GLenum, GLintptr, GLsizeiptr, const void *);
+static void CODEGEN_FUNCPTR Switch_BufferSubData(
+    GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETEBUFFERSPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteBuffers(GLsizei n, const GLuint *buffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETEQUERIESPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_DeleteQueries(GLsizei n, const GLuint *ids);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENDQUERYPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_EndQuery(GLenum target);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENBUFFERSPROC)(GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GenBuffers(GLsizei n, GLuint *buffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENQUERIESPROC)(GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GenQueries(GLsizei n, GLuint *ids);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETBUFFERPARAMETERIVPROC)(
+    GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetBufferParameteriv(GLenum target, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETBUFFERPOINTERVPROC)(
+    GLenum, GLenum, void **);
+static void CODEGEN_FUNCPTR
+Switch_GetBufferPointerv(GLenum target, GLenum pname, void **params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETBUFFERSUBDATAPROC)(
+    GLenum, GLintptr, GLsizeiptr, void *);
+static void CODEGEN_FUNCPTR Switch_GetBufferSubData(
+    GLenum target, GLintptr offset, GLsizeiptr size, void *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYOBJECTIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjectiv(GLuint id, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYOBJECTUIVPROC)(
+    GLuint, GLenum, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjectuiv(GLuint id, GLenum pname, GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYIVPROC)(
+    GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetQueryiv(GLenum target, GLenum pname, GLint *params);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISBUFFERPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsBuffer(GLuint buffer);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISQUERYPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsQuery(GLuint id);
+typedef void *(CODEGEN_FUNCPTR *PFN_PTRC_GLMAPBUFFERPROC)(GLenum, GLenum);
+static void *CODEGEN_FUNCPTR Switch_MapBuffer(GLenum target, GLenum access);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLUNMAPBUFFERPROC)(GLenum);
+static GLboolean CODEGEN_FUNCPTR Switch_UnmapBuffer(GLenum target);
+
+/* Extension: 2.0*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLATTACHSHADERPROC)(GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_AttachShader(GLuint program, GLuint shader);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDATTRIBLOCATIONPROC)(
+    GLuint, GLuint, const GLchar *);
+static void CODEGEN_FUNCPTR
+Switch_BindAttribLocation(GLuint program, GLuint index, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBLENDEQUATIONSEPARATEPROC)(
+    GLenum, GLenum);
+static void CODEGEN_FUNCPTR
+Switch_BlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOMPILESHADERPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_CompileShader(GLuint shader);
+typedef GLuint(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATEPROGRAMPROC)(void);
+static GLuint CODEGEN_FUNCPTR Switch_CreateProgram(void);
+typedef GLuint(CODEGEN_FUNCPTR *PFN_PTRC_GLCREATESHADERPROC)(GLenum);
+static GLuint CODEGEN_FUNCPTR Switch_CreateShader(GLenum type);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETEPROGRAMPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_DeleteProgram(GLuint program);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETESHADERPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_DeleteShader(GLuint shader);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDETACHSHADERPROC)(GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_DetachShader(GLuint program, GLuint shader);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDISABLEVERTEXATTRIBARRAYPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_DisableVertexAttribArray(GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWBUFFERSPROC)(
+    GLsizei, const GLenum *);
+static void CODEGEN_FUNCPTR Switch_DrawBuffers(GLsizei n, const GLenum *bufs);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENABLEVERTEXATTRIBARRAYPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_EnableVertexAttribArray(GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETACTIVEATTRIBPROC)(
+    GLuint, GLuint, GLsizei, GLsizei *, GLint *, GLenum *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetActiveAttrib(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+    GLenum *type, GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETACTIVEUNIFORMPROC)(
+    GLuint, GLuint, GLsizei, GLsizei *, GLint *, GLenum *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetActiveUniform(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+    GLenum *type, GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETATTACHEDSHADERSPROC)(
+    GLuint, GLsizei, GLsizei *, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GetAttachedShaders(
+    GLuint program, GLsizei maxCount, GLsizei *count, GLuint *shaders);
+typedef GLint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETATTRIBLOCATIONPROC)(
+    GLuint, const GLchar *);
+static GLint CODEGEN_FUNCPTR
+Switch_GetAttribLocation(GLuint program, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMINFOLOGPROC)(
+    GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetProgramInfoLog(
+    GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETPROGRAMIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetProgramiv(GLuint program, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSHADERINFOLOGPROC)(
+    GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetShaderInfoLog(
+    GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSHADERSOURCEPROC)(
+    GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetShaderSource(
+    GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSHADERIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetShaderiv(GLuint shader, GLenum pname, GLint *params);
+typedef GLint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETUNIFORMLOCATIONPROC)(
+    GLuint, const GLchar *);
+static GLint CODEGEN_FUNCPTR
+Switch_GetUniformLocation(GLuint program, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETUNIFORMFVPROC)(
+    GLuint, GLint, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetUniformfv(GLuint program, GLint location, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETUNIFORMIVPROC)(
+    GLuint, GLint, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetUniformiv(GLuint program, GLint location, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXATTRIBPOINTERVPROC)(
+    GLuint, GLenum, void **);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribPointerv(GLuint index, GLenum pname, void **pointer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXATTRIBDVPROC)(
+    GLuint, GLenum, GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribdv(GLuint index, GLenum pname, GLdouble *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXATTRIBFVPROC)(
+    GLuint, GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribfv(GLuint index, GLenum pname, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXATTRIBIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribiv(GLuint index, GLenum pname, GLint *params);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISPROGRAMPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsProgram(GLuint program);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISSHADERPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsShader(GLuint shader);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLLINKPROGRAMPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_LinkProgram(GLuint program);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSHADERSOURCEPROC)(
+    GLuint, GLsizei, const GLchar *const *, const GLint *);
+static void CODEGEN_FUNCPTR Switch_ShaderSource(
+    GLuint shader, GLsizei count, const GLchar *const *string,
+    const GLint *length);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSTENCILFUNCSEPARATEPROC)(
+    GLenum, GLenum, GLint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_StencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSTENCILMASKSEPARATEPROC)(
+    GLenum, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_StencilMaskSeparate(GLenum face, GLuint mask);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSTENCILOPSEPARATEPROC)(
+    GLenum, GLenum, GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_StencilOpSeparate(
+    GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM1FPROC)(GLint, GLfloat);
+static void CODEGEN_FUNCPTR Switch_Uniform1f(GLint location, GLfloat v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM1FVPROC)(
+    GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform1fv(GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM1IPROC)(GLint, GLint);
+static void CODEGEN_FUNCPTR Switch_Uniform1i(GLint location, GLint v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM1IVPROC)(
+    GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform1iv(GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM2FPROC)(
+    GLint, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_Uniform2f(GLint location, GLfloat v0, GLfloat v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM2FVPROC)(
+    GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform2fv(GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM2IPROC)(GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_Uniform2i(GLint location, GLint v0, GLint v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM2IVPROC)(
+    GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform2iv(GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM3FPROC)(
+    GLint, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_Uniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM3FVPROC)(
+    GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform3fv(GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM3IPROC)(
+    GLint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_Uniform3i(GLint location, GLint v0, GLint v1, GLint v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM3IVPROC)(
+    GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform3iv(GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM4FPROC)(
+    GLint, GLfloat, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR Switch_Uniform4f(
+    GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM4FVPROC)(
+    GLint, GLsizei, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform4fv(GLint location, GLsizei count, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM4IPROC)(
+    GLint, GLint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_Uniform4i(GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM4IVPROC)(
+    GLint, GLsizei, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform4iv(GLint location, GLsizei count, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX2FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix2fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX3FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix3fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX4FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix4fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUSEPROGRAMPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_UseProgram(GLuint program);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVALIDATEPROGRAMPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_ValidateProgram(GLuint program);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB1DPROC)(GLuint, GLdouble);
+static void CODEGEN_FUNCPTR Switch_VertexAttrib1d(GLuint index, GLdouble x);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB1DVPROC)(
+    GLuint, const GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib1dv(GLuint index, const GLdouble *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB1FPROC)(GLuint, GLfloat);
+static void CODEGEN_FUNCPTR Switch_VertexAttrib1f(GLuint index, GLfloat x);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB1FVPROC)(
+    GLuint, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib1fv(GLuint index, const GLfloat *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB1SPROC)(GLuint, GLshort);
+static void CODEGEN_FUNCPTR Switch_VertexAttrib1s(GLuint index, GLshort x);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB1SVPROC)(
+    GLuint, const GLshort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib1sv(GLuint index, const GLshort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB2DPROC)(
+    GLuint, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2d(GLuint index, GLdouble x, GLdouble y);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB2DVPROC)(
+    GLuint, const GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2dv(GLuint index, const GLdouble *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB2FPROC)(
+    GLuint, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2f(GLuint index, GLfloat x, GLfloat y);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB2FVPROC)(
+    GLuint, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2fv(GLuint index, const GLfloat *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB2SPROC)(
+    GLuint, GLshort, GLshort);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2s(GLuint index, GLshort x, GLshort y);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB2SVPROC)(
+    GLuint, const GLshort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2sv(GLuint index, const GLshort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB3DPROC)(
+    GLuint, GLdouble, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3d(GLuint index, GLdouble x, GLdouble y, GLdouble z);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB3DVPROC)(
+    GLuint, const GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3dv(GLuint index, const GLdouble *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB3FPROC)(
+    GLuint, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3f(GLuint index, GLfloat x, GLfloat y, GLfloat z);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB3FVPROC)(
+    GLuint, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3fv(GLuint index, const GLfloat *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB3SPROC)(
+    GLuint, GLshort, GLshort, GLshort);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3s(GLuint index, GLshort x, GLshort y, GLshort z);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB3SVPROC)(
+    GLuint, const GLshort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3sv(GLuint index, const GLshort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NBVPROC)(
+    GLuint, const GLbyte *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nbv(GLuint index, const GLbyte *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NIVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Niv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NSVPROC)(
+    GLuint, const GLshort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nsv(GLuint index, const GLshort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NUBPROC)(
+    GLuint, GLubyte, GLubyte, GLubyte, GLubyte);
+static void CODEGEN_FUNCPTR Switch_VertexAttrib4Nub(
+    GLuint index, GLubyte x, GLubyte y, GLubyte z, GLubyte w);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NUBVPROC)(
+    GLuint, const GLubyte *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nubv(GLuint index, const GLubyte *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NUIVPROC)(
+    GLuint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nuiv(GLuint index, const GLuint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4NUSVPROC)(
+    GLuint, const GLushort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nusv(GLuint index, const GLushort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4BVPROC)(
+    GLuint, const GLbyte *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4bv(GLuint index, const GLbyte *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4DPROC)(
+    GLuint, GLdouble, GLdouble, GLdouble, GLdouble);
+static void CODEGEN_FUNCPTR Switch_VertexAttrib4d(
+    GLuint index, GLdouble x, GLdouble y, GLdouble z, GLdouble w);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4DVPROC)(
+    GLuint, const GLdouble *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4dv(GLuint index, const GLdouble *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4FPROC)(
+    GLuint, GLfloat, GLfloat, GLfloat, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4f(GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4FVPROC)(
+    GLuint, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4fv(GLuint index, const GLfloat *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4IVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4iv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4SPROC)(
+    GLuint, GLshort, GLshort, GLshort, GLshort);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4s(GLuint index, GLshort x, GLshort y, GLshort z, GLshort w);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4SVPROC)(
+    GLuint, const GLshort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4sv(GLuint index, const GLshort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4UBVPROC)(
+    GLuint, const GLubyte *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4ubv(GLuint index, const GLubyte *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4UIVPROC)(
+    GLuint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4uiv(GLuint index, const GLuint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIB4USVPROC)(
+    GLuint, const GLushort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4usv(GLuint index, const GLushort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBPOINTERPROC)(
+    GLuint, GLint, GLenum, GLboolean, GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_VertexAttribPointer(
+    GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride,
+    const void *pointer);
+
+/* Extension: 2.1*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX2X3FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix2x3fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX2X4FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix2x4fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX3X2FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix3x2fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX3X4FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix3x4fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX4X2FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix4x2fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMMATRIX4X3FVPROC)(
+    GLint, GLsizei, GLboolean, const GLfloat *);
+static void CODEGEN_FUNCPTR Switch_UniformMatrix4x3fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+
+/* Extension: 3.0*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBEGINCONDITIONALRENDERPROC)(
+    GLuint, GLenum);
+static void CODEGEN_FUNCPTR
+Switch_BeginConditionalRender(GLuint id, GLenum mode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBEGINTRANSFORMFEEDBACKPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_BeginTransformFeedback(GLenum primitiveMode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDBUFFERBASEPROC)(
+    GLenum, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_BindBufferBase(GLenum target, GLuint index, GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDBUFFERRANGEPROC)(
+    GLenum, GLuint, GLuint, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_BindBufferRange(
+    GLenum target, GLuint index, GLuint buffer, GLintptr offset,
+    GLsizeiptr size);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDFRAGDATALOCATIONPROC)(
+    GLuint, GLuint, const GLchar *);
+static void CODEGEN_FUNCPTR
+Switch_BindFragDataLocation(GLuint program, GLuint color, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDFRAMEBUFFERPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_BindFramebuffer(GLenum target, GLuint framebuffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDRENDERBUFFERPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_BindRenderbuffer(GLenum target, GLuint renderbuffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDVERTEXARRAYPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_BindVertexArray(GLuint ren_array);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBLITFRAMEBUFFERPROC)(
+    GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLbitfield, GLenum);
+static void CODEGEN_FUNCPTR Switch_BlitFramebuffer(
+    GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0,
+    GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+typedef GLenum(CODEGEN_FUNCPTR *PFN_PTRC_GLCHECKFRAMEBUFFERSTATUSPROC)(GLenum);
+static GLenum CODEGEN_FUNCPTR Switch_CheckFramebufferStatus(GLenum target);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLAMPCOLORPROC)(GLenum, GLenum);
+static void CODEGEN_FUNCPTR Switch_ClampColor(GLenum target, GLenum clamp);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARBUFFERFIPROC)(
+    GLenum, GLint, GLfloat, GLint);
+static void CODEGEN_FUNCPTR Switch_ClearBufferfi(
+    GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARBUFFERFVPROC)(
+    GLenum, GLint, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_ClearBufferfv(GLenum buffer, GLint drawbuffer, const GLfloat *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARBUFFERIVPROC)(
+    GLenum, GLint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_ClearBufferiv(GLenum buffer, GLint drawbuffer, const GLint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCLEARBUFFERUIVPROC)(
+    GLenum, GLint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_ClearBufferuiv(GLenum buffer, GLint drawbuffer, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOLORMASKIPROC)(
+    GLuint, GLboolean, GLboolean, GLboolean, GLboolean);
+static void CODEGEN_FUNCPTR Switch_ColorMaski(
+    GLuint index, GLboolean r, GLboolean g, GLboolean b, GLboolean a);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETEFRAMEBUFFERSPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteFramebuffers(GLsizei n, const GLuint *framebuffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETERENDERBUFFERSPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteRenderbuffers(GLsizei n, const GLuint *renderbuffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETEVERTEXARRAYSPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteVertexArrays(GLsizei n, const GLuint *arrays);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDISABLEIPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_Disablei(GLenum target, GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENABLEIPROC)(GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_Enablei(GLenum target, GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENDCONDITIONALRENDERPROC)(void);
+static void CODEGEN_FUNCPTR Switch_EndConditionalRender(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLENDTRANSFORMFEEDBACKPROC)(void);
+static void CODEGEN_FUNCPTR Switch_EndTransformFeedback(void);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFLUSHMAPPEDBUFFERRANGEPROC)(
+    GLenum, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_FlushMappedBufferRange(
+    GLenum target, GLintptr offset, GLsizeiptr length);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERRENDERBUFFERPROC)(
+    GLenum, GLenum, GLenum, GLuint);
+static void CODEGEN_FUNCPTR Switch_FramebufferRenderbuffer(
+    GLenum target, GLenum attachment, GLenum renderbuffertarget,
+    GLuint renderbuffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERTEXTURE1DPROC)(
+    GLenum, GLenum, GLenum, GLuint, GLint);
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture1D(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERTEXTURE2DPROC)(
+    GLenum, GLenum, GLenum, GLuint, GLint);
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture2D(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERTEXTURE3DPROC)(
+    GLenum, GLenum, GLenum, GLuint, GLint, GLint);
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture3D(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level, GLint zoffset);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERTEXTURELAYERPROC)(
+    GLenum, GLenum, GLuint, GLint, GLint);
+static void CODEGEN_FUNCPTR Switch_FramebufferTextureLayer(
+    GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENFRAMEBUFFERSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GenFramebuffers(GLsizei n, GLuint *framebuffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENRENDERBUFFERSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GenRenderbuffers(GLsizei n, GLuint *renderbuffers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENVERTEXARRAYSPROC)(
+    GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GenVertexArrays(GLsizei n, GLuint *arrays);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENERATEMIPMAPPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_GenerateMipmap(GLenum target);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETBOOLEANI_VPROC)(
+    GLenum, GLuint, GLboolean *);
+static void CODEGEN_FUNCPTR
+Switch_GetBooleani_v(GLenum target, GLuint index, GLboolean *data);
+typedef GLint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETFRAGDATALOCATIONPROC)(
+    GLuint, const GLchar *);
+static GLint CODEGEN_FUNCPTR
+Switch_GetFragDataLocation(GLuint program, const GLchar *name);
+typedef void(
+    CODEGEN_FUNCPTR *PFN_PTRC_GLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC)(
+    GLenum, GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetFramebufferAttachmentParameteriv(
+    GLenum target, GLenum attachment, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETINTEGERI_VPROC)(
+    GLenum, GLuint, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetIntegeri_v(GLenum target, GLuint index, GLint *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETRENDERBUFFERPARAMETERIVPROC)(
+    GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetRenderbufferParameteriv(GLenum target, GLenum pname, GLint *params);
+typedef const GLubyte *(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSTRINGIPROC)(
+    GLenum, GLuint);
+static const GLubyte *CODEGEN_FUNCPTR
+Switch_GetStringi(GLenum name, GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXPARAMETERIIVPROC)(
+    GLenum, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameterIiv(GLenum target, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTEXPARAMETERIUIVPROC)(
+    GLenum, GLenum, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameterIuiv(GLenum target, GLenum pname, GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETTRANSFORMFEEDBACKVARYINGPROC)(
+    GLuint, GLuint, GLsizei, GLsizei *, GLsizei *, GLenum *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetTransformFeedbackVarying(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length,
+    GLsizei *size, GLenum *type, GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETUNIFORMUIVPROC)(
+    GLuint, GLint, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GetUniformuiv(GLuint program, GLint location, GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXATTRIBIIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribIiv(GLuint index, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETVERTEXATTRIBIUIVPROC)(
+    GLuint, GLenum, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribIuiv(GLuint index, GLenum pname, GLuint *params);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISENABLEDIPROC)(GLenum, GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsEnabledi(GLenum target, GLuint index);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISFRAMEBUFFERPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsFramebuffer(GLuint framebuffer);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISRENDERBUFFERPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsRenderbuffer(GLuint renderbuffer);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISVERTEXARRAYPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsVertexArray(GLuint ren_array);
+typedef void *(CODEGEN_FUNCPTR *PFN_PTRC_GLMAPBUFFERRANGEPROC)(
+    GLenum, GLintptr, GLsizeiptr, GLbitfield);
+static void *CODEGEN_FUNCPTR Switch_MapBufferRange(
+    GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLRENDERBUFFERSTORAGEPROC)(
+    GLenum, GLenum, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_RenderbufferStorage(
+    GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLRENDERBUFFERSTORAGEMULTISAMPLEPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_RenderbufferStorageMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXPARAMETERIIVPROC)(
+    GLenum, GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_TexParameterIiv(GLenum target, GLenum pname, const GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXPARAMETERIUIVPROC)(
+    GLenum, GLenum, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_TexParameterIuiv(GLenum target, GLenum pname, const GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTRANSFORMFEEDBACKVARYINGSPROC)(
+    GLuint, GLsizei, const GLchar *const *, GLenum);
+static void CODEGEN_FUNCPTR Switch_TransformFeedbackVaryings(
+    GLuint program, GLsizei count, const GLchar *const *varyings,
+    GLenum bufferMode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM1UIPROC)(GLint, GLuint);
+static void CODEGEN_FUNCPTR Switch_Uniform1ui(GLint location, GLuint v0);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM1UIVPROC)(
+    GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform1uiv(GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM2UIPROC)(GLint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_Uniform2ui(GLint location, GLuint v0, GLuint v1);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM2UIVPROC)(
+    GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform2uiv(GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM3UIPROC)(
+    GLint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_Uniform3ui(GLint location, GLuint v0, GLuint v1, GLuint v2);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM3UIVPROC)(
+    GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform3uiv(GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM4UIPROC)(
+    GLint, GLuint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_Uniform4ui(GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORM4UIVPROC)(
+    GLint, GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_Uniform4uiv(GLint location, GLsizei count, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI1IPROC)(GLuint, GLint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribI1i(GLuint index, GLint x);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI1IVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI1iv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI1UIPROC)(GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribI1ui(GLuint index, GLuint x);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI1UIVPROC)(
+    GLuint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI1uiv(GLuint index, const GLuint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI2IPROC)(
+    GLuint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2i(GLuint index, GLint x, GLint y);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI2IVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2iv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI2UIPROC)(
+    GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2ui(GLuint index, GLuint x, GLuint y);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI2UIVPROC)(
+    GLuint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2uiv(GLuint index, const GLuint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI3IPROC)(
+    GLuint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3i(GLuint index, GLint x, GLint y, GLint z);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI3IVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3iv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI3UIPROC)(
+    GLuint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3ui(GLuint index, GLuint x, GLuint y, GLuint z);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI3UIVPROC)(
+    GLuint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3uiv(GLuint index, const GLuint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4BVPROC)(
+    GLuint, const GLbyte *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4bv(GLuint index, const GLbyte *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4IPROC)(
+    GLuint, GLint, GLint, GLint, GLint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4IVPROC)(
+    GLuint, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4iv(GLuint index, const GLint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4SVPROC)(
+    GLuint, const GLshort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4sv(GLuint index, const GLshort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4UBVPROC)(
+    GLuint, const GLubyte *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4ubv(GLuint index, const GLubyte *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4UIPROC)(
+    GLuint, GLuint, GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4UIVPROC)(
+    GLuint, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4uiv(GLuint index, const GLuint *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBI4USVPROC)(
+    GLuint, const GLushort *);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4usv(GLuint index, const GLushort *v);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBIPOINTERPROC)(
+    GLuint, GLint, GLenum, GLsizei, const void *);
+static void CODEGEN_FUNCPTR Switch_VertexAttribIPointer(
+    GLuint index, GLint size, GLenum type, GLsizei stride, const void *pointer);
+
+/* Extension: 3.1*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLCOPYBUFFERSUBDATAPROC)(
+    GLenum, GLenum, GLintptr, GLintptr, GLsizeiptr);
+static void CODEGEN_FUNCPTR Switch_CopyBufferSubData(
+    GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
+    GLintptr writeOffset, GLsizeiptr size);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWARRAYSINSTANCEDPROC)(
+    GLenum, GLint, GLsizei, GLsizei);
+static void CODEGEN_FUNCPTR Switch_DrawArraysInstanced(
+    GLenum mode, GLint first, GLsizei count, GLsizei instancecount);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWELEMENTSINSTANCEDPROC)(
+    GLenum, GLsizei, GLenum, const void *, GLsizei);
+static void CODEGEN_FUNCPTR Switch_DrawElementsInstanced(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLsizei instancecount);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETACTIVEUNIFORMBLOCKNAMEPROC)(
+    GLuint, GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformBlockName(
+    GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length,
+    GLchar *uniformBlockName);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETACTIVEUNIFORMBLOCKIVPROC)(
+    GLuint, GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformBlockiv(
+    GLuint program, GLuint uniformBlockIndex, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETACTIVEUNIFORMNAMEPROC)(
+    GLuint, GLuint, GLsizei, GLsizei *, GLchar *);
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformName(
+    GLuint program, GLuint uniformIndex, GLsizei bufSize, GLsizei *length,
+    GLchar *uniformName);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETACTIVEUNIFORMSIVPROC)(
+    GLuint, GLsizei, const GLuint *, GLenum, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformsiv(
+    GLuint program, GLsizei uniformCount, const GLuint *uniformIndices,
+    GLenum pname, GLint *params);
+typedef GLuint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETUNIFORMBLOCKINDEXPROC)(
+    GLuint, const GLchar *);
+static GLuint CODEGEN_FUNCPTR
+Switch_GetUniformBlockIndex(GLuint program, const GLchar *uniformBlockName);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETUNIFORMINDICESPROC)(
+    GLuint, GLsizei, const GLchar *const *, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GetUniformIndices(
+    GLuint program, GLsizei uniformCount, const GLchar *const *uniformNames,
+    GLuint *uniformIndices);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPRIMITIVERESTARTINDEXPROC)(GLuint);
+static void CODEGEN_FUNCPTR Switch_PrimitiveRestartIndex(GLuint index);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXBUFFERPROC)(GLenum, GLenum, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_TexBuffer(GLenum target, GLenum internalformat, GLuint buffer);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLUNIFORMBLOCKBINDINGPROC)(
+    GLuint, GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_UniformBlockBinding(
+    GLuint program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
+
+/* Extension: 3.2*/
+typedef GLenum(CODEGEN_FUNCPTR *PFN_PTRC_GLCLIENTWAITSYNCPROC)(
+    GLsync, GLbitfield, GLuint64);
+static GLenum CODEGEN_FUNCPTR
+Switch_ClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETESYNCPROC)(GLsync);
+static void CODEGEN_FUNCPTR Switch_DeleteSync(GLsync sync);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWELEMENTSBASEVERTEXPROC)(
+    GLenum, GLsizei, GLenum, const void *, GLint);
+static void CODEGEN_FUNCPTR Switch_DrawElementsBaseVertex(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLint basevertex);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWELEMENTSINSTANCEDBASEVERTEXPROC)(
+    GLenum, GLsizei, GLenum, const void *, GLsizei, GLint);
+static void CODEGEN_FUNCPTR Switch_DrawElementsInstancedBaseVertex(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLsizei instancecount, GLint basevertex);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDRAWRANGEELEMENTSBASEVERTEXPROC)(
+    GLenum, GLuint, GLuint, GLsizei, GLenum, const void *, GLint);
+static void CODEGEN_FUNCPTR Switch_DrawRangeElementsBaseVertex(
+    GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type,
+    const void *indices, GLint basevertex);
+typedef GLsync(CODEGEN_FUNCPTR *PFN_PTRC_GLFENCESYNCPROC)(GLenum, GLbitfield);
+static GLsync CODEGEN_FUNCPTR
+Switch_FenceSync(GLenum condition, GLbitfield flags);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLFRAMEBUFFERTEXTUREPROC)(
+    GLenum, GLenum, GLuint, GLint);
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture(
+    GLenum target, GLenum attachment, GLuint texture, GLint level);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETBUFFERPARAMETERI64VPROC)(
+    GLenum, GLenum, GLint64 *);
+static void CODEGEN_FUNCPTR
+Switch_GetBufferParameteri64v(GLenum target, GLenum pname, GLint64 *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETINTEGER64I_VPROC)(
+    GLenum, GLuint, GLint64 *);
+static void CODEGEN_FUNCPTR
+Switch_GetInteger64i_v(GLenum target, GLuint index, GLint64 *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETINTEGER64VPROC)(GLenum, GLint64 *);
+static void CODEGEN_FUNCPTR Switch_GetInteger64v(GLenum pname, GLint64 *data);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETMULTISAMPLEFVPROC)(
+    GLenum, GLuint, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetMultisamplefv(GLenum pname, GLuint index, GLfloat *val);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSYNCIVPROC)(
+    GLsync, GLenum, GLsizei, GLsizei *, GLint *);
+static void CODEGEN_FUNCPTR Switch_GetSynciv(
+    GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISSYNCPROC)(GLsync);
+static GLboolean CODEGEN_FUNCPTR Switch_IsSync(GLsync sync);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLMULTIDRAWELEMENTSBASEVERTEXPROC)(
+    GLenum, const GLsizei *, GLenum, const void *const *, GLsizei,
+    const GLint *);
+static void CODEGEN_FUNCPTR Switch_MultiDrawElementsBaseVertex(
+    GLenum mode, const GLsizei *count, GLenum type, const void *const *indices,
+    GLsizei drawcount, const GLint *basevertex);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLPROVOKINGVERTEXPROC)(GLenum);
+static void CODEGEN_FUNCPTR Switch_ProvokingVertex(GLenum mode);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLEMASKIPROC)(GLuint, GLbitfield);
+static void CODEGEN_FUNCPTR
+Switch_SampleMaski(GLuint maskNumber, GLbitfield mask);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXIMAGE2DMULTISAMPLEPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei, GLboolean);
+static void CODEGEN_FUNCPTR Switch_TexImage2DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLTEXIMAGE3DMULTISAMPLEPROC)(
+    GLenum, GLsizei, GLenum, GLsizei, GLsizei, GLsizei, GLboolean);
+static void CODEGEN_FUNCPTR Switch_TexImage3DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLWAITSYNCPROC)(
+    GLsync, GLbitfield, GLuint64);
+static void CODEGEN_FUNCPTR
+Switch_WaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout);
+
+/* Extension: 3.3*/
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDFRAGDATALOCATIONINDEXEDPROC)(
+    GLuint, GLuint, GLuint, const GLchar *);
+static void CODEGEN_FUNCPTR Switch_BindFragDataLocationIndexed(
+    GLuint program, GLuint colorNumber, GLuint index, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLBINDSAMPLERPROC)(GLuint, GLuint);
+static void CODEGEN_FUNCPTR Switch_BindSampler(GLuint unit, GLuint sampler);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLDELETESAMPLERSPROC)(
+    GLsizei, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_DeleteSamplers(GLsizei count, const GLuint *samplers);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGENSAMPLERSPROC)(GLsizei, GLuint *);
+static void CODEGEN_FUNCPTR Switch_GenSamplers(GLsizei count, GLuint *samplers);
+typedef GLint(CODEGEN_FUNCPTR *PFN_PTRC_GLGETFRAGDATAINDEXPROC)(
+    GLuint, const GLchar *);
+static GLint CODEGEN_FUNCPTR
+Switch_GetFragDataIndex(GLuint program, const GLchar *name);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYOBJECTI64VPROC)(
+    GLuint, GLenum, GLint64 *);
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjecti64v(GLuint id, GLenum pname, GLint64 *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETQUERYOBJECTUI64VPROC)(
+    GLuint, GLenum, GLuint64 *);
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjectui64v(GLuint id, GLenum pname, GLuint64 *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSAMPLERPARAMETERIIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameterIiv(GLuint sampler, GLenum pname, GLint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSAMPLERPARAMETERIUIVPROC)(
+    GLuint, GLenum, GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameterIuiv(GLuint sampler, GLenum pname, GLuint *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSAMPLERPARAMETERFVPROC)(
+    GLuint, GLenum, GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameterfv(GLuint sampler, GLenum pname, GLfloat *params);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLGETSAMPLERPARAMETERIVPROC)(
+    GLuint, GLenum, GLint *);
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameteriv(GLuint sampler, GLenum pname, GLint *params);
+typedef GLboolean(CODEGEN_FUNCPTR *PFN_PTRC_GLISSAMPLERPROC)(GLuint);
+static GLboolean CODEGEN_FUNCPTR Switch_IsSampler(GLuint sampler);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLQUERYCOUNTERPROC)(GLuint, GLenum);
+static void CODEGEN_FUNCPTR Switch_QueryCounter(GLuint id, GLenum target);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLERPARAMETERIIVPROC)(
+    GLuint, GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterIiv(GLuint sampler, GLenum pname, const GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLERPARAMETERIUIVPROC)(
+    GLuint, GLenum, const GLuint *);
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterIuiv(GLuint sampler, GLenum pname, const GLuint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLERPARAMETERFPROC)(
+    GLuint, GLenum, GLfloat);
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterf(GLuint sampler, GLenum pname, GLfloat param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLERPARAMETERFVPROC)(
+    GLuint, GLenum, const GLfloat *);
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterfv(GLuint sampler, GLenum pname, const GLfloat *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLERPARAMETERIPROC)(
+    GLuint, GLenum, GLint);
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameteri(GLuint sampler, GLenum pname, GLint param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLSAMPLERPARAMETERIVPROC)(
+    GLuint, GLenum, const GLint *);
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameteriv(GLuint sampler, GLenum pname, const GLint *param);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBDIVISORPROC)(
+    GLuint, GLuint);
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribDivisor(GLuint index, GLuint divisor);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP1UIPROC)(
+    GLuint, GLenum, GLboolean, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP1ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP1UIVPROC)(
+    GLuint, GLenum, GLboolean, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP1uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP2UIPROC)(
+    GLuint, GLenum, GLboolean, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP2ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP2UIVPROC)(
+    GLuint, GLenum, GLboolean, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP2uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP3UIPROC)(
+    GLuint, GLenum, GLboolean, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP3ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP3UIVPROC)(
+    GLuint, GLenum, GLboolean, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP3uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP4UIPROC)(
+    GLuint, GLenum, GLboolean, GLuint);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP4ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value);
+typedef void(CODEGEN_FUNCPTR *PFN_PTRC_GLVERTEXATTRIBP4UIVPROC)(
+    GLuint, GLenum, GLboolean, const GLuint *);
+static void CODEGEN_FUNCPTR Switch_VertexAttribP4uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value);
+
+/* Extension: ARB_ES2_compatibility*/
+PFN_PTRC_GLCLEARDEPTHFPROC _ptrc_glClearDepthf = Switch_ClearDepthf;
+PFN_PTRC_GLDEPTHRANGEFPROC _ptrc_glDepthRangef = Switch_DepthRangef;
+PFN_PTRC_GLGETSHADERPRECISIONFORMATPROC _ptrc_glGetShaderPrecisionFormat =
+    Switch_GetShaderPrecisionFormat;
+PFN_PTRC_GLRELEASESHADERCOMPILERPROC _ptrc_glReleaseShaderCompiler =
+    Switch_ReleaseShaderCompiler;
+PFN_PTRC_GLSHADERBINARYPROC _ptrc_glShaderBinary = Switch_ShaderBinary;
+
+/* Extension: ARB_get_program_binary*/
+PFN_PTRC_GLGETPROGRAMBINARYPROC _ptrc_glGetProgramBinary =
+    Switch_GetProgramBinary;
+PFN_PTRC_GLPROGRAMBINARYPROC _ptrc_glProgramBinary = Switch_ProgramBinary;
+PFN_PTRC_GLPROGRAMPARAMETERIPROC _ptrc_glProgramParameteri =
+    Switch_ProgramParameteri;
+
+/* Extension: ARB_internalformat_query*/
+PFN_PTRC_GLGETINTERNALFORMATIVPROC _ptrc_glGetInternalformativ =
+    Switch_GetInternalformativ;
+
+/* Extension: ARB_internalformat_query2*/
+PFN_PTRC_GLGETINTERNALFORMATI64VPROC _ptrc_glGetInternalformati64v =
+    Switch_GetInternalformati64v;
+
+/* Extension: ARB_program_interface_query*/
+PFN_PTRC_GLGETPROGRAMINTERFACEIVPROC _ptrc_glGetProgramInterfaceiv =
+    Switch_GetProgramInterfaceiv;
+PFN_PTRC_GLGETPROGRAMRESOURCEINDEXPROC _ptrc_glGetProgramResourceIndex =
+    Switch_GetProgramResourceIndex;
+PFN_PTRC_GLGETPROGRAMRESOURCELOCATIONPROC _ptrc_glGetProgramResourceLocation =
+    Switch_GetProgramResourceLocation;
+PFN_PTRC_GLGETPROGRAMRESOURCELOCATIONINDEXPROC
+_ptrc_glGetProgramResourceLocationIndex =
+    Switch_GetProgramResourceLocationIndex;
+PFN_PTRC_GLGETPROGRAMRESOURCENAMEPROC _ptrc_glGetProgramResourceName =
+    Switch_GetProgramResourceName;
+PFN_PTRC_GLGETPROGRAMRESOURCEIVPROC _ptrc_glGetProgramResourceiv =
+    Switch_GetProgramResourceiv;
+
+/* Extension: ARB_separate_shader_objects*/
+PFN_PTRC_GLACTIVESHADERPROGRAMPROC _ptrc_glActiveShaderProgram =
+    Switch_ActiveShaderProgram;
+PFN_PTRC_GLBINDPROGRAMPIPELINEPROC _ptrc_glBindProgramPipeline =
+    Switch_BindProgramPipeline;
+PFN_PTRC_GLCREATESHADERPROGRAMVPROC _ptrc_glCreateShaderProgramv =
+    Switch_CreateShaderProgramv;
+PFN_PTRC_GLDELETEPROGRAMPIPELINESPROC _ptrc_glDeleteProgramPipelines =
+    Switch_DeleteProgramPipelines;
+PFN_PTRC_GLGENPROGRAMPIPELINESPROC _ptrc_glGenProgramPipelines =
+    Switch_GenProgramPipelines;
+PFN_PTRC_GLGETPROGRAMPIPELINEINFOLOGPROC _ptrc_glGetProgramPipelineInfoLog =
+    Switch_GetProgramPipelineInfoLog;
+PFN_PTRC_GLGETPROGRAMPIPELINEIVPROC _ptrc_glGetProgramPipelineiv =
+    Switch_GetProgramPipelineiv;
+PFN_PTRC_GLISPROGRAMPIPELINEPROC _ptrc_glIsProgramPipeline =
+    Switch_IsProgramPipeline;
+PFN_PTRC_GLPROGRAMUNIFORM1DPROC _ptrc_glProgramUniform1d =
+    Switch_ProgramUniform1d;
+PFN_PTRC_GLPROGRAMUNIFORM1DVPROC _ptrc_glProgramUniform1dv =
+    Switch_ProgramUniform1dv;
+PFN_PTRC_GLPROGRAMUNIFORM1FPROC _ptrc_glProgramUniform1f =
+    Switch_ProgramUniform1f;
+PFN_PTRC_GLPROGRAMUNIFORM1FVPROC _ptrc_glProgramUniform1fv =
+    Switch_ProgramUniform1fv;
+PFN_PTRC_GLPROGRAMUNIFORM1IPROC _ptrc_glProgramUniform1i =
+    Switch_ProgramUniform1i;
+PFN_PTRC_GLPROGRAMUNIFORM1IVPROC _ptrc_glProgramUniform1iv =
+    Switch_ProgramUniform1iv;
+PFN_PTRC_GLPROGRAMUNIFORM1UIPROC _ptrc_glProgramUniform1ui =
+    Switch_ProgramUniform1ui;
+PFN_PTRC_GLPROGRAMUNIFORM1UIVPROC _ptrc_glProgramUniform1uiv =
+    Switch_ProgramUniform1uiv;
+PFN_PTRC_GLPROGRAMUNIFORM2DPROC _ptrc_glProgramUniform2d =
+    Switch_ProgramUniform2d;
+PFN_PTRC_GLPROGRAMUNIFORM2DVPROC _ptrc_glProgramUniform2dv =
+    Switch_ProgramUniform2dv;
+PFN_PTRC_GLPROGRAMUNIFORM2FPROC _ptrc_glProgramUniform2f =
+    Switch_ProgramUniform2f;
+PFN_PTRC_GLPROGRAMUNIFORM2FVPROC _ptrc_glProgramUniform2fv =
+    Switch_ProgramUniform2fv;
+PFN_PTRC_GLPROGRAMUNIFORM2IPROC _ptrc_glProgramUniform2i =
+    Switch_ProgramUniform2i;
+PFN_PTRC_GLPROGRAMUNIFORM2IVPROC _ptrc_glProgramUniform2iv =
+    Switch_ProgramUniform2iv;
+PFN_PTRC_GLPROGRAMUNIFORM2UIPROC _ptrc_glProgramUniform2ui =
+    Switch_ProgramUniform2ui;
+PFN_PTRC_GLPROGRAMUNIFORM2UIVPROC _ptrc_glProgramUniform2uiv =
+    Switch_ProgramUniform2uiv;
+PFN_PTRC_GLPROGRAMUNIFORM3DPROC _ptrc_glProgramUniform3d =
+    Switch_ProgramUniform3d;
+PFN_PTRC_GLPROGRAMUNIFORM3DVPROC _ptrc_glProgramUniform3dv =
+    Switch_ProgramUniform3dv;
+PFN_PTRC_GLPROGRAMUNIFORM3FPROC _ptrc_glProgramUniform3f =
+    Switch_ProgramUniform3f;
+PFN_PTRC_GLPROGRAMUNIFORM3FVPROC _ptrc_glProgramUniform3fv =
+    Switch_ProgramUniform3fv;
+PFN_PTRC_GLPROGRAMUNIFORM3IPROC _ptrc_glProgramUniform3i =
+    Switch_ProgramUniform3i;
+PFN_PTRC_GLPROGRAMUNIFORM3IVPROC _ptrc_glProgramUniform3iv =
+    Switch_ProgramUniform3iv;
+PFN_PTRC_GLPROGRAMUNIFORM3UIPROC _ptrc_glProgramUniform3ui =
+    Switch_ProgramUniform3ui;
+PFN_PTRC_GLPROGRAMUNIFORM3UIVPROC _ptrc_glProgramUniform3uiv =
+    Switch_ProgramUniform3uiv;
+PFN_PTRC_GLPROGRAMUNIFORM4DPROC _ptrc_glProgramUniform4d =
+    Switch_ProgramUniform4d;
+PFN_PTRC_GLPROGRAMUNIFORM4DVPROC _ptrc_glProgramUniform4dv =
+    Switch_ProgramUniform4dv;
+PFN_PTRC_GLPROGRAMUNIFORM4FPROC _ptrc_glProgramUniform4f =
+    Switch_ProgramUniform4f;
+PFN_PTRC_GLPROGRAMUNIFORM4FVPROC _ptrc_glProgramUniform4fv =
+    Switch_ProgramUniform4fv;
+PFN_PTRC_GLPROGRAMUNIFORM4IPROC _ptrc_glProgramUniform4i =
+    Switch_ProgramUniform4i;
+PFN_PTRC_GLPROGRAMUNIFORM4IVPROC _ptrc_glProgramUniform4iv =
+    Switch_ProgramUniform4iv;
+PFN_PTRC_GLPROGRAMUNIFORM4UIPROC _ptrc_glProgramUniform4ui =
+    Switch_ProgramUniform4ui;
+PFN_PTRC_GLPROGRAMUNIFORM4UIVPROC _ptrc_glProgramUniform4uiv =
+    Switch_ProgramUniform4uiv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX2DVPROC _ptrc_glProgramUniformMatrix2dv =
+    Switch_ProgramUniformMatrix2dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX2FVPROC _ptrc_glProgramUniformMatrix2fv =
+    Switch_ProgramUniformMatrix2fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X3DVPROC _ptrc_glProgramUniformMatrix2x3dv =
+    Switch_ProgramUniformMatrix2x3dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X3FVPROC _ptrc_glProgramUniformMatrix2x3fv =
+    Switch_ProgramUniformMatrix2x3fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X4DVPROC _ptrc_glProgramUniformMatrix2x4dv =
+    Switch_ProgramUniformMatrix2x4dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X4FVPROC _ptrc_glProgramUniformMatrix2x4fv =
+    Switch_ProgramUniformMatrix2x4fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX3DVPROC _ptrc_glProgramUniformMatrix3dv =
+    Switch_ProgramUniformMatrix3dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX3FVPROC _ptrc_glProgramUniformMatrix3fv =
+    Switch_ProgramUniformMatrix3fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X2DVPROC _ptrc_glProgramUniformMatrix3x2dv =
+    Switch_ProgramUniformMatrix3x2dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X2FVPROC _ptrc_glProgramUniformMatrix3x2fv =
+    Switch_ProgramUniformMatrix3x2fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X4DVPROC _ptrc_glProgramUniformMatrix3x4dv =
+    Switch_ProgramUniformMatrix3x4dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X4FVPROC _ptrc_glProgramUniformMatrix3x4fv =
+    Switch_ProgramUniformMatrix3x4fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX4DVPROC _ptrc_glProgramUniformMatrix4dv =
+    Switch_ProgramUniformMatrix4dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX4FVPROC _ptrc_glProgramUniformMatrix4fv =
+    Switch_ProgramUniformMatrix4fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X2DVPROC _ptrc_glProgramUniformMatrix4x2dv =
+    Switch_ProgramUniformMatrix4x2dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X2FVPROC _ptrc_glProgramUniformMatrix4x2fv =
+    Switch_ProgramUniformMatrix4x2fv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X3DVPROC _ptrc_glProgramUniformMatrix4x3dv =
+    Switch_ProgramUniformMatrix4x3dv;
+PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X3FVPROC _ptrc_glProgramUniformMatrix4x3fv =
+    Switch_ProgramUniformMatrix4x3fv;
+PFN_PTRC_GLUSEPROGRAMSTAGESPROC _ptrc_glUseProgramStages =
+    Switch_UseProgramStages;
+PFN_PTRC_GLVALIDATEPROGRAMPIPELINEPROC _ptrc_glValidateProgramPipeline =
+    Switch_ValidateProgramPipeline;
+
+/* Extension: ARB_texture_buffer_range*/
+PFN_PTRC_GLTEXBUFFERRANGEPROC _ptrc_glTexBufferRange = Switch_TexBufferRange;
+
+/* Extension: ARB_texture_storage*/
+PFN_PTRC_GLTEXSTORAGE1DPROC _ptrc_glTexStorage1D = Switch_TexStorage1D;
+PFN_PTRC_GLTEXSTORAGE2DPROC _ptrc_glTexStorage2D = Switch_TexStorage2D;
+PFN_PTRC_GLTEXSTORAGE3DPROC _ptrc_glTexStorage3D = Switch_TexStorage3D;
+
+/* Extension: ARB_texture_view*/
+PFN_PTRC_GLTEXTUREVIEWPROC _ptrc_glTextureView = Switch_TextureView;
+
+/* Extension: ARB_vertex_attrib_binding*/
+PFN_PTRC_GLBINDVERTEXBUFFERPROC _ptrc_glBindVertexBuffer =
+    Switch_BindVertexBuffer;
+PFN_PTRC_GLVERTEXATTRIBBINDINGPROC _ptrc_glVertexAttribBinding =
+    Switch_VertexAttribBinding;
+PFN_PTRC_GLVERTEXATTRIBFORMATPROC _ptrc_glVertexAttribFormat =
+    Switch_VertexAttribFormat;
+PFN_PTRC_GLVERTEXATTRIBIFORMATPROC _ptrc_glVertexAttribIFormat =
+    Switch_VertexAttribIFormat;
+PFN_PTRC_GLVERTEXATTRIBLFORMATPROC _ptrc_glVertexAttribLFormat =
+    Switch_VertexAttribLFormat;
+PFN_PTRC_GLVERTEXBINDINGDIVISORPROC _ptrc_glVertexBindingDivisor =
+    Switch_VertexBindingDivisor;
+
+/* Extension: ARB_viewport_array*/
+PFN_PTRC_GLDEPTHRANGEARRAYVPROC _ptrc_glDepthRangeArrayv =
+    Switch_DepthRangeArrayv;
+PFN_PTRC_GLDEPTHRANGEINDEXEDPROC _ptrc_glDepthRangeIndexed =
+    Switch_DepthRangeIndexed;
+PFN_PTRC_GLGETDOUBLEI_VPROC _ptrc_glGetDoublei_v = Switch_GetDoublei_v;
+PFN_PTRC_GLGETFLOATI_VPROC _ptrc_glGetFloati_v = Switch_GetFloati_v;
+PFN_PTRC_GLSCISSORARRAYVPROC _ptrc_glScissorArrayv = Switch_ScissorArrayv;
+PFN_PTRC_GLSCISSORINDEXEDPROC _ptrc_glScissorIndexed = Switch_ScissorIndexed;
+PFN_PTRC_GLSCISSORINDEXEDVPROC _ptrc_glScissorIndexedv = Switch_ScissorIndexedv;
+PFN_PTRC_GLVIEWPORTARRAYVPROC _ptrc_glViewportArrayv = Switch_ViewportArrayv;
+PFN_PTRC_GLVIEWPORTINDEXEDFPROC _ptrc_glViewportIndexedf =
+    Switch_ViewportIndexedf;
+PFN_PTRC_GLVIEWPORTINDEXEDFVPROC _ptrc_glViewportIndexedfv =
+    Switch_ViewportIndexedfv;
+
+/* Extension: ARB_clear_buffer_object*/
+PFN_PTRC_GLCLEARBUFFERDATAPROC _ptrc_glClearBufferData = Switch_ClearBufferData;
+PFN_PTRC_GLCLEARBUFFERSUBDATAPROC _ptrc_glClearBufferSubData =
+    Switch_ClearBufferSubData;
+
+/* Extension: ARB_copy_image*/
+PFN_PTRC_GLCOPYIMAGESUBDATAPROC _ptrc_glCopyImageSubData =
+    Switch_CopyImageSubData;
+
+/* Extension: ARB_framebuffer_no_attachments*/
+PFN_PTRC_GLFRAMEBUFFERPARAMETERIPROC _ptrc_glFramebufferParameteri =
+    Switch_FramebufferParameteri;
+PFN_PTRC_GLGETFRAMEBUFFERPARAMETERIVPROC _ptrc_glGetFramebufferParameteriv =
+    Switch_GetFramebufferParameteriv;
+
+/* Extension: ARB_invalidate_subdata*/
+PFN_PTRC_GLINVALIDATEBUFFERDATAPROC _ptrc_glInvalidateBufferData =
+    Switch_InvalidateBufferData;
+PFN_PTRC_GLINVALIDATEBUFFERSUBDATAPROC _ptrc_glInvalidateBufferSubData =
+    Switch_InvalidateBufferSubData;
+PFN_PTRC_GLINVALIDATEFRAMEBUFFERPROC _ptrc_glInvalidateFramebuffer =
+    Switch_InvalidateFramebuffer;
+PFN_PTRC_GLINVALIDATESUBFRAMEBUFFERPROC _ptrc_glInvalidateSubFramebuffer =
+    Switch_InvalidateSubFramebuffer;
+PFN_PTRC_GLINVALIDATETEXIMAGEPROC _ptrc_glInvalidateTexImage =
+    Switch_InvalidateTexImage;
+PFN_PTRC_GLINVALIDATETEXSUBIMAGEPROC _ptrc_glInvalidateTexSubImage =
+    Switch_InvalidateTexSubImage;
+
+/* Extension: ARB_texture_storage_multisample*/
+PFN_PTRC_GLTEXSTORAGE2DMULTISAMPLEPROC _ptrc_glTexStorage2DMultisample =
+    Switch_TexStorage2DMultisample;
+PFN_PTRC_GLTEXSTORAGE3DMULTISAMPLEPROC _ptrc_glTexStorage3DMultisample =
+    Switch_TexStorage3DMultisample;
+
+/* Extension: KHR_debug*/
+PFN_PTRC_GLDEBUGMESSAGECALLBACKPROC _ptrc_glDebugMessageCallback =
+    Switch_DebugMessageCallback;
+PFN_PTRC_GLDEBUGMESSAGECONTROLPROC _ptrc_glDebugMessageControl =
+    Switch_DebugMessageControl;
+PFN_PTRC_GLDEBUGMESSAGEINSERTPROC _ptrc_glDebugMessageInsert =
+    Switch_DebugMessageInsert;
+PFN_PTRC_GLGETDEBUGMESSAGELOGPROC _ptrc_glGetDebugMessageLog =
+    Switch_GetDebugMessageLog;
+PFN_PTRC_GLGETOBJECTLABELPROC _ptrc_glGetObjectLabel = Switch_GetObjectLabel;
+PFN_PTRC_GLGETOBJECTPTRLABELPROC _ptrc_glGetObjectPtrLabel =
+    Switch_GetObjectPtrLabel;
+PFN_PTRC_GLGETPOINTERVPROC _ptrc_glGetPointerv = Switch_GetPointerv;
+PFN_PTRC_GLOBJECTLABELPROC _ptrc_glObjectLabel = Switch_ObjectLabel;
+PFN_PTRC_GLOBJECTPTRLABELPROC _ptrc_glObjectPtrLabel = Switch_ObjectPtrLabel;
+PFN_PTRC_GLPOPDEBUGGROUPPROC _ptrc_glPopDebugGroup = Switch_PopDebugGroup;
+PFN_PTRC_GLPUSHDEBUGGROUPPROC _ptrc_glPushDebugGroup = Switch_PushDebugGroup;
+
+/* Extension: ARB_buffer_storage*/
+PFN_PTRC_GLBUFFERSTORAGEPROC _ptrc_glBufferStorage = Switch_BufferStorage;
+
+/* Extension: ARB_clear_texture*/
+PFN_PTRC_GLCLEARTEXIMAGEPROC _ptrc_glClearTexImage = Switch_ClearTexImage;
+PFN_PTRC_GLCLEARTEXSUBIMAGEPROC _ptrc_glClearTexSubImage =
+    Switch_ClearTexSubImage;
+
+/* Extension: ARB_multi_bind*/
+PFN_PTRC_GLBINDBUFFERSBASEPROC _ptrc_glBindBuffersBase = Switch_BindBuffersBase;
+PFN_PTRC_GLBINDBUFFERSRANGEPROC _ptrc_glBindBuffersRange =
+    Switch_BindBuffersRange;
+PFN_PTRC_GLBINDIMAGETEXTURESPROC _ptrc_glBindImageTextures =
+    Switch_BindImageTextures;
+PFN_PTRC_GLBINDSAMPLERSPROC _ptrc_glBindSamplers = Switch_BindSamplers;
+PFN_PTRC_GLBINDTEXTURESPROC _ptrc_glBindTextures = Switch_BindTextures;
+PFN_PTRC_GLBINDVERTEXBUFFERSPROC _ptrc_glBindVertexBuffers =
+    Switch_BindVertexBuffers;
+
+/* Extension: ARB_clip_control*/
+PFN_PTRC_GLCLIPCONTROLPROC _ptrc_glClipControl = Switch_ClipControl;
+
+/* Extension: ARB_direct_state_access*/
+PFN_PTRC_GLBINDTEXTUREUNITPROC _ptrc_glBindTextureUnit = Switch_BindTextureUnit;
+PFN_PTRC_GLBLITNAMEDFRAMEBUFFERPROC _ptrc_glBlitNamedFramebuffer =
+    Switch_BlitNamedFramebuffer;
+PFN_PTRC_GLCHECKNAMEDFRAMEBUFFERSTATUSPROC _ptrc_glCheckNamedFramebufferStatus =
+    Switch_CheckNamedFramebufferStatus;
+PFN_PTRC_GLCLEARNAMEDBUFFERDATAPROC _ptrc_glClearNamedBufferData =
+    Switch_ClearNamedBufferData;
+PFN_PTRC_GLCLEARNAMEDBUFFERSUBDATAPROC _ptrc_glClearNamedBufferSubData =
+    Switch_ClearNamedBufferSubData;
+PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERFIPROC _ptrc_glClearNamedFramebufferfi =
+    Switch_ClearNamedFramebufferfi;
+PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERFVPROC _ptrc_glClearNamedFramebufferfv =
+    Switch_ClearNamedFramebufferfv;
+PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERIVPROC _ptrc_glClearNamedFramebufferiv =
+    Switch_ClearNamedFramebufferiv;
+PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERUIVPROC _ptrc_glClearNamedFramebufferuiv =
+    Switch_ClearNamedFramebufferuiv;
+PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE1DPROC _ptrc_glCompressedTextureSubImage1D =
+    Switch_CompressedTextureSubImage1D;
+PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE2DPROC _ptrc_glCompressedTextureSubImage2D =
+    Switch_CompressedTextureSubImage2D;
+PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE3DPROC _ptrc_glCompressedTextureSubImage3D =
+    Switch_CompressedTextureSubImage3D;
+PFN_PTRC_GLCOPYNAMEDBUFFERSUBDATAPROC _ptrc_glCopyNamedBufferSubData =
+    Switch_CopyNamedBufferSubData;
+PFN_PTRC_GLCOPYTEXTURESUBIMAGE1DPROC _ptrc_glCopyTextureSubImage1D =
+    Switch_CopyTextureSubImage1D;
+PFN_PTRC_GLCOPYTEXTURESUBIMAGE2DPROC _ptrc_glCopyTextureSubImage2D =
+    Switch_CopyTextureSubImage2D;
+PFN_PTRC_GLCOPYTEXTURESUBIMAGE3DPROC _ptrc_glCopyTextureSubImage3D =
+    Switch_CopyTextureSubImage3D;
+PFN_PTRC_GLCREATEBUFFERSPROC _ptrc_glCreateBuffers = Switch_CreateBuffers;
+PFN_PTRC_GLCREATEFRAMEBUFFERSPROC _ptrc_glCreateFramebuffers =
+    Switch_CreateFramebuffers;
+PFN_PTRC_GLCREATEPROGRAMPIPELINESPROC _ptrc_glCreateProgramPipelines =
+    Switch_CreateProgramPipelines;
+PFN_PTRC_GLCREATEQUERIESPROC _ptrc_glCreateQueries = Switch_CreateQueries;
+PFN_PTRC_GLCREATERENDERBUFFERSPROC _ptrc_glCreateRenderbuffers =
+    Switch_CreateRenderbuffers;
+PFN_PTRC_GLCREATESAMPLERSPROC _ptrc_glCreateSamplers = Switch_CreateSamplers;
+PFN_PTRC_GLCREATETEXTURESPROC _ptrc_glCreateTextures = Switch_CreateTextures;
+PFN_PTRC_GLCREATETRANSFORMFEEDBACKSPROC _ptrc_glCreateTransformFeedbacks =
+    Switch_CreateTransformFeedbacks;
+PFN_PTRC_GLCREATEVERTEXARRAYSPROC _ptrc_glCreateVertexArrays =
+    Switch_CreateVertexArrays;
+PFN_PTRC_GLDISABLEVERTEXARRAYATTRIBPROC _ptrc_glDisableVertexArrayAttrib =
+    Switch_DisableVertexArrayAttrib;
+PFN_PTRC_GLENABLEVERTEXARRAYATTRIBPROC _ptrc_glEnableVertexArrayAttrib =
+    Switch_EnableVertexArrayAttrib;
+PFN_PTRC_GLFLUSHMAPPEDNAMEDBUFFERRANGEPROC _ptrc_glFlushMappedNamedBufferRange =
+    Switch_FlushMappedNamedBufferRange;
+PFN_PTRC_GLGENERATETEXTUREMIPMAPPROC _ptrc_glGenerateTextureMipmap =
+    Switch_GenerateTextureMipmap;
+PFN_PTRC_GLGETCOMPRESSEDTEXTUREIMAGEPROC _ptrc_glGetCompressedTextureImage =
+    Switch_GetCompressedTextureImage;
+PFN_PTRC_GLGETNAMEDBUFFERPARAMETERI64VPROC _ptrc_glGetNamedBufferParameteri64v =
+    Switch_GetNamedBufferParameteri64v;
+PFN_PTRC_GLGETNAMEDBUFFERPARAMETERIVPROC _ptrc_glGetNamedBufferParameteriv =
+    Switch_GetNamedBufferParameteriv;
+PFN_PTRC_GLGETNAMEDBUFFERPOINTERVPROC _ptrc_glGetNamedBufferPointerv =
+    Switch_GetNamedBufferPointerv;
+PFN_PTRC_GLGETNAMEDBUFFERSUBDATAPROC _ptrc_glGetNamedBufferSubData =
+    Switch_GetNamedBufferSubData;
+PFN_PTRC_GLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC
+_ptrc_glGetNamedFramebufferAttachmentParameteriv =
+    Switch_GetNamedFramebufferAttachmentParameteriv;
+PFN_PTRC_GLGETNAMEDFRAMEBUFFERPARAMETERIVPROC
+_ptrc_glGetNamedFramebufferParameteriv = Switch_GetNamedFramebufferParameteriv;
+PFN_PTRC_GLGETNAMEDRENDERBUFFERPARAMETERIVPROC
+_ptrc_glGetNamedRenderbufferParameteriv =
+    Switch_GetNamedRenderbufferParameteriv;
+PFN_PTRC_GLGETQUERYBUFFEROBJECTI64VPROC _ptrc_glGetQueryBufferObjecti64v =
+    Switch_GetQueryBufferObjecti64v;
+PFN_PTRC_GLGETQUERYBUFFEROBJECTIVPROC _ptrc_glGetQueryBufferObjectiv =
+    Switch_GetQueryBufferObjectiv;
+PFN_PTRC_GLGETQUERYBUFFEROBJECTUI64VPROC _ptrc_glGetQueryBufferObjectui64v =
+    Switch_GetQueryBufferObjectui64v;
+PFN_PTRC_GLGETQUERYBUFFEROBJECTUIVPROC _ptrc_glGetQueryBufferObjectuiv =
+    Switch_GetQueryBufferObjectuiv;
+PFN_PTRC_GLGETTEXTUREIMAGEPROC _ptrc_glGetTextureImage = Switch_GetTextureImage;
+PFN_PTRC_GLGETTEXTURELEVELPARAMETERFVPROC _ptrc_glGetTextureLevelParameterfv =
+    Switch_GetTextureLevelParameterfv;
+PFN_PTRC_GLGETTEXTURELEVELPARAMETERIVPROC _ptrc_glGetTextureLevelParameteriv =
+    Switch_GetTextureLevelParameteriv;
+PFN_PTRC_GLGETTEXTUREPARAMETERIIVPROC _ptrc_glGetTextureParameterIiv =
+    Switch_GetTextureParameterIiv;
+PFN_PTRC_GLGETTEXTUREPARAMETERIUIVPROC _ptrc_glGetTextureParameterIuiv =
+    Switch_GetTextureParameterIuiv;
+PFN_PTRC_GLGETTEXTUREPARAMETERFVPROC _ptrc_glGetTextureParameterfv =
+    Switch_GetTextureParameterfv;
+PFN_PTRC_GLGETTEXTUREPARAMETERIVPROC _ptrc_glGetTextureParameteriv =
+    Switch_GetTextureParameteriv;
+PFN_PTRC_GLGETTRANSFORMFEEDBACKI64_VPROC _ptrc_glGetTransformFeedbacki64_v =
+    Switch_GetTransformFeedbacki64_v;
+PFN_PTRC_GLGETTRANSFORMFEEDBACKI_VPROC _ptrc_glGetTransformFeedbacki_v =
+    Switch_GetTransformFeedbacki_v;
+PFN_PTRC_GLGETTRANSFORMFEEDBACKIVPROC _ptrc_glGetTransformFeedbackiv =
+    Switch_GetTransformFeedbackiv;
+PFN_PTRC_GLGETVERTEXARRAYINDEXED64IVPROC _ptrc_glGetVertexArrayIndexed64iv =
+    Switch_GetVertexArrayIndexed64iv;
+PFN_PTRC_GLGETVERTEXARRAYINDEXEDIVPROC _ptrc_glGetVertexArrayIndexediv =
+    Switch_GetVertexArrayIndexediv;
+PFN_PTRC_GLGETVERTEXARRAYIVPROC _ptrc_glGetVertexArrayiv =
+    Switch_GetVertexArrayiv;
+PFN_PTRC_GLINVALIDATENAMEDFRAMEBUFFERDATAPROC
+_ptrc_glInvalidateNamedFramebufferData = Switch_InvalidateNamedFramebufferData;
+PFN_PTRC_GLINVALIDATENAMEDFRAMEBUFFERSUBDATAPROC
+_ptrc_glInvalidateNamedFramebufferSubData =
+    Switch_InvalidateNamedFramebufferSubData;
+PFN_PTRC_GLMAPNAMEDBUFFERPROC _ptrc_glMapNamedBuffer = Switch_MapNamedBuffer;
+PFN_PTRC_GLMAPNAMEDBUFFERRANGEPROC _ptrc_glMapNamedBufferRange =
+    Switch_MapNamedBufferRange;
+PFN_PTRC_GLNAMEDBUFFERDATAPROC _ptrc_glNamedBufferData = Switch_NamedBufferData;
+PFN_PTRC_GLNAMEDBUFFERSTORAGEPROC _ptrc_glNamedBufferStorage =
+    Switch_NamedBufferStorage;
+PFN_PTRC_GLNAMEDBUFFERSUBDATAPROC _ptrc_glNamedBufferSubData =
+    Switch_NamedBufferSubData;
+PFN_PTRC_GLNAMEDFRAMEBUFFERDRAWBUFFERPROC _ptrc_glNamedFramebufferDrawBuffer =
+    Switch_NamedFramebufferDrawBuffer;
+PFN_PTRC_GLNAMEDFRAMEBUFFERDRAWBUFFERSPROC _ptrc_glNamedFramebufferDrawBuffers =
+    Switch_NamedFramebufferDrawBuffers;
+PFN_PTRC_GLNAMEDFRAMEBUFFERPARAMETERIPROC _ptrc_glNamedFramebufferParameteri =
+    Switch_NamedFramebufferParameteri;
+PFN_PTRC_GLNAMEDFRAMEBUFFERREADBUFFERPROC _ptrc_glNamedFramebufferReadBuffer =
+    Switch_NamedFramebufferReadBuffer;
+PFN_PTRC_GLNAMEDFRAMEBUFFERRENDERBUFFERPROC
+_ptrc_glNamedFramebufferRenderbuffer = Switch_NamedFramebufferRenderbuffer;
+PFN_PTRC_GLNAMEDFRAMEBUFFERTEXTUREPROC _ptrc_glNamedFramebufferTexture =
+    Switch_NamedFramebufferTexture;
+PFN_PTRC_GLNAMEDFRAMEBUFFERTEXTURELAYERPROC
+_ptrc_glNamedFramebufferTextureLayer = Switch_NamedFramebufferTextureLayer;
+PFN_PTRC_GLNAMEDRENDERBUFFERSTORAGEPROC _ptrc_glNamedRenderbufferStorage =
+    Switch_NamedRenderbufferStorage;
+PFN_PTRC_GLNAMEDRENDERBUFFERSTORAGEMULTISAMPLEPROC
+_ptrc_glNamedRenderbufferStorageMultisample =
+    Switch_NamedRenderbufferStorageMultisample;
+PFN_PTRC_GLTEXTUREBUFFERPROC _ptrc_glTextureBuffer = Switch_TextureBuffer;
+PFN_PTRC_GLTEXTUREBUFFERRANGEPROC _ptrc_glTextureBufferRange =
+    Switch_TextureBufferRange;
+PFN_PTRC_GLTEXTUREPARAMETERIIVPROC _ptrc_glTextureParameterIiv =
+    Switch_TextureParameterIiv;
+PFN_PTRC_GLTEXTUREPARAMETERIUIVPROC _ptrc_glTextureParameterIuiv =
+    Switch_TextureParameterIuiv;
+PFN_PTRC_GLTEXTUREPARAMETERFPROC _ptrc_glTextureParameterf =
+    Switch_TextureParameterf;
+PFN_PTRC_GLTEXTUREPARAMETERFVPROC _ptrc_glTextureParameterfv =
+    Switch_TextureParameterfv;
+PFN_PTRC_GLTEXTUREPARAMETERIPROC _ptrc_glTextureParameteri =
+    Switch_TextureParameteri;
+PFN_PTRC_GLTEXTUREPARAMETERIVPROC _ptrc_glTextureParameteriv =
+    Switch_TextureParameteriv;
+PFN_PTRC_GLTEXTURESTORAGE1DPROC _ptrc_glTextureStorage1D =
+    Switch_TextureStorage1D;
+PFN_PTRC_GLTEXTURESTORAGE2DPROC _ptrc_glTextureStorage2D =
+    Switch_TextureStorage2D;
+PFN_PTRC_GLTEXTURESTORAGE2DMULTISAMPLEPROC _ptrc_glTextureStorage2DMultisample =
+    Switch_TextureStorage2DMultisample;
+PFN_PTRC_GLTEXTURESTORAGE3DPROC _ptrc_glTextureStorage3D =
+    Switch_TextureStorage3D;
+PFN_PTRC_GLTEXTURESTORAGE3DMULTISAMPLEPROC _ptrc_glTextureStorage3DMultisample =
+    Switch_TextureStorage3DMultisample;
+PFN_PTRC_GLTEXTURESUBIMAGE1DPROC _ptrc_glTextureSubImage1D =
+    Switch_TextureSubImage1D;
+PFN_PTRC_GLTEXTURESUBIMAGE2DPROC _ptrc_glTextureSubImage2D =
+    Switch_TextureSubImage2D;
+PFN_PTRC_GLTEXTURESUBIMAGE3DPROC _ptrc_glTextureSubImage3D =
+    Switch_TextureSubImage3D;
+PFN_PTRC_GLTRANSFORMFEEDBACKBUFFERBASEPROC _ptrc_glTransformFeedbackBufferBase =
+    Switch_TransformFeedbackBufferBase;
+PFN_PTRC_GLTRANSFORMFEEDBACKBUFFERRANGEPROC
+_ptrc_glTransformFeedbackBufferRange = Switch_TransformFeedbackBufferRange;
+PFN_PTRC_GLUNMAPNAMEDBUFFERPROC _ptrc_glUnmapNamedBuffer =
+    Switch_UnmapNamedBuffer;
+PFN_PTRC_GLVERTEXARRAYATTRIBBINDINGPROC _ptrc_glVertexArrayAttribBinding =
+    Switch_VertexArrayAttribBinding;
+PFN_PTRC_GLVERTEXARRAYATTRIBFORMATPROC _ptrc_glVertexArrayAttribFormat =
+    Switch_VertexArrayAttribFormat;
+PFN_PTRC_GLVERTEXARRAYATTRIBIFORMATPROC _ptrc_glVertexArrayAttribIFormat =
+    Switch_VertexArrayAttribIFormat;
+PFN_PTRC_GLVERTEXARRAYATTRIBLFORMATPROC _ptrc_glVertexArrayAttribLFormat =
+    Switch_VertexArrayAttribLFormat;
+PFN_PTRC_GLVERTEXARRAYBINDINGDIVISORPROC _ptrc_glVertexArrayBindingDivisor =
+    Switch_VertexArrayBindingDivisor;
+PFN_PTRC_GLVERTEXARRAYELEMENTBUFFERPROC _ptrc_glVertexArrayElementBuffer =
+    Switch_VertexArrayElementBuffer;
+PFN_PTRC_GLVERTEXARRAYVERTEXBUFFERPROC _ptrc_glVertexArrayVertexBuffer =
+    Switch_VertexArrayVertexBuffer;
+PFN_PTRC_GLVERTEXARRAYVERTEXBUFFERSPROC _ptrc_glVertexArrayVertexBuffers =
+    Switch_VertexArrayVertexBuffers;
+
+/* Extension: ARB_get_texture_sub_image*/
+PFN_PTRC_GLGETCOMPRESSEDTEXTURESUBIMAGEPROC
+_ptrc_glGetCompressedTextureSubImage = Switch_GetCompressedTextureSubImage;
+PFN_PTRC_GLGETTEXTURESUBIMAGEPROC _ptrc_glGetTextureSubImage =
+    Switch_GetTextureSubImage;
+
+/* Extension: ARB_texture_barrier*/
+PFN_PTRC_GLTEXTUREBARRIERPROC _ptrc_glTextureBarrier = Switch_TextureBarrier;
+
+/* Extension: KHR_robustness*/
+PFN_PTRC_GLGETGRAPHICSRESETSTATUSPROC _ptrc_glGetGraphicsResetStatus =
+    Switch_GetGraphicsResetStatus;
+PFN_PTRC_GLGETNUNIFORMFVPROC _ptrc_glGetnUniformfv = Switch_GetnUniformfv;
+PFN_PTRC_GLGETNUNIFORMIVPROC _ptrc_glGetnUniformiv = Switch_GetnUniformiv;
+PFN_PTRC_GLGETNUNIFORMUIVPROC _ptrc_glGetnUniformuiv = Switch_GetnUniformuiv;
+PFN_PTRC_GLREADNPIXELSPROC _ptrc_glReadnPixels = Switch_ReadnPixels;
+
+/* Extension: 1.0*/
+PFN_PTRC_GLBLENDFUNCPROC _ptrc_glBlendFunc = Switch_BlendFunc;
+PFN_PTRC_GLCLEARPROC _ptrc_glClear = Switch_Clear;
+PFN_PTRC_GLCLEARCOLORPROC _ptrc_glClearColor = Switch_ClearColor;
+PFN_PTRC_GLCLEARDEPTHPROC _ptrc_glClearDepth = Switch_ClearDepth;
+PFN_PTRC_GLCLEARSTENCILPROC _ptrc_glClearStencil = Switch_ClearStencil;
+PFN_PTRC_GLCOLORMASKPROC _ptrc_glColorMask = Switch_ColorMask;
+PFN_PTRC_GLCULLFACEPROC _ptrc_glCullFace = Switch_CullFace;
+PFN_PTRC_GLDEPTHFUNCPROC _ptrc_glDepthFunc = Switch_DepthFunc;
+PFN_PTRC_GLDEPTHMASKPROC _ptrc_glDepthMask = Switch_DepthMask;
+PFN_PTRC_GLDEPTHRANGEPROC _ptrc_glDepthRange = Switch_DepthRange;
+PFN_PTRC_GLDISABLEPROC _ptrc_glDisable = Switch_Disable;
+PFN_PTRC_GLDRAWBUFFERPROC _ptrc_glDrawBuffer = Switch_DrawBuffer;
+PFN_PTRC_GLENABLEPROC _ptrc_glEnable = Switch_Enable;
+PFN_PTRC_GLFINISHPROC _ptrc_glFinish = Switch_Finish;
+PFN_PTRC_GLFLUSHPROC _ptrc_glFlush = Switch_Flush;
+PFN_PTRC_GLFRONTFACEPROC _ptrc_glFrontFace = Switch_FrontFace;
+PFN_PTRC_GLGETBOOLEANVPROC _ptrc_glGetBooleanv = Switch_GetBooleanv;
+PFN_PTRC_GLGETDOUBLEVPROC _ptrc_glGetDoublev = Switch_GetDoublev;
+PFN_PTRC_GLGETERRORPROC _ptrc_glGetError = Switch_GetError;
+PFN_PTRC_GLGETFLOATVPROC _ptrc_glGetFloatv = Switch_GetFloatv;
+PFN_PTRC_GLGETINTEGERVPROC _ptrc_glGetIntegerv = Switch_GetIntegerv;
+PFN_PTRC_GLGETSTRINGPROC _ptrc_glGetString = Switch_GetString;
+PFN_PTRC_GLGETTEXIMAGEPROC _ptrc_glGetTexImage = Switch_GetTexImage;
+PFN_PTRC_GLGETTEXLEVELPARAMETERFVPROC _ptrc_glGetTexLevelParameterfv =
+    Switch_GetTexLevelParameterfv;
+PFN_PTRC_GLGETTEXLEVELPARAMETERIVPROC _ptrc_glGetTexLevelParameteriv =
+    Switch_GetTexLevelParameteriv;
+PFN_PTRC_GLGETTEXPARAMETERFVPROC _ptrc_glGetTexParameterfv =
+    Switch_GetTexParameterfv;
+PFN_PTRC_GLGETTEXPARAMETERIVPROC _ptrc_glGetTexParameteriv =
+    Switch_GetTexParameteriv;
+PFN_PTRC_GLHINTPROC _ptrc_glHint = Switch_Hint;
+PFN_PTRC_GLISENABLEDPROC _ptrc_glIsEnabled = Switch_IsEnabled;
+PFN_PTRC_GLLINEWIDTHPROC _ptrc_glLineWidth = Switch_LineWidth;
+PFN_PTRC_GLLOGICOPPROC _ptrc_glLogicOp = Switch_LogicOp;
+PFN_PTRC_GLPIXELSTOREFPROC _ptrc_glPixelStoref = Switch_PixelStoref;
+PFN_PTRC_GLPIXELSTOREIPROC _ptrc_glPixelStorei = Switch_PixelStorei;
+PFN_PTRC_GLPOINTSIZEPROC _ptrc_glPointSize = Switch_PointSize;
+PFN_PTRC_GLPOLYGONMODEPROC _ptrc_glPolygonMode = Switch_PolygonMode;
+PFN_PTRC_GLREADBUFFERPROC _ptrc_glReadBuffer = Switch_ReadBuffer;
+PFN_PTRC_GLREADPIXELSPROC _ptrc_glReadPixels = Switch_ReadPixels;
+PFN_PTRC_GLSCISSORPROC _ptrc_glScissor = Switch_Scissor;
+PFN_PTRC_GLSTENCILFUNCPROC _ptrc_glStencilFunc = Switch_StencilFunc;
+PFN_PTRC_GLSTENCILMASKPROC _ptrc_glStencilMask = Switch_StencilMask;
+PFN_PTRC_GLSTENCILOPPROC _ptrc_glStencilOp = Switch_StencilOp;
+PFN_PTRC_GLTEXIMAGE1DPROC _ptrc_glTexImage1D = Switch_TexImage1D;
+PFN_PTRC_GLTEXIMAGE2DPROC _ptrc_glTexImage2D = Switch_TexImage2D;
+PFN_PTRC_GLTEXPARAMETERFPROC _ptrc_glTexParameterf = Switch_TexParameterf;
+PFN_PTRC_GLTEXPARAMETERFVPROC _ptrc_glTexParameterfv = Switch_TexParameterfv;
+PFN_PTRC_GLTEXPARAMETERIPROC _ptrc_glTexParameteri = Switch_TexParameteri;
+PFN_PTRC_GLTEXPARAMETERIVPROC _ptrc_glTexParameteriv = Switch_TexParameteriv;
+PFN_PTRC_GLVIEWPORTPROC _ptrc_glViewport = Switch_Viewport;
+
+/* Extension: 1.1*/
+PFN_PTRC_GLBINDTEXTUREPROC _ptrc_glBindTexture = Switch_BindTexture;
+PFN_PTRC_GLCOPYTEXIMAGE1DPROC _ptrc_glCopyTexImage1D = Switch_CopyTexImage1D;
+PFN_PTRC_GLCOPYTEXIMAGE2DPROC _ptrc_glCopyTexImage2D = Switch_CopyTexImage2D;
+PFN_PTRC_GLCOPYTEXSUBIMAGE1DPROC _ptrc_glCopyTexSubImage1D =
+    Switch_CopyTexSubImage1D;
+PFN_PTRC_GLCOPYTEXSUBIMAGE2DPROC _ptrc_glCopyTexSubImage2D =
+    Switch_CopyTexSubImage2D;
+PFN_PTRC_GLDELETETEXTURESPROC _ptrc_glDeleteTextures = Switch_DeleteTextures;
+PFN_PTRC_GLDRAWARRAYSPROC _ptrc_glDrawArrays = Switch_DrawArrays;
+PFN_PTRC_GLDRAWELEMENTSPROC _ptrc_glDrawElements = Switch_DrawElements;
+PFN_PTRC_GLGENTEXTURESPROC _ptrc_glGenTextures = Switch_GenTextures;
+PFN_PTRC_GLISTEXTUREPROC _ptrc_glIsTexture = Switch_IsTexture;
+PFN_PTRC_GLPOLYGONOFFSETPROC _ptrc_glPolygonOffset = Switch_PolygonOffset;
+PFN_PTRC_GLTEXSUBIMAGE1DPROC _ptrc_glTexSubImage1D = Switch_TexSubImage1D;
+PFN_PTRC_GLTEXSUBIMAGE2DPROC _ptrc_glTexSubImage2D = Switch_TexSubImage2D;
+
+/* Extension: 1.2*/
+PFN_PTRC_GLCOPYTEXSUBIMAGE3DPROC _ptrc_glCopyTexSubImage3D =
+    Switch_CopyTexSubImage3D;
+PFN_PTRC_GLDRAWRANGEELEMENTSPROC _ptrc_glDrawRangeElements =
+    Switch_DrawRangeElements;
+PFN_PTRC_GLTEXIMAGE3DPROC _ptrc_glTexImage3D = Switch_TexImage3D;
+PFN_PTRC_GLTEXSUBIMAGE3DPROC _ptrc_glTexSubImage3D = Switch_TexSubImage3D;
+
+/* Extension: 1.3*/
+PFN_PTRC_GLACTIVETEXTUREPROC _ptrc_glActiveTexture = Switch_ActiveTexture;
+PFN_PTRC_GLCOMPRESSEDTEXIMAGE1DPROC _ptrc_glCompressedTexImage1D =
+    Switch_CompressedTexImage1D;
+PFN_PTRC_GLCOMPRESSEDTEXIMAGE2DPROC _ptrc_glCompressedTexImage2D =
+    Switch_CompressedTexImage2D;
+PFN_PTRC_GLCOMPRESSEDTEXIMAGE3DPROC _ptrc_glCompressedTexImage3D =
+    Switch_CompressedTexImage3D;
+PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE1DPROC _ptrc_glCompressedTexSubImage1D =
+    Switch_CompressedTexSubImage1D;
+PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE2DPROC _ptrc_glCompressedTexSubImage2D =
+    Switch_CompressedTexSubImage2D;
+PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE3DPROC _ptrc_glCompressedTexSubImage3D =
+    Switch_CompressedTexSubImage3D;
+PFN_PTRC_GLGETCOMPRESSEDTEXIMAGEPROC _ptrc_glGetCompressedTexImage =
+    Switch_GetCompressedTexImage;
+PFN_PTRC_GLSAMPLECOVERAGEPROC _ptrc_glSampleCoverage = Switch_SampleCoverage;
+
+/* Extension: 1.4*/
+PFN_PTRC_GLBLENDFUNCSEPARATEPROC _ptrc_glBlendFuncSeparate =
+    Switch_BlendFuncSeparate;
+PFN_PTRC_GLMULTIDRAWARRAYSPROC _ptrc_glMultiDrawArrays = Switch_MultiDrawArrays;
+PFN_PTRC_GLMULTIDRAWELEMENTSPROC _ptrc_glMultiDrawElements =
+    Switch_MultiDrawElements;
+PFN_PTRC_GLPOINTPARAMETERFPROC _ptrc_glPointParameterf = Switch_PointParameterf;
+PFN_PTRC_GLPOINTPARAMETERFVPROC _ptrc_glPointParameterfv =
+    Switch_PointParameterfv;
+PFN_PTRC_GLPOINTPARAMETERIPROC _ptrc_glPointParameteri = Switch_PointParameteri;
+PFN_PTRC_GLPOINTPARAMETERIVPROC _ptrc_glPointParameteriv =
+    Switch_PointParameteriv;
+
+/* Extension: 1.5*/
+PFN_PTRC_GLBEGINQUERYPROC _ptrc_glBeginQuery = Switch_BeginQuery;
+PFN_PTRC_GLBINDBUFFERPROC _ptrc_glBindBuffer = Switch_BindBuffer;
+PFN_PTRC_GLBUFFERDATAPROC _ptrc_glBufferData = Switch_BufferData;
+PFN_PTRC_GLBUFFERSUBDATAPROC _ptrc_glBufferSubData = Switch_BufferSubData;
+PFN_PTRC_GLDELETEBUFFERSPROC _ptrc_glDeleteBuffers = Switch_DeleteBuffers;
+PFN_PTRC_GLDELETEQUERIESPROC _ptrc_glDeleteQueries = Switch_DeleteQueries;
+PFN_PTRC_GLENDQUERYPROC _ptrc_glEndQuery = Switch_EndQuery;
+PFN_PTRC_GLGENBUFFERSPROC _ptrc_glGenBuffers = Switch_GenBuffers;
+PFN_PTRC_GLGENQUERIESPROC _ptrc_glGenQueries = Switch_GenQueries;
+PFN_PTRC_GLGETBUFFERPARAMETERIVPROC _ptrc_glGetBufferParameteriv =
+    Switch_GetBufferParameteriv;
+PFN_PTRC_GLGETBUFFERPOINTERVPROC _ptrc_glGetBufferPointerv =
+    Switch_GetBufferPointerv;
+PFN_PTRC_GLGETBUFFERSUBDATAPROC _ptrc_glGetBufferSubData =
+    Switch_GetBufferSubData;
+PFN_PTRC_GLGETQUERYOBJECTIVPROC _ptrc_glGetQueryObjectiv =
+    Switch_GetQueryObjectiv;
+PFN_PTRC_GLGETQUERYOBJECTUIVPROC _ptrc_glGetQueryObjectuiv =
+    Switch_GetQueryObjectuiv;
+PFN_PTRC_GLGETQUERYIVPROC _ptrc_glGetQueryiv = Switch_GetQueryiv;
+PFN_PTRC_GLISBUFFERPROC _ptrc_glIsBuffer = Switch_IsBuffer;
+PFN_PTRC_GLISQUERYPROC _ptrc_glIsQuery = Switch_IsQuery;
+PFN_PTRC_GLMAPBUFFERPROC _ptrc_glMapBuffer = Switch_MapBuffer;
+PFN_PTRC_GLUNMAPBUFFERPROC _ptrc_glUnmapBuffer = Switch_UnmapBuffer;
+
+/* Extension: 2.0*/
+PFN_PTRC_GLATTACHSHADERPROC _ptrc_glAttachShader = Switch_AttachShader;
+PFN_PTRC_GLBINDATTRIBLOCATIONPROC _ptrc_glBindAttribLocation =
+    Switch_BindAttribLocation;
+PFN_PTRC_GLBLENDEQUATIONSEPARATEPROC _ptrc_glBlendEquationSeparate =
+    Switch_BlendEquationSeparate;
+PFN_PTRC_GLCOMPILESHADERPROC _ptrc_glCompileShader = Switch_CompileShader;
+PFN_PTRC_GLCREATEPROGRAMPROC _ptrc_glCreateProgram = Switch_CreateProgram;
+PFN_PTRC_GLCREATESHADERPROC _ptrc_glCreateShader = Switch_CreateShader;
+PFN_PTRC_GLDELETEPROGRAMPROC _ptrc_glDeleteProgram = Switch_DeleteProgram;
+PFN_PTRC_GLDELETESHADERPROC _ptrc_glDeleteShader = Switch_DeleteShader;
+PFN_PTRC_GLDETACHSHADERPROC _ptrc_glDetachShader = Switch_DetachShader;
+PFN_PTRC_GLDISABLEVERTEXATTRIBARRAYPROC _ptrc_glDisableVertexAttribArray =
+    Switch_DisableVertexAttribArray;
+PFN_PTRC_GLDRAWBUFFERSPROC _ptrc_glDrawBuffers = Switch_DrawBuffers;
+PFN_PTRC_GLENABLEVERTEXATTRIBARRAYPROC _ptrc_glEnableVertexAttribArray =
+    Switch_EnableVertexAttribArray;
+PFN_PTRC_GLGETACTIVEATTRIBPROC _ptrc_glGetActiveAttrib = Switch_GetActiveAttrib;
+PFN_PTRC_GLGETACTIVEUNIFORMPROC _ptrc_glGetActiveUniform =
+    Switch_GetActiveUniform;
+PFN_PTRC_GLGETATTACHEDSHADERSPROC _ptrc_glGetAttachedShaders =
+    Switch_GetAttachedShaders;
+PFN_PTRC_GLGETATTRIBLOCATIONPROC _ptrc_glGetAttribLocation =
+    Switch_GetAttribLocation;
+PFN_PTRC_GLGETPROGRAMINFOLOGPROC _ptrc_glGetProgramInfoLog =
+    Switch_GetProgramInfoLog;
+PFN_PTRC_GLGETPROGRAMIVPROC _ptrc_glGetProgramiv = Switch_GetProgramiv;
+PFN_PTRC_GLGETSHADERINFOLOGPROC _ptrc_glGetShaderInfoLog =
+    Switch_GetShaderInfoLog;
+PFN_PTRC_GLGETSHADERSOURCEPROC _ptrc_glGetShaderSource = Switch_GetShaderSource;
+PFN_PTRC_GLGETSHADERIVPROC _ptrc_glGetShaderiv = Switch_GetShaderiv;
+PFN_PTRC_GLGETUNIFORMLOCATIONPROC _ptrc_glGetUniformLocation =
+    Switch_GetUniformLocation;
+PFN_PTRC_GLGETUNIFORMFVPROC _ptrc_glGetUniformfv = Switch_GetUniformfv;
+PFN_PTRC_GLGETUNIFORMIVPROC _ptrc_glGetUniformiv = Switch_GetUniformiv;
+PFN_PTRC_GLGETVERTEXATTRIBPOINTERVPROC _ptrc_glGetVertexAttribPointerv =
+    Switch_GetVertexAttribPointerv;
+PFN_PTRC_GLGETVERTEXATTRIBDVPROC _ptrc_glGetVertexAttribdv =
+    Switch_GetVertexAttribdv;
+PFN_PTRC_GLGETVERTEXATTRIBFVPROC _ptrc_glGetVertexAttribfv =
+    Switch_GetVertexAttribfv;
+PFN_PTRC_GLGETVERTEXATTRIBIVPROC _ptrc_glGetVertexAttribiv =
+    Switch_GetVertexAttribiv;
+PFN_PTRC_GLISPROGRAMPROC _ptrc_glIsProgram = Switch_IsProgram;
+PFN_PTRC_GLISSHADERPROC _ptrc_glIsShader = Switch_IsShader;
+PFN_PTRC_GLLINKPROGRAMPROC _ptrc_glLinkProgram = Switch_LinkProgram;
+PFN_PTRC_GLSHADERSOURCEPROC _ptrc_glShaderSource = Switch_ShaderSource;
+PFN_PTRC_GLSTENCILFUNCSEPARATEPROC _ptrc_glStencilFuncSeparate =
+    Switch_StencilFuncSeparate;
+PFN_PTRC_GLSTENCILMASKSEPARATEPROC _ptrc_glStencilMaskSeparate =
+    Switch_StencilMaskSeparate;
+PFN_PTRC_GLSTENCILOPSEPARATEPROC _ptrc_glStencilOpSeparate =
+    Switch_StencilOpSeparate;
+PFN_PTRC_GLUNIFORM1FPROC _ptrc_glUniform1f = Switch_Uniform1f;
+PFN_PTRC_GLUNIFORM1FVPROC _ptrc_glUniform1fv = Switch_Uniform1fv;
+PFN_PTRC_GLUNIFORM1IPROC _ptrc_glUniform1i = Switch_Uniform1i;
+PFN_PTRC_GLUNIFORM1IVPROC _ptrc_glUniform1iv = Switch_Uniform1iv;
+PFN_PTRC_GLUNIFORM2FPROC _ptrc_glUniform2f = Switch_Uniform2f;
+PFN_PTRC_GLUNIFORM2FVPROC _ptrc_glUniform2fv = Switch_Uniform2fv;
+PFN_PTRC_GLUNIFORM2IPROC _ptrc_glUniform2i = Switch_Uniform2i;
+PFN_PTRC_GLUNIFORM2IVPROC _ptrc_glUniform2iv = Switch_Uniform2iv;
+PFN_PTRC_GLUNIFORM3FPROC _ptrc_glUniform3f = Switch_Uniform3f;
+PFN_PTRC_GLUNIFORM3FVPROC _ptrc_glUniform3fv = Switch_Uniform3fv;
+PFN_PTRC_GLUNIFORM3IPROC _ptrc_glUniform3i = Switch_Uniform3i;
+PFN_PTRC_GLUNIFORM3IVPROC _ptrc_glUniform3iv = Switch_Uniform3iv;
+PFN_PTRC_GLUNIFORM4FPROC _ptrc_glUniform4f = Switch_Uniform4f;
+PFN_PTRC_GLUNIFORM4FVPROC _ptrc_glUniform4fv = Switch_Uniform4fv;
+PFN_PTRC_GLUNIFORM4IPROC _ptrc_glUniform4i = Switch_Uniform4i;
+PFN_PTRC_GLUNIFORM4IVPROC _ptrc_glUniform4iv = Switch_Uniform4iv;
+PFN_PTRC_GLUNIFORMMATRIX2FVPROC _ptrc_glUniformMatrix2fv =
+    Switch_UniformMatrix2fv;
+PFN_PTRC_GLUNIFORMMATRIX3FVPROC _ptrc_glUniformMatrix3fv =
+    Switch_UniformMatrix3fv;
+PFN_PTRC_GLUNIFORMMATRIX4FVPROC _ptrc_glUniformMatrix4fv =
+    Switch_UniformMatrix4fv;
+PFN_PTRC_GLUSEPROGRAMPROC _ptrc_glUseProgram = Switch_UseProgram;
+PFN_PTRC_GLVALIDATEPROGRAMPROC _ptrc_glValidateProgram = Switch_ValidateProgram;
+PFN_PTRC_GLVERTEXATTRIB1DPROC _ptrc_glVertexAttrib1d = Switch_VertexAttrib1d;
+PFN_PTRC_GLVERTEXATTRIB1DVPROC _ptrc_glVertexAttrib1dv = Switch_VertexAttrib1dv;
+PFN_PTRC_GLVERTEXATTRIB1FPROC _ptrc_glVertexAttrib1f = Switch_VertexAttrib1f;
+PFN_PTRC_GLVERTEXATTRIB1FVPROC _ptrc_glVertexAttrib1fv = Switch_VertexAttrib1fv;
+PFN_PTRC_GLVERTEXATTRIB1SPROC _ptrc_glVertexAttrib1s = Switch_VertexAttrib1s;
+PFN_PTRC_GLVERTEXATTRIB1SVPROC _ptrc_glVertexAttrib1sv = Switch_VertexAttrib1sv;
+PFN_PTRC_GLVERTEXATTRIB2DPROC _ptrc_glVertexAttrib2d = Switch_VertexAttrib2d;
+PFN_PTRC_GLVERTEXATTRIB2DVPROC _ptrc_glVertexAttrib2dv = Switch_VertexAttrib2dv;
+PFN_PTRC_GLVERTEXATTRIB2FPROC _ptrc_glVertexAttrib2f = Switch_VertexAttrib2f;
+PFN_PTRC_GLVERTEXATTRIB2FVPROC _ptrc_glVertexAttrib2fv = Switch_VertexAttrib2fv;
+PFN_PTRC_GLVERTEXATTRIB2SPROC _ptrc_glVertexAttrib2s = Switch_VertexAttrib2s;
+PFN_PTRC_GLVERTEXATTRIB2SVPROC _ptrc_glVertexAttrib2sv = Switch_VertexAttrib2sv;
+PFN_PTRC_GLVERTEXATTRIB3DPROC _ptrc_glVertexAttrib3d = Switch_VertexAttrib3d;
+PFN_PTRC_GLVERTEXATTRIB3DVPROC _ptrc_glVertexAttrib3dv = Switch_VertexAttrib3dv;
+PFN_PTRC_GLVERTEXATTRIB3FPROC _ptrc_glVertexAttrib3f = Switch_VertexAttrib3f;
+PFN_PTRC_GLVERTEXATTRIB3FVPROC _ptrc_glVertexAttrib3fv = Switch_VertexAttrib3fv;
+PFN_PTRC_GLVERTEXATTRIB3SPROC _ptrc_glVertexAttrib3s = Switch_VertexAttrib3s;
+PFN_PTRC_GLVERTEXATTRIB3SVPROC _ptrc_glVertexAttrib3sv = Switch_VertexAttrib3sv;
+PFN_PTRC_GLVERTEXATTRIB4NBVPROC _ptrc_glVertexAttrib4Nbv =
+    Switch_VertexAttrib4Nbv;
+PFN_PTRC_GLVERTEXATTRIB4NIVPROC _ptrc_glVertexAttrib4Niv =
+    Switch_VertexAttrib4Niv;
+PFN_PTRC_GLVERTEXATTRIB4NSVPROC _ptrc_glVertexAttrib4Nsv =
+    Switch_VertexAttrib4Nsv;
+PFN_PTRC_GLVERTEXATTRIB4NUBPROC _ptrc_glVertexAttrib4Nub =
+    Switch_VertexAttrib4Nub;
+PFN_PTRC_GLVERTEXATTRIB4NUBVPROC _ptrc_glVertexAttrib4Nubv =
+    Switch_VertexAttrib4Nubv;
+PFN_PTRC_GLVERTEXATTRIB4NUIVPROC _ptrc_glVertexAttrib4Nuiv =
+    Switch_VertexAttrib4Nuiv;
+PFN_PTRC_GLVERTEXATTRIB4NUSVPROC _ptrc_glVertexAttrib4Nusv =
+    Switch_VertexAttrib4Nusv;
+PFN_PTRC_GLVERTEXATTRIB4BVPROC _ptrc_glVertexAttrib4bv = Switch_VertexAttrib4bv;
+PFN_PTRC_GLVERTEXATTRIB4DPROC _ptrc_glVertexAttrib4d = Switch_VertexAttrib4d;
+PFN_PTRC_GLVERTEXATTRIB4DVPROC _ptrc_glVertexAttrib4dv = Switch_VertexAttrib4dv;
+PFN_PTRC_GLVERTEXATTRIB4FPROC _ptrc_glVertexAttrib4f = Switch_VertexAttrib4f;
+PFN_PTRC_GLVERTEXATTRIB4FVPROC _ptrc_glVertexAttrib4fv = Switch_VertexAttrib4fv;
+PFN_PTRC_GLVERTEXATTRIB4IVPROC _ptrc_glVertexAttrib4iv = Switch_VertexAttrib4iv;
+PFN_PTRC_GLVERTEXATTRIB4SPROC _ptrc_glVertexAttrib4s = Switch_VertexAttrib4s;
+PFN_PTRC_GLVERTEXATTRIB4SVPROC _ptrc_glVertexAttrib4sv = Switch_VertexAttrib4sv;
+PFN_PTRC_GLVERTEXATTRIB4UBVPROC _ptrc_glVertexAttrib4ubv =
+    Switch_VertexAttrib4ubv;
+PFN_PTRC_GLVERTEXATTRIB4UIVPROC _ptrc_glVertexAttrib4uiv =
+    Switch_VertexAttrib4uiv;
+PFN_PTRC_GLVERTEXATTRIB4USVPROC _ptrc_glVertexAttrib4usv =
+    Switch_VertexAttrib4usv;
+PFN_PTRC_GLVERTEXATTRIBPOINTERPROC _ptrc_glVertexAttribPointer =
+    Switch_VertexAttribPointer;
+
+/* Extension: 2.1*/
+PFN_PTRC_GLUNIFORMMATRIX2X3FVPROC _ptrc_glUniformMatrix2x3fv =
+    Switch_UniformMatrix2x3fv;
+PFN_PTRC_GLUNIFORMMATRIX2X4FVPROC _ptrc_glUniformMatrix2x4fv =
+    Switch_UniformMatrix2x4fv;
+PFN_PTRC_GLUNIFORMMATRIX3X2FVPROC _ptrc_glUniformMatrix3x2fv =
+    Switch_UniformMatrix3x2fv;
+PFN_PTRC_GLUNIFORMMATRIX3X4FVPROC _ptrc_glUniformMatrix3x4fv =
+    Switch_UniformMatrix3x4fv;
+PFN_PTRC_GLUNIFORMMATRIX4X2FVPROC _ptrc_glUniformMatrix4x2fv =
+    Switch_UniformMatrix4x2fv;
+PFN_PTRC_GLUNIFORMMATRIX4X3FVPROC _ptrc_glUniformMatrix4x3fv =
+    Switch_UniformMatrix4x3fv;
+
+/* Extension: 3.0*/
+PFN_PTRC_GLBEGINCONDITIONALRENDERPROC _ptrc_glBeginConditionalRender =
+    Switch_BeginConditionalRender;
+PFN_PTRC_GLBEGINTRANSFORMFEEDBACKPROC _ptrc_glBeginTransformFeedback =
+    Switch_BeginTransformFeedback;
+PFN_PTRC_GLBINDBUFFERBASEPROC _ptrc_glBindBufferBase = Switch_BindBufferBase;
+PFN_PTRC_GLBINDBUFFERRANGEPROC _ptrc_glBindBufferRange = Switch_BindBufferRange;
+PFN_PTRC_GLBINDFRAGDATALOCATIONPROC _ptrc_glBindFragDataLocation =
+    Switch_BindFragDataLocation;
+PFN_PTRC_GLBINDFRAMEBUFFERPROC _ptrc_glBindFramebuffer = Switch_BindFramebuffer;
+PFN_PTRC_GLBINDRENDERBUFFERPROC _ptrc_glBindRenderbuffer =
+    Switch_BindRenderbuffer;
+PFN_PTRC_GLBINDVERTEXARRAYPROC _ptrc_glBindVertexArray = Switch_BindVertexArray;
+PFN_PTRC_GLBLITFRAMEBUFFERPROC _ptrc_glBlitFramebuffer = Switch_BlitFramebuffer;
+PFN_PTRC_GLCHECKFRAMEBUFFERSTATUSPROC _ptrc_glCheckFramebufferStatus =
+    Switch_CheckFramebufferStatus;
+PFN_PTRC_GLCLAMPCOLORPROC _ptrc_glClampColor = Switch_ClampColor;
+PFN_PTRC_GLCLEARBUFFERFIPROC _ptrc_glClearBufferfi = Switch_ClearBufferfi;
+PFN_PTRC_GLCLEARBUFFERFVPROC _ptrc_glClearBufferfv = Switch_ClearBufferfv;
+PFN_PTRC_GLCLEARBUFFERIVPROC _ptrc_glClearBufferiv = Switch_ClearBufferiv;
+PFN_PTRC_GLCLEARBUFFERUIVPROC _ptrc_glClearBufferuiv = Switch_ClearBufferuiv;
+PFN_PTRC_GLCOLORMASKIPROC _ptrc_glColorMaski = Switch_ColorMaski;
+PFN_PTRC_GLDELETEFRAMEBUFFERSPROC _ptrc_glDeleteFramebuffers =
+    Switch_DeleteFramebuffers;
+PFN_PTRC_GLDELETERENDERBUFFERSPROC _ptrc_glDeleteRenderbuffers =
+    Switch_DeleteRenderbuffers;
+PFN_PTRC_GLDELETEVERTEXARRAYSPROC _ptrc_glDeleteVertexArrays =
+    Switch_DeleteVertexArrays;
+PFN_PTRC_GLDISABLEIPROC _ptrc_glDisablei = Switch_Disablei;
+PFN_PTRC_GLENABLEIPROC _ptrc_glEnablei = Switch_Enablei;
+PFN_PTRC_GLENDCONDITIONALRENDERPROC _ptrc_glEndConditionalRender =
+    Switch_EndConditionalRender;
+PFN_PTRC_GLENDTRANSFORMFEEDBACKPROC _ptrc_glEndTransformFeedback =
+    Switch_EndTransformFeedback;
+PFN_PTRC_GLFLUSHMAPPEDBUFFERRANGEPROC _ptrc_glFlushMappedBufferRange =
+    Switch_FlushMappedBufferRange;
+PFN_PTRC_GLFRAMEBUFFERRENDERBUFFERPROC _ptrc_glFramebufferRenderbuffer =
+    Switch_FramebufferRenderbuffer;
+PFN_PTRC_GLFRAMEBUFFERTEXTURE1DPROC _ptrc_glFramebufferTexture1D =
+    Switch_FramebufferTexture1D;
+PFN_PTRC_GLFRAMEBUFFERTEXTURE2DPROC _ptrc_glFramebufferTexture2D =
+    Switch_FramebufferTexture2D;
+PFN_PTRC_GLFRAMEBUFFERTEXTURE3DPROC _ptrc_glFramebufferTexture3D =
+    Switch_FramebufferTexture3D;
+PFN_PTRC_GLFRAMEBUFFERTEXTURELAYERPROC _ptrc_glFramebufferTextureLayer =
+    Switch_FramebufferTextureLayer;
+PFN_PTRC_GLGENFRAMEBUFFERSPROC _ptrc_glGenFramebuffers = Switch_GenFramebuffers;
+PFN_PTRC_GLGENRENDERBUFFERSPROC _ptrc_glGenRenderbuffers =
+    Switch_GenRenderbuffers;
+PFN_PTRC_GLGENVERTEXARRAYSPROC _ptrc_glGenVertexArrays = Switch_GenVertexArrays;
+PFN_PTRC_GLGENERATEMIPMAPPROC _ptrc_glGenerateMipmap = Switch_GenerateMipmap;
+PFN_PTRC_GLGETBOOLEANI_VPROC _ptrc_glGetBooleani_v = Switch_GetBooleani_v;
+PFN_PTRC_GLGETFRAGDATALOCATIONPROC _ptrc_glGetFragDataLocation =
+    Switch_GetFragDataLocation;
+PFN_PTRC_GLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC
+_ptrc_glGetFramebufferAttachmentParameteriv =
+    Switch_GetFramebufferAttachmentParameteriv;
+PFN_PTRC_GLGETINTEGERI_VPROC _ptrc_glGetIntegeri_v = Switch_GetIntegeri_v;
+PFN_PTRC_GLGETRENDERBUFFERPARAMETERIVPROC _ptrc_glGetRenderbufferParameteriv =
+    Switch_GetRenderbufferParameteriv;
+PFN_PTRC_GLGETSTRINGIPROC _ptrc_glGetStringi = Switch_GetStringi;
+PFN_PTRC_GLGETTEXPARAMETERIIVPROC _ptrc_glGetTexParameterIiv =
+    Switch_GetTexParameterIiv;
+PFN_PTRC_GLGETTEXPARAMETERIUIVPROC _ptrc_glGetTexParameterIuiv =
+    Switch_GetTexParameterIuiv;
+PFN_PTRC_GLGETTRANSFORMFEEDBACKVARYINGPROC _ptrc_glGetTransformFeedbackVarying =
+    Switch_GetTransformFeedbackVarying;
+PFN_PTRC_GLGETUNIFORMUIVPROC _ptrc_glGetUniformuiv = Switch_GetUniformuiv;
+PFN_PTRC_GLGETVERTEXATTRIBIIVPROC _ptrc_glGetVertexAttribIiv =
+    Switch_GetVertexAttribIiv;
+PFN_PTRC_GLGETVERTEXATTRIBIUIVPROC _ptrc_glGetVertexAttribIuiv =
+    Switch_GetVertexAttribIuiv;
+PFN_PTRC_GLISENABLEDIPROC _ptrc_glIsEnabledi = Switch_IsEnabledi;
+PFN_PTRC_GLISFRAMEBUFFERPROC _ptrc_glIsFramebuffer = Switch_IsFramebuffer;
+PFN_PTRC_GLISRENDERBUFFERPROC _ptrc_glIsRenderbuffer = Switch_IsRenderbuffer;
+PFN_PTRC_GLISVERTEXARRAYPROC _ptrc_glIsVertexArray = Switch_IsVertexArray;
+PFN_PTRC_GLMAPBUFFERRANGEPROC _ptrc_glMapBufferRange = Switch_MapBufferRange;
+PFN_PTRC_GLRENDERBUFFERSTORAGEPROC _ptrc_glRenderbufferStorage =
+    Switch_RenderbufferStorage;
+PFN_PTRC_GLRENDERBUFFERSTORAGEMULTISAMPLEPROC
+_ptrc_glRenderbufferStorageMultisample = Switch_RenderbufferStorageMultisample;
+PFN_PTRC_GLTEXPARAMETERIIVPROC _ptrc_glTexParameterIiv = Switch_TexParameterIiv;
+PFN_PTRC_GLTEXPARAMETERIUIVPROC _ptrc_glTexParameterIuiv =
+    Switch_TexParameterIuiv;
+PFN_PTRC_GLTRANSFORMFEEDBACKVARYINGSPROC _ptrc_glTransformFeedbackVaryings =
+    Switch_TransformFeedbackVaryings;
+PFN_PTRC_GLUNIFORM1UIPROC _ptrc_glUniform1ui = Switch_Uniform1ui;
+PFN_PTRC_GLUNIFORM1UIVPROC _ptrc_glUniform1uiv = Switch_Uniform1uiv;
+PFN_PTRC_GLUNIFORM2UIPROC _ptrc_glUniform2ui = Switch_Uniform2ui;
+PFN_PTRC_GLUNIFORM2UIVPROC _ptrc_glUniform2uiv = Switch_Uniform2uiv;
+PFN_PTRC_GLUNIFORM3UIPROC _ptrc_glUniform3ui = Switch_Uniform3ui;
+PFN_PTRC_GLUNIFORM3UIVPROC _ptrc_glUniform3uiv = Switch_Uniform3uiv;
+PFN_PTRC_GLUNIFORM4UIPROC _ptrc_glUniform4ui = Switch_Uniform4ui;
+PFN_PTRC_GLUNIFORM4UIVPROC _ptrc_glUniform4uiv = Switch_Uniform4uiv;
+PFN_PTRC_GLVERTEXATTRIBI1IPROC _ptrc_glVertexAttribI1i = Switch_VertexAttribI1i;
+PFN_PTRC_GLVERTEXATTRIBI1IVPROC _ptrc_glVertexAttribI1iv =
+    Switch_VertexAttribI1iv;
+PFN_PTRC_GLVERTEXATTRIBI1UIPROC _ptrc_glVertexAttribI1ui =
+    Switch_VertexAttribI1ui;
+PFN_PTRC_GLVERTEXATTRIBI1UIVPROC _ptrc_glVertexAttribI1uiv =
+    Switch_VertexAttribI1uiv;
+PFN_PTRC_GLVERTEXATTRIBI2IPROC _ptrc_glVertexAttribI2i = Switch_VertexAttribI2i;
+PFN_PTRC_GLVERTEXATTRIBI2IVPROC _ptrc_glVertexAttribI2iv =
+    Switch_VertexAttribI2iv;
+PFN_PTRC_GLVERTEXATTRIBI2UIPROC _ptrc_glVertexAttribI2ui =
+    Switch_VertexAttribI2ui;
+PFN_PTRC_GLVERTEXATTRIBI2UIVPROC _ptrc_glVertexAttribI2uiv =
+    Switch_VertexAttribI2uiv;
+PFN_PTRC_GLVERTEXATTRIBI3IPROC _ptrc_glVertexAttribI3i = Switch_VertexAttribI3i;
+PFN_PTRC_GLVERTEXATTRIBI3IVPROC _ptrc_glVertexAttribI3iv =
+    Switch_VertexAttribI3iv;
+PFN_PTRC_GLVERTEXATTRIBI3UIPROC _ptrc_glVertexAttribI3ui =
+    Switch_VertexAttribI3ui;
+PFN_PTRC_GLVERTEXATTRIBI3UIVPROC _ptrc_glVertexAttribI3uiv =
+    Switch_VertexAttribI3uiv;
+PFN_PTRC_GLVERTEXATTRIBI4BVPROC _ptrc_glVertexAttribI4bv =
+    Switch_VertexAttribI4bv;
+PFN_PTRC_GLVERTEXATTRIBI4IPROC _ptrc_glVertexAttribI4i = Switch_VertexAttribI4i;
+PFN_PTRC_GLVERTEXATTRIBI4IVPROC _ptrc_glVertexAttribI4iv =
+    Switch_VertexAttribI4iv;
+PFN_PTRC_GLVERTEXATTRIBI4SVPROC _ptrc_glVertexAttribI4sv =
+    Switch_VertexAttribI4sv;
+PFN_PTRC_GLVERTEXATTRIBI4UBVPROC _ptrc_glVertexAttribI4ubv =
+    Switch_VertexAttribI4ubv;
+PFN_PTRC_GLVERTEXATTRIBI4UIPROC _ptrc_glVertexAttribI4ui =
+    Switch_VertexAttribI4ui;
+PFN_PTRC_GLVERTEXATTRIBI4UIVPROC _ptrc_glVertexAttribI4uiv =
+    Switch_VertexAttribI4uiv;
+PFN_PTRC_GLVERTEXATTRIBI4USVPROC _ptrc_glVertexAttribI4usv =
+    Switch_VertexAttribI4usv;
+PFN_PTRC_GLVERTEXATTRIBIPOINTERPROC _ptrc_glVertexAttribIPointer =
+    Switch_VertexAttribIPointer;
+
+/* Extension: 3.1*/
+PFN_PTRC_GLCOPYBUFFERSUBDATAPROC _ptrc_glCopyBufferSubData =
+    Switch_CopyBufferSubData;
+PFN_PTRC_GLDRAWARRAYSINSTANCEDPROC _ptrc_glDrawArraysInstanced =
+    Switch_DrawArraysInstanced;
+PFN_PTRC_GLDRAWELEMENTSINSTANCEDPROC _ptrc_glDrawElementsInstanced =
+    Switch_DrawElementsInstanced;
+PFN_PTRC_GLGETACTIVEUNIFORMBLOCKNAMEPROC _ptrc_glGetActiveUniformBlockName =
+    Switch_GetActiveUniformBlockName;
+PFN_PTRC_GLGETACTIVEUNIFORMBLOCKIVPROC _ptrc_glGetActiveUniformBlockiv =
+    Switch_GetActiveUniformBlockiv;
+PFN_PTRC_GLGETACTIVEUNIFORMNAMEPROC _ptrc_glGetActiveUniformName =
+    Switch_GetActiveUniformName;
+PFN_PTRC_GLGETACTIVEUNIFORMSIVPROC _ptrc_glGetActiveUniformsiv =
+    Switch_GetActiveUniformsiv;
+PFN_PTRC_GLGETUNIFORMBLOCKINDEXPROC _ptrc_glGetUniformBlockIndex =
+    Switch_GetUniformBlockIndex;
+PFN_PTRC_GLGETUNIFORMINDICESPROC _ptrc_glGetUniformIndices =
+    Switch_GetUniformIndices;
+PFN_PTRC_GLPRIMITIVERESTARTINDEXPROC _ptrc_glPrimitiveRestartIndex =
+    Switch_PrimitiveRestartIndex;
+PFN_PTRC_GLTEXBUFFERPROC _ptrc_glTexBuffer = Switch_TexBuffer;
+PFN_PTRC_GLUNIFORMBLOCKBINDINGPROC _ptrc_glUniformBlockBinding =
+    Switch_UniformBlockBinding;
+
+/* Extension: 3.2*/
+PFN_PTRC_GLCLIENTWAITSYNCPROC _ptrc_glClientWaitSync = Switch_ClientWaitSync;
+PFN_PTRC_GLDELETESYNCPROC _ptrc_glDeleteSync = Switch_DeleteSync;
+PFN_PTRC_GLDRAWELEMENTSBASEVERTEXPROC _ptrc_glDrawElementsBaseVertex =
+    Switch_DrawElementsBaseVertex;
+PFN_PTRC_GLDRAWELEMENTSINSTANCEDBASEVERTEXPROC
+_ptrc_glDrawElementsInstancedBaseVertex =
+    Switch_DrawElementsInstancedBaseVertex;
+PFN_PTRC_GLDRAWRANGEELEMENTSBASEVERTEXPROC _ptrc_glDrawRangeElementsBaseVertex =
+    Switch_DrawRangeElementsBaseVertex;
+PFN_PTRC_GLFENCESYNCPROC _ptrc_glFenceSync = Switch_FenceSync;
+PFN_PTRC_GLFRAMEBUFFERTEXTUREPROC _ptrc_glFramebufferTexture =
+    Switch_FramebufferTexture;
+PFN_PTRC_GLGETBUFFERPARAMETERI64VPROC _ptrc_glGetBufferParameteri64v =
+    Switch_GetBufferParameteri64v;
+PFN_PTRC_GLGETINTEGER64I_VPROC _ptrc_glGetInteger64i_v = Switch_GetInteger64i_v;
+PFN_PTRC_GLGETINTEGER64VPROC _ptrc_glGetInteger64v = Switch_GetInteger64v;
+PFN_PTRC_GLGETMULTISAMPLEFVPROC _ptrc_glGetMultisamplefv =
+    Switch_GetMultisamplefv;
+PFN_PTRC_GLGETSYNCIVPROC _ptrc_glGetSynciv = Switch_GetSynciv;
+PFN_PTRC_GLISSYNCPROC _ptrc_glIsSync = Switch_IsSync;
+PFN_PTRC_GLMULTIDRAWELEMENTSBASEVERTEXPROC _ptrc_glMultiDrawElementsBaseVertex =
+    Switch_MultiDrawElementsBaseVertex;
+PFN_PTRC_GLPROVOKINGVERTEXPROC _ptrc_glProvokingVertex = Switch_ProvokingVertex;
+PFN_PTRC_GLSAMPLEMASKIPROC _ptrc_glSampleMaski = Switch_SampleMaski;
+PFN_PTRC_GLTEXIMAGE2DMULTISAMPLEPROC _ptrc_glTexImage2DMultisample =
+    Switch_TexImage2DMultisample;
+PFN_PTRC_GLTEXIMAGE3DMULTISAMPLEPROC _ptrc_glTexImage3DMultisample =
+    Switch_TexImage3DMultisample;
+PFN_PTRC_GLWAITSYNCPROC _ptrc_glWaitSync = Switch_WaitSync;
+
+/* Extension: 3.3*/
+PFN_PTRC_GLBINDFRAGDATALOCATIONINDEXEDPROC _ptrc_glBindFragDataLocationIndexed =
+    Switch_BindFragDataLocationIndexed;
+PFN_PTRC_GLBINDSAMPLERPROC _ptrc_glBindSampler = Switch_BindSampler;
+PFN_PTRC_GLDELETESAMPLERSPROC _ptrc_glDeleteSamplers = Switch_DeleteSamplers;
+PFN_PTRC_GLGENSAMPLERSPROC _ptrc_glGenSamplers = Switch_GenSamplers;
+PFN_PTRC_GLGETFRAGDATAINDEXPROC _ptrc_glGetFragDataIndex =
+    Switch_GetFragDataIndex;
+PFN_PTRC_GLGETQUERYOBJECTI64VPROC _ptrc_glGetQueryObjecti64v =
+    Switch_GetQueryObjecti64v;
+PFN_PTRC_GLGETQUERYOBJECTUI64VPROC _ptrc_glGetQueryObjectui64v =
+    Switch_GetQueryObjectui64v;
+PFN_PTRC_GLGETSAMPLERPARAMETERIIVPROC _ptrc_glGetSamplerParameterIiv =
+    Switch_GetSamplerParameterIiv;
+PFN_PTRC_GLGETSAMPLERPARAMETERIUIVPROC _ptrc_glGetSamplerParameterIuiv =
+    Switch_GetSamplerParameterIuiv;
+PFN_PTRC_GLGETSAMPLERPARAMETERFVPROC _ptrc_glGetSamplerParameterfv =
+    Switch_GetSamplerParameterfv;
+PFN_PTRC_GLGETSAMPLERPARAMETERIVPROC _ptrc_glGetSamplerParameteriv =
+    Switch_GetSamplerParameteriv;
+PFN_PTRC_GLISSAMPLERPROC _ptrc_glIsSampler = Switch_IsSampler;
+PFN_PTRC_GLQUERYCOUNTERPROC _ptrc_glQueryCounter = Switch_QueryCounter;
+PFN_PTRC_GLSAMPLERPARAMETERIIVPROC _ptrc_glSamplerParameterIiv =
+    Switch_SamplerParameterIiv;
+PFN_PTRC_GLSAMPLERPARAMETERIUIVPROC _ptrc_glSamplerParameterIuiv =
+    Switch_SamplerParameterIuiv;
+PFN_PTRC_GLSAMPLERPARAMETERFPROC _ptrc_glSamplerParameterf =
+    Switch_SamplerParameterf;
+PFN_PTRC_GLSAMPLERPARAMETERFVPROC _ptrc_glSamplerParameterfv =
+    Switch_SamplerParameterfv;
+PFN_PTRC_GLSAMPLERPARAMETERIPROC _ptrc_glSamplerParameteri =
+    Switch_SamplerParameteri;
+PFN_PTRC_GLSAMPLERPARAMETERIVPROC _ptrc_glSamplerParameteriv =
+    Switch_SamplerParameteriv;
+PFN_PTRC_GLVERTEXATTRIBDIVISORPROC _ptrc_glVertexAttribDivisor =
+    Switch_VertexAttribDivisor;
+PFN_PTRC_GLVERTEXATTRIBP1UIPROC _ptrc_glVertexAttribP1ui =
+    Switch_VertexAttribP1ui;
+PFN_PTRC_GLVERTEXATTRIBP1UIVPROC _ptrc_glVertexAttribP1uiv =
+    Switch_VertexAttribP1uiv;
+PFN_PTRC_GLVERTEXATTRIBP2UIPROC _ptrc_glVertexAttribP2ui =
+    Switch_VertexAttribP2ui;
+PFN_PTRC_GLVERTEXATTRIBP2UIVPROC _ptrc_glVertexAttribP2uiv =
+    Switch_VertexAttribP2uiv;
+PFN_PTRC_GLVERTEXATTRIBP3UIPROC _ptrc_glVertexAttribP3ui =
+    Switch_VertexAttribP3ui;
+PFN_PTRC_GLVERTEXATTRIBP3UIVPROC _ptrc_glVertexAttribP3uiv =
+    Switch_VertexAttribP3uiv;
+PFN_PTRC_GLVERTEXATTRIBP4UIPROC _ptrc_glVertexAttribP4ui =
+    Switch_VertexAttribP4ui;
+PFN_PTRC_GLVERTEXATTRIBP4UIVPROC _ptrc_glVertexAttribP4uiv =
+    Switch_VertexAttribP4uiv;
+
+/* Extension: ARB_ES2_compatibility*/
+static void CODEGEN_FUNCPTR Switch_ClearDepthf(GLfloat d)
+{
+    _ptrc_glClearDepthf =
+        (PFN_PTRC_GLCLEARDEPTHFPROC)IntGetProcAddress("glClearDepthf");
+    _ptrc_glClearDepthf(d);
+}
+
+static void CODEGEN_FUNCPTR Switch_DepthRangef(GLfloat n, GLfloat f)
+{
+    _ptrc_glDepthRangef =
+        (PFN_PTRC_GLDEPTHRANGEFPROC)IntGetProcAddress("glDepthRangef");
+    _ptrc_glDepthRangef(n, f);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetShaderPrecisionFormat(
+    GLenum shadertype, GLenum precisiontype, GLint *range, GLint *precision)
+{
+    _ptrc_glGetShaderPrecisionFormat =
+        (PFN_PTRC_GLGETSHADERPRECISIONFORMATPROC)IntGetProcAddress(
+            "glGetShaderPrecisionFormat");
+    _ptrc_glGetShaderPrecisionFormat(
+        shadertype, precisiontype, range, precision);
+}
+
+static void CODEGEN_FUNCPTR Switch_ReleaseShaderCompiler(void)
+{
+    _ptrc_glReleaseShaderCompiler =
+        (PFN_PTRC_GLRELEASESHADERCOMPILERPROC)IntGetProcAddress(
+            "glReleaseShaderCompiler");
+    _ptrc_glReleaseShaderCompiler();
+}
+
+static void CODEGEN_FUNCPTR Switch_ShaderBinary(
+    GLsizei count, const GLuint *shaders, GLenum binaryformat,
+    const void *binary, GLsizei length)
+{
+    _ptrc_glShaderBinary =
+        (PFN_PTRC_GLSHADERBINARYPROC)IntGetProcAddress("glShaderBinary");
+    _ptrc_glShaderBinary(count, shaders, binaryformat, binary, length);
+}
+
+/* Extension: ARB_get_program_binary*/
+static void CODEGEN_FUNCPTR Switch_GetProgramBinary(
+    GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat,
+    void *binary)
+{
+    _ptrc_glGetProgramBinary =
+        (PFN_PTRC_GLGETPROGRAMBINARYPROC)IntGetProcAddress(
+            "glGetProgramBinary");
+    _ptrc_glGetProgramBinary(program, bufSize, length, binaryFormat, binary);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramBinary(
+    GLuint program, GLenum binaryFormat, const void *binary, GLsizei length)
+{
+    _ptrc_glProgramBinary =
+        (PFN_PTRC_GLPROGRAMBINARYPROC)IntGetProcAddress("glProgramBinary");
+    _ptrc_glProgramBinary(program, binaryFormat, binary, length);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramParameteri(GLuint program, GLenum pname, GLint value)
+{
+    _ptrc_glProgramParameteri =
+        (PFN_PTRC_GLPROGRAMPARAMETERIPROC)IntGetProcAddress(
+            "glProgramParameteri");
+    _ptrc_glProgramParameteri(program, pname, value);
+}
+
+/* Extension: ARB_internalformat_query*/
+static void CODEGEN_FUNCPTR Switch_GetInternalformativ(
+    GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize,
+    GLint *params)
+{
+    _ptrc_glGetInternalformativ =
+        (PFN_PTRC_GLGETINTERNALFORMATIVPROC)IntGetProcAddress(
+            "glGetInternalformativ");
+    _ptrc_glGetInternalformativ(target, internalformat, pname, bufSize, params);
+}
+
+/* Extension: ARB_internalformat_query2*/
+static void CODEGEN_FUNCPTR Switch_GetInternalformati64v(
+    GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize,
+    GLint64 *params)
+{
+    _ptrc_glGetInternalformati64v =
+        (PFN_PTRC_GLGETINTERNALFORMATI64VPROC)IntGetProcAddress(
+            "glGetInternalformati64v");
+    _ptrc_glGetInternalformati64v(
+        target, internalformat, pname, bufSize, params);
+}
+
+/* Extension: ARB_program_interface_query*/
+static void CODEGEN_FUNCPTR Switch_GetProgramInterfaceiv(
+    GLuint program, GLenum programInterface, GLenum pname, GLint *params)
+{
+    _ptrc_glGetProgramInterfaceiv =
+        (PFN_PTRC_GLGETPROGRAMINTERFACEIVPROC)IntGetProcAddress(
+            "glGetProgramInterfaceiv");
+    _ptrc_glGetProgramInterfaceiv(program, programInterface, pname, params);
+}
+
+static GLuint CODEGEN_FUNCPTR Switch_GetProgramResourceIndex(
+    GLuint program, GLenum programInterface, const GLchar *name)
+{
+    _ptrc_glGetProgramResourceIndex =
+        (PFN_PTRC_GLGETPROGRAMRESOURCEINDEXPROC)IntGetProcAddress(
+            "glGetProgramResourceIndex");
+    return _ptrc_glGetProgramResourceIndex(program, programInterface, name);
+}
+
+static GLint CODEGEN_FUNCPTR Switch_GetProgramResourceLocation(
+    GLuint program, GLenum programInterface, const GLchar *name)
+{
+    _ptrc_glGetProgramResourceLocation =
+        (PFN_PTRC_GLGETPROGRAMRESOURCELOCATIONPROC)IntGetProcAddress(
+            "glGetProgramResourceLocation");
+    return _ptrc_glGetProgramResourceLocation(program, programInterface, name);
+}
+
+static GLint CODEGEN_FUNCPTR Switch_GetProgramResourceLocationIndex(
+    GLuint program, GLenum programInterface, const GLchar *name)
+{
+    _ptrc_glGetProgramResourceLocationIndex =
+        (PFN_PTRC_GLGETPROGRAMRESOURCELOCATIONINDEXPROC)IntGetProcAddress(
+            "glGetProgramResourceLocationIndex");
+    return _ptrc_glGetProgramResourceLocationIndex(
+        program, programInterface, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetProgramResourceName(
+    GLuint program, GLenum programInterface, GLuint index, GLsizei bufSize,
+    GLsizei *length, GLchar *name)
+{
+    _ptrc_glGetProgramResourceName =
+        (PFN_PTRC_GLGETPROGRAMRESOURCENAMEPROC)IntGetProcAddress(
+            "glGetProgramResourceName");
+    _ptrc_glGetProgramResourceName(
+        program, programInterface, index, bufSize, length, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetProgramResourceiv(
+    GLuint program, GLenum programInterface, GLuint index, GLsizei propCount,
+    const GLenum *props, GLsizei bufSize, GLsizei *length, GLint *params)
+{
+    _ptrc_glGetProgramResourceiv =
+        (PFN_PTRC_GLGETPROGRAMRESOURCEIVPROC)IntGetProcAddress(
+            "glGetProgramResourceiv");
+    _ptrc_glGetProgramResourceiv(
+        program, programInterface, index, propCount, props, bufSize, length,
+        params);
+}
+
+/* Extension: ARB_separate_shader_objects*/
+static void CODEGEN_FUNCPTR
+Switch_ActiveShaderProgram(GLuint pipeline, GLuint program)
+{
+    _ptrc_glActiveShaderProgram =
+        (PFN_PTRC_GLACTIVESHADERPROGRAMPROC)IntGetProcAddress(
+            "glActiveShaderProgram");
+    _ptrc_glActiveShaderProgram(pipeline, program);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindProgramPipeline(GLuint pipeline)
+{
+    _ptrc_glBindProgramPipeline =
+        (PFN_PTRC_GLBINDPROGRAMPIPELINEPROC)IntGetProcAddress(
+            "glBindProgramPipeline");
+    _ptrc_glBindProgramPipeline(pipeline);
+}
+
+static GLuint CODEGEN_FUNCPTR Switch_CreateShaderProgramv(
+    GLenum type, GLsizei count, const GLchar *const *strings)
+{
+    _ptrc_glCreateShaderProgramv =
+        (PFN_PTRC_GLCREATESHADERPROGRAMVPROC)IntGetProcAddress(
+            "glCreateShaderProgramv");
+    return _ptrc_glCreateShaderProgramv(type, count, strings);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteProgramPipelines(GLsizei n, const GLuint *pipelines)
+{
+    _ptrc_glDeleteProgramPipelines =
+        (PFN_PTRC_GLDELETEPROGRAMPIPELINESPROC)IntGetProcAddress(
+            "glDeleteProgramPipelines");
+    _ptrc_glDeleteProgramPipelines(n, pipelines);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GenProgramPipelines(GLsizei n, GLuint *pipelines)
+{
+    _ptrc_glGenProgramPipelines =
+        (PFN_PTRC_GLGENPROGRAMPIPELINESPROC)IntGetProcAddress(
+            "glGenProgramPipelines");
+    _ptrc_glGenProgramPipelines(n, pipelines);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetProgramPipelineInfoLog(
+    GLuint pipeline, GLsizei bufSize, GLsizei *length, GLchar *infoLog)
+{
+    _ptrc_glGetProgramPipelineInfoLog =
+        (PFN_PTRC_GLGETPROGRAMPIPELINEINFOLOGPROC)IntGetProcAddress(
+            "glGetProgramPipelineInfoLog");
+    _ptrc_glGetProgramPipelineInfoLog(pipeline, bufSize, length, infoLog);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetProgramPipelineiv(GLuint pipeline, GLenum pname, GLint *params)
+{
+    _ptrc_glGetProgramPipelineiv =
+        (PFN_PTRC_GLGETPROGRAMPIPELINEIVPROC)IntGetProcAddress(
+            "glGetProgramPipelineiv");
+    _ptrc_glGetProgramPipelineiv(pipeline, pname, params);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsProgramPipeline(GLuint pipeline)
+{
+    _ptrc_glIsProgramPipeline =
+        (PFN_PTRC_GLISPROGRAMPIPELINEPROC)IntGetProcAddress(
+            "glIsProgramPipeline");
+    return _ptrc_glIsProgramPipeline(pipeline);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1d(GLuint program, GLint location, GLdouble v0)
+{
+    _ptrc_glProgramUniform1d =
+        (PFN_PTRC_GLPROGRAMUNIFORM1DPROC)IntGetProcAddress(
+            "glProgramUniform1d");
+    _ptrc_glProgramUniform1d(program, location, v0);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value)
+{
+    _ptrc_glProgramUniform1dv =
+        (PFN_PTRC_GLPROGRAMUNIFORM1DVPROC)IntGetProcAddress(
+            "glProgramUniform1dv");
+    _ptrc_glProgramUniform1dv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1f(GLuint program, GLint location, GLfloat v0)
+{
+    _ptrc_glProgramUniform1f =
+        (PFN_PTRC_GLPROGRAMUNIFORM1FPROC)IntGetProcAddress(
+            "glProgramUniform1f");
+    _ptrc_glProgramUniform1f(program, location, v0);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glProgramUniform1fv =
+        (PFN_PTRC_GLPROGRAMUNIFORM1FVPROC)IntGetProcAddress(
+            "glProgramUniform1fv");
+    _ptrc_glProgramUniform1fv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1i(GLuint program, GLint location, GLint v0)
+{
+    _ptrc_glProgramUniform1i =
+        (PFN_PTRC_GLPROGRAMUNIFORM1IPROC)IntGetProcAddress(
+            "glProgramUniform1i");
+    _ptrc_glProgramUniform1i(program, location, v0);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glProgramUniform1iv =
+        (PFN_PTRC_GLPROGRAMUNIFORM1IVPROC)IntGetProcAddress(
+            "glProgramUniform1iv");
+    _ptrc_glProgramUniform1iv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform1ui(GLuint program, GLint location, GLuint v0)
+{
+    _ptrc_glProgramUniform1ui =
+        (PFN_PTRC_GLPROGRAMUNIFORM1UIPROC)IntGetProcAddress(
+            "glProgramUniform1ui");
+    _ptrc_glProgramUniform1ui(program, location, v0);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform1uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glProgramUniform1uiv =
+        (PFN_PTRC_GLPROGRAMUNIFORM1UIVPROC)IntGetProcAddress(
+            "glProgramUniform1uiv");
+    _ptrc_glProgramUniform1uiv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2d(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1)
+{
+    _ptrc_glProgramUniform2d =
+        (PFN_PTRC_GLPROGRAMUNIFORM2DPROC)IntGetProcAddress(
+            "glProgramUniform2d");
+    _ptrc_glProgramUniform2d(program, location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value)
+{
+    _ptrc_glProgramUniform2dv =
+        (PFN_PTRC_GLPROGRAMUNIFORM2DVPROC)IntGetProcAddress(
+            "glProgramUniform2dv");
+    _ptrc_glProgramUniform2dv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform2f(GLuint program, GLint location, GLfloat v0, GLfloat v1)
+{
+    _ptrc_glProgramUniform2f =
+        (PFN_PTRC_GLPROGRAMUNIFORM2FPROC)IntGetProcAddress(
+            "glProgramUniform2f");
+    _ptrc_glProgramUniform2f(program, location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glProgramUniform2fv =
+        (PFN_PTRC_GLPROGRAMUNIFORM2FVPROC)IntGetProcAddress(
+            "glProgramUniform2fv");
+    _ptrc_glProgramUniform2fv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform2i(GLuint program, GLint location, GLint v0, GLint v1)
+{
+    _ptrc_glProgramUniform2i =
+        (PFN_PTRC_GLPROGRAMUNIFORM2IPROC)IntGetProcAddress(
+            "glProgramUniform2i");
+    _ptrc_glProgramUniform2i(program, location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glProgramUniform2iv =
+        (PFN_PTRC_GLPROGRAMUNIFORM2IVPROC)IntGetProcAddress(
+            "glProgramUniform2iv");
+    _ptrc_glProgramUniform2iv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ProgramUniform2ui(GLuint program, GLint location, GLuint v0, GLuint v1)
+{
+    _ptrc_glProgramUniform2ui =
+        (PFN_PTRC_GLPROGRAMUNIFORM2UIPROC)IntGetProcAddress(
+            "glProgramUniform2ui");
+    _ptrc_glProgramUniform2ui(program, location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform2uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glProgramUniform2uiv =
+        (PFN_PTRC_GLPROGRAMUNIFORM2UIVPROC)IntGetProcAddress(
+            "glProgramUniform2uiv");
+    _ptrc_glProgramUniform2uiv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3d(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1, GLdouble v2)
+{
+    _ptrc_glProgramUniform3d =
+        (PFN_PTRC_GLPROGRAMUNIFORM3DPROC)IntGetProcAddress(
+            "glProgramUniform3d");
+    _ptrc_glProgramUniform3d(program, location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value)
+{
+    _ptrc_glProgramUniform3dv =
+        (PFN_PTRC_GLPROGRAMUNIFORM3DVPROC)IntGetProcAddress(
+            "glProgramUniform3dv");
+    _ptrc_glProgramUniform3dv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3f(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2)
+{
+    _ptrc_glProgramUniform3f =
+        (PFN_PTRC_GLPROGRAMUNIFORM3FPROC)IntGetProcAddress(
+            "glProgramUniform3f");
+    _ptrc_glProgramUniform3f(program, location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glProgramUniform3fv =
+        (PFN_PTRC_GLPROGRAMUNIFORM3FVPROC)IntGetProcAddress(
+            "glProgramUniform3fv");
+    _ptrc_glProgramUniform3fv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3i(
+    GLuint program, GLint location, GLint v0, GLint v1, GLint v2)
+{
+    _ptrc_glProgramUniform3i =
+        (PFN_PTRC_GLPROGRAMUNIFORM3IPROC)IntGetProcAddress(
+            "glProgramUniform3i");
+    _ptrc_glProgramUniform3i(program, location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glProgramUniform3iv =
+        (PFN_PTRC_GLPROGRAMUNIFORM3IVPROC)IntGetProcAddress(
+            "glProgramUniform3iv");
+    _ptrc_glProgramUniform3iv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3ui(
+    GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2)
+{
+    _ptrc_glProgramUniform3ui =
+        (PFN_PTRC_GLPROGRAMUNIFORM3UIPROC)IntGetProcAddress(
+            "glProgramUniform3ui");
+    _ptrc_glProgramUniform3ui(program, location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform3uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glProgramUniform3uiv =
+        (PFN_PTRC_GLPROGRAMUNIFORM3UIVPROC)IntGetProcAddress(
+            "glProgramUniform3uiv");
+    _ptrc_glProgramUniform3uiv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4d(
+    GLuint program, GLint location, GLdouble v0, GLdouble v1, GLdouble v2,
+    GLdouble v3)
+{
+    _ptrc_glProgramUniform4d =
+        (PFN_PTRC_GLPROGRAMUNIFORM4DPROC)IntGetProcAddress(
+            "glProgramUniform4d");
+    _ptrc_glProgramUniform4d(program, location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4dv(
+    GLuint program, GLint location, GLsizei count, const GLdouble *value)
+{
+    _ptrc_glProgramUniform4dv =
+        (PFN_PTRC_GLPROGRAMUNIFORM4DVPROC)IntGetProcAddress(
+            "glProgramUniform4dv");
+    _ptrc_glProgramUniform4dv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4f(
+    GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2,
+    GLfloat v3)
+{
+    _ptrc_glProgramUniform4f =
+        (PFN_PTRC_GLPROGRAMUNIFORM4FPROC)IntGetProcAddress(
+            "glProgramUniform4f");
+    _ptrc_glProgramUniform4f(program, location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4fv(
+    GLuint program, GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glProgramUniform4fv =
+        (PFN_PTRC_GLPROGRAMUNIFORM4FVPROC)IntGetProcAddress(
+            "glProgramUniform4fv");
+    _ptrc_glProgramUniform4fv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4i(
+    GLuint program, GLint location, GLint v0, GLint v1, GLint v2, GLint v3)
+{
+    _ptrc_glProgramUniform4i =
+        (PFN_PTRC_GLPROGRAMUNIFORM4IPROC)IntGetProcAddress(
+            "glProgramUniform4i");
+    _ptrc_glProgramUniform4i(program, location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4iv(
+    GLuint program, GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glProgramUniform4iv =
+        (PFN_PTRC_GLPROGRAMUNIFORM4IVPROC)IntGetProcAddress(
+            "glProgramUniform4iv");
+    _ptrc_glProgramUniform4iv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4ui(
+    GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3)
+{
+    _ptrc_glProgramUniform4ui =
+        (PFN_PTRC_GLPROGRAMUNIFORM4UIPROC)IntGetProcAddress(
+            "glProgramUniform4ui");
+    _ptrc_glProgramUniform4ui(program, location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniform4uiv(
+    GLuint program, GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glProgramUniform4uiv =
+        (PFN_PTRC_GLPROGRAMUNIFORM4UIVPROC)IntGetProcAddress(
+            "glProgramUniform4uiv");
+    _ptrc_glProgramUniform4uiv(program, location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix2dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX2DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix2dv");
+    _ptrc_glProgramUniformMatrix2dv(program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix2fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX2FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix2fv");
+    _ptrc_glProgramUniformMatrix2fv(program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x3dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix2x3dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X3DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix2x3dv");
+    _ptrc_glProgramUniformMatrix2x3dv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x3fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix2x3fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X3FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix2x3fv");
+    _ptrc_glProgramUniformMatrix2x3fv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x4dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix2x4dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X4DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix2x4dv");
+    _ptrc_glProgramUniformMatrix2x4dv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix2x4fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix2x4fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX2X4FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix2x4fv");
+    _ptrc_glProgramUniformMatrix2x4fv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix3dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX3DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix3dv");
+    _ptrc_glProgramUniformMatrix3dv(program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix3fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX3FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix3fv");
+    _ptrc_glProgramUniformMatrix3fv(program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x2dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix3x2dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X2DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix3x2dv");
+    _ptrc_glProgramUniformMatrix3x2dv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x2fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix3x2fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X2FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix3x2fv");
+    _ptrc_glProgramUniformMatrix3x2fv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x4dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix3x4dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X4DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix3x4dv");
+    _ptrc_glProgramUniformMatrix3x4dv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix3x4fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix3x4fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX3X4FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix3x4fv");
+    _ptrc_glProgramUniformMatrix3x4fv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix4dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX4DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix4dv");
+    _ptrc_glProgramUniformMatrix4dv(program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix4fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX4FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix4fv");
+    _ptrc_glProgramUniformMatrix4fv(program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x2dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix4x2dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X2DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix4x2dv");
+    _ptrc_glProgramUniformMatrix4x2dv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x2fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix4x2fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X2FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix4x2fv");
+    _ptrc_glProgramUniformMatrix4x2fv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x3dv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLdouble *value)
+{
+    _ptrc_glProgramUniformMatrix4x3dv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X3DVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix4x3dv");
+    _ptrc_glProgramUniformMatrix4x3dv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProgramUniformMatrix4x3fv(
+    GLuint program, GLint location, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    _ptrc_glProgramUniformMatrix4x3fv =
+        (PFN_PTRC_GLPROGRAMUNIFORMMATRIX4X3FVPROC)IntGetProcAddress(
+            "glProgramUniformMatrix4x3fv");
+    _ptrc_glProgramUniformMatrix4x3fv(
+        program, location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_UseProgramStages(GLuint pipeline, GLbitfield stages, GLuint program)
+{
+    _ptrc_glUseProgramStages =
+        (PFN_PTRC_GLUSEPROGRAMSTAGESPROC)IntGetProcAddress(
+            "glUseProgramStages");
+    _ptrc_glUseProgramStages(pipeline, stages, program);
+}
+
+static void CODEGEN_FUNCPTR Switch_ValidateProgramPipeline(GLuint pipeline)
+{
+    _ptrc_glValidateProgramPipeline =
+        (PFN_PTRC_GLVALIDATEPROGRAMPIPELINEPROC)IntGetProcAddress(
+            "glValidateProgramPipeline");
+    _ptrc_glValidateProgramPipeline(pipeline);
+}
+
+/* Extension: ARB_texture_buffer_range*/
+static void CODEGEN_FUNCPTR Switch_TexBufferRange(
+    GLenum target, GLenum internalformat, GLuint buffer, GLintptr offset,
+    GLsizeiptr size)
+{
+    _ptrc_glTexBufferRange =
+        (PFN_PTRC_GLTEXBUFFERRANGEPROC)IntGetProcAddress("glTexBufferRange");
+    _ptrc_glTexBufferRange(target, internalformat, buffer, offset, size);
+}
+
+/* Extension: ARB_texture_storage*/
+static void CODEGEN_FUNCPTR Switch_TexStorage1D(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width)
+{
+    _ptrc_glTexStorage1D =
+        (PFN_PTRC_GLTEXSTORAGE1DPROC)IntGetProcAddress("glTexStorage1D");
+    _ptrc_glTexStorage1D(target, levels, internalformat, width);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexStorage2D(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height)
+{
+    _ptrc_glTexStorage2D =
+        (PFN_PTRC_GLTEXSTORAGE2DPROC)IntGetProcAddress("glTexStorage2D");
+    _ptrc_glTexStorage2D(target, levels, internalformat, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexStorage3D(
+    GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth)
+{
+    _ptrc_glTexStorage3D =
+        (PFN_PTRC_GLTEXSTORAGE3DPROC)IntGetProcAddress("glTexStorage3D");
+    _ptrc_glTexStorage3D(target, levels, internalformat, width, height, depth);
+}
+
+/* Extension: ARB_texture_view*/
+static void CODEGEN_FUNCPTR Switch_TextureView(
+    GLuint texture, GLenum target, GLuint origtexture, GLenum internalformat,
+    GLuint minlevel, GLuint numlevels, GLuint minlayer, GLuint numlayers)
+{
+    _ptrc_glTextureView =
+        (PFN_PTRC_GLTEXTUREVIEWPROC)IntGetProcAddress("glTextureView");
+    _ptrc_glTextureView(
+        texture, target, origtexture, internalformat, minlevel, numlevels,
+        minlayer, numlayers);
+}
+
+/* Extension: ARB_vertex_attrib_binding*/
+static void CODEGEN_FUNCPTR Switch_BindVertexBuffer(
+    GLuint bindingindex, GLuint buffer, GLintptr offset, GLsizei stride)
+{
+    _ptrc_glBindVertexBuffer =
+        (PFN_PTRC_GLBINDVERTEXBUFFERPROC)IntGetProcAddress(
+            "glBindVertexBuffer");
+    _ptrc_glBindVertexBuffer(bindingindex, buffer, offset, stride);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribBinding(GLuint attribindex, GLuint bindingindex)
+{
+    _ptrc_glVertexAttribBinding =
+        (PFN_PTRC_GLVERTEXATTRIBBINDINGPROC)IntGetProcAddress(
+            "glVertexAttribBinding");
+    _ptrc_glVertexAttribBinding(attribindex, bindingindex);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribFormat(
+    GLuint attribindex, GLint size, GLenum type, GLboolean normalized,
+    GLuint relativeoffset)
+{
+    _ptrc_glVertexAttribFormat =
+        (PFN_PTRC_GLVERTEXATTRIBFORMATPROC)IntGetProcAddress(
+            "glVertexAttribFormat");
+    _ptrc_glVertexAttribFormat(
+        attribindex, size, type, normalized, relativeoffset);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribIFormat(
+    GLuint attribindex, GLint size, GLenum type, GLuint relativeoffset)
+{
+    _ptrc_glVertexAttribIFormat =
+        (PFN_PTRC_GLVERTEXATTRIBIFORMATPROC)IntGetProcAddress(
+            "glVertexAttribIFormat");
+    _ptrc_glVertexAttribIFormat(attribindex, size, type, relativeoffset);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribLFormat(
+    GLuint attribindex, GLint size, GLenum type, GLuint relativeoffset)
+{
+    _ptrc_glVertexAttribLFormat =
+        (PFN_PTRC_GLVERTEXATTRIBLFORMATPROC)IntGetProcAddress(
+            "glVertexAttribLFormat");
+    _ptrc_glVertexAttribLFormat(attribindex, size, type, relativeoffset);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexBindingDivisor(GLuint bindingindex, GLuint divisor)
+{
+    _ptrc_glVertexBindingDivisor =
+        (PFN_PTRC_GLVERTEXBINDINGDIVISORPROC)IntGetProcAddress(
+            "glVertexBindingDivisor");
+    _ptrc_glVertexBindingDivisor(bindingindex, divisor);
+}
+
+/* Extension: ARB_viewport_array*/
+static void CODEGEN_FUNCPTR
+Switch_DepthRangeArrayv(GLuint first, GLsizei count, const GLdouble *v)
+{
+    _ptrc_glDepthRangeArrayv =
+        (PFN_PTRC_GLDEPTHRANGEARRAYVPROC)IntGetProcAddress(
+            "glDepthRangeArrayv");
+    _ptrc_glDepthRangeArrayv(first, count, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DepthRangeIndexed(GLuint index, GLdouble n, GLdouble f)
+{
+    _ptrc_glDepthRangeIndexed =
+        (PFN_PTRC_GLDEPTHRANGEINDEXEDPROC)IntGetProcAddress(
+            "glDepthRangeIndexed");
+    _ptrc_glDepthRangeIndexed(index, n, f);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetDoublei_v(GLenum target, GLuint index, GLdouble *data)
+{
+    _ptrc_glGetDoublei_v =
+        (PFN_PTRC_GLGETDOUBLEI_VPROC)IntGetProcAddress("glGetDoublei_v");
+    _ptrc_glGetDoublei_v(target, index, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetFloati_v(GLenum target, GLuint index, GLfloat *data)
+{
+    _ptrc_glGetFloati_v =
+        (PFN_PTRC_GLGETFLOATI_VPROC)IntGetProcAddress("glGetFloati_v");
+    _ptrc_glGetFloati_v(target, index, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ScissorArrayv(GLuint first, GLsizei count, const GLint *v)
+{
+    _ptrc_glScissorArrayv =
+        (PFN_PTRC_GLSCISSORARRAYVPROC)IntGetProcAddress("glScissorArrayv");
+    _ptrc_glScissorArrayv(first, count, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_ScissorIndexed(
+    GLuint index, GLint left, GLint bottom, GLsizei width, GLsizei height)
+{
+    _ptrc_glScissorIndexed =
+        (PFN_PTRC_GLSCISSORINDEXEDPROC)IntGetProcAddress("glScissorIndexed");
+    _ptrc_glScissorIndexed(index, left, bottom, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_ScissorIndexedv(GLuint index, const GLint *v)
+{
+    _ptrc_glScissorIndexedv =
+        (PFN_PTRC_GLSCISSORINDEXEDVPROC)IntGetProcAddress("glScissorIndexedv");
+    _ptrc_glScissorIndexedv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ViewportArrayv(GLuint first, GLsizei count, const GLfloat *v)
+{
+    _ptrc_glViewportArrayv =
+        (PFN_PTRC_GLVIEWPORTARRAYVPROC)IntGetProcAddress("glViewportArrayv");
+    _ptrc_glViewportArrayv(first, count, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_ViewportIndexedf(
+    GLuint index, GLfloat x, GLfloat y, GLfloat w, GLfloat h)
+{
+    _ptrc_glViewportIndexedf =
+        (PFN_PTRC_GLVIEWPORTINDEXEDFPROC)IntGetProcAddress(
+            "glViewportIndexedf");
+    _ptrc_glViewportIndexedf(index, x, y, w, h);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ViewportIndexedfv(GLuint index, const GLfloat *v)
+{
+    _ptrc_glViewportIndexedfv =
+        (PFN_PTRC_GLVIEWPORTINDEXEDFVPROC)IntGetProcAddress(
+            "glViewportIndexedfv");
+    _ptrc_glViewportIndexedfv(index, v);
+}
+
+/* Extension: ARB_clear_buffer_object*/
+static void CODEGEN_FUNCPTR Switch_ClearBufferData(
+    GLenum target, GLenum internalformat, GLenum format, GLenum type,
+    const void *data)
+{
+    _ptrc_glClearBufferData =
+        (PFN_PTRC_GLCLEARBUFFERDATAPROC)IntGetProcAddress("glClearBufferData");
+    _ptrc_glClearBufferData(target, internalformat, format, type, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearBufferSubData(
+    GLenum target, GLenum internalformat, GLintptr offset, GLsizeiptr size,
+    GLenum format, GLenum type, const void *data)
+{
+    _ptrc_glClearBufferSubData =
+        (PFN_PTRC_GLCLEARBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glClearBufferSubData");
+    _ptrc_glClearBufferSubData(
+        target, internalformat, offset, size, format, type, data);
+}
+
+/* Extension: ARB_copy_image*/
+static void CODEGEN_FUNCPTR Switch_CopyImageSubData(
+    GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY,
+    GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX,
+    GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight,
+    GLsizei srcDepth)
+{
+    _ptrc_glCopyImageSubData =
+        (PFN_PTRC_GLCOPYIMAGESUBDATAPROC)IntGetProcAddress(
+            "glCopyImageSubData");
+    _ptrc_glCopyImageSubData(
+        srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget,
+        dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+}
+
+/* Extension: ARB_framebuffer_no_attachments*/
+static void CODEGEN_FUNCPTR
+Switch_FramebufferParameteri(GLenum target, GLenum pname, GLint param)
+{
+    _ptrc_glFramebufferParameteri =
+        (PFN_PTRC_GLFRAMEBUFFERPARAMETERIPROC)IntGetProcAddress(
+            "glFramebufferParameteri");
+    _ptrc_glFramebufferParameteri(target, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetFramebufferParameteriv(GLenum target, GLenum pname, GLint *params)
+{
+    _ptrc_glGetFramebufferParameteriv =
+        (PFN_PTRC_GLGETFRAMEBUFFERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetFramebufferParameteriv");
+    _ptrc_glGetFramebufferParameteriv(target, pname, params);
+}
+
+/* Extension: ARB_invalidate_subdata*/
+static void CODEGEN_FUNCPTR Switch_InvalidateBufferData(GLuint buffer)
+{
+    _ptrc_glInvalidateBufferData =
+        (PFN_PTRC_GLINVALIDATEBUFFERDATAPROC)IntGetProcAddress(
+            "glInvalidateBufferData");
+    _ptrc_glInvalidateBufferData(buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_InvalidateBufferSubData(
+    GLuint buffer, GLintptr offset, GLsizeiptr length)
+{
+    _ptrc_glInvalidateBufferSubData =
+        (PFN_PTRC_GLINVALIDATEBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glInvalidateBufferSubData");
+    _ptrc_glInvalidateBufferSubData(buffer, offset, length);
+}
+
+static void CODEGEN_FUNCPTR Switch_InvalidateFramebuffer(
+    GLenum target, GLsizei numAttachments, const GLenum *attachments)
+{
+    _ptrc_glInvalidateFramebuffer =
+        (PFN_PTRC_GLINVALIDATEFRAMEBUFFERPROC)IntGetProcAddress(
+            "glInvalidateFramebuffer");
+    _ptrc_glInvalidateFramebuffer(target, numAttachments, attachments);
+}
+
+static void CODEGEN_FUNCPTR Switch_InvalidateSubFramebuffer(
+    GLenum target, GLsizei numAttachments, const GLenum *attachments, GLint x,
+    GLint y, GLsizei width, GLsizei height)
+{
+    _ptrc_glInvalidateSubFramebuffer =
+        (PFN_PTRC_GLINVALIDATESUBFRAMEBUFFERPROC)IntGetProcAddress(
+            "glInvalidateSubFramebuffer");
+    _ptrc_glInvalidateSubFramebuffer(
+        target, numAttachments, attachments, x, y, width, height);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_InvalidateTexImage(GLuint texture, GLint level)
+{
+    _ptrc_glInvalidateTexImage =
+        (PFN_PTRC_GLINVALIDATETEXIMAGEPROC)IntGetProcAddress(
+            "glInvalidateTexImage");
+    _ptrc_glInvalidateTexImage(texture, level);
+}
+
+static void CODEGEN_FUNCPTR Switch_InvalidateTexSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth)
+{
+    _ptrc_glInvalidateTexSubImage =
+        (PFN_PTRC_GLINVALIDATETEXSUBIMAGEPROC)IntGetProcAddress(
+            "glInvalidateTexSubImage");
+    _ptrc_glInvalidateTexSubImage(
+        texture, level, xoffset, yoffset, zoffset, width, height, depth);
+}
+
+/* Extension: ARB_texture_storage_multisample*/
+static void CODEGEN_FUNCPTR Switch_TexStorage2DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations)
+{
+    _ptrc_glTexStorage2DMultisample =
+        (PFN_PTRC_GLTEXSTORAGE2DMULTISAMPLEPROC)IntGetProcAddress(
+            "glTexStorage2DMultisample");
+    _ptrc_glTexStorage2DMultisample(
+        target, samples, internalformat, width, height, fixedsamplelocations);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexStorage3DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations)
+{
+    _ptrc_glTexStorage3DMultisample =
+        (PFN_PTRC_GLTEXSTORAGE3DMULTISAMPLEPROC)IntGetProcAddress(
+            "glTexStorage3DMultisample");
+    _ptrc_glTexStorage3DMultisample(
+        target, samples, internalformat, width, height, depth,
+        fixedsamplelocations);
+}
+
+/* Extension: KHR_debug*/
+static void CODEGEN_FUNCPTR
+Switch_DebugMessageCallback(GLDEBUGPROC callback, const void *userParam)
+{
+    _ptrc_glDebugMessageCallback =
+        (PFN_PTRC_GLDEBUGMESSAGECALLBACKPROC)IntGetProcAddress(
+            "glDebugMessageCallback");
+    _ptrc_glDebugMessageCallback(callback, userParam);
+}
+
+static void CODEGEN_FUNCPTR Switch_DebugMessageControl(
+    GLenum source, GLenum type, GLenum severity, GLsizei count,
+    const GLuint *ids, GLboolean enabled)
+{
+    _ptrc_glDebugMessageControl =
+        (PFN_PTRC_GLDEBUGMESSAGECONTROLPROC)IntGetProcAddress(
+            "glDebugMessageControl");
+    _ptrc_glDebugMessageControl(source, type, severity, count, ids, enabled);
+}
+
+static void CODEGEN_FUNCPTR Switch_DebugMessageInsert(
+    GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+    const GLchar *buf)
+{
+    _ptrc_glDebugMessageInsert =
+        (PFN_PTRC_GLDEBUGMESSAGEINSERTPROC)IntGetProcAddress(
+            "glDebugMessageInsert");
+    _ptrc_glDebugMessageInsert(source, type, id, severity, length, buf);
+}
+
+static GLuint CODEGEN_FUNCPTR Switch_GetDebugMessageLog(
+    GLuint count, GLsizei bufSize, GLenum *sources, GLenum *types, GLuint *ids,
+    GLenum *severities, GLsizei *lengths, GLchar *messageLog)
+{
+    _ptrc_glGetDebugMessageLog =
+        (PFN_PTRC_GLGETDEBUGMESSAGELOGPROC)IntGetProcAddress(
+            "glGetDebugMessageLog");
+    return _ptrc_glGetDebugMessageLog(
+        count, bufSize, sources, types, ids, severities, lengths, messageLog);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetObjectLabel(
+    GLenum identifier, GLuint name, GLsizei bufSize, GLsizei *length,
+    GLchar *label)
+{
+    _ptrc_glGetObjectLabel =
+        (PFN_PTRC_GLGETOBJECTLABELPROC)IntGetProcAddress("glGetObjectLabel");
+    _ptrc_glGetObjectLabel(identifier, name, bufSize, length, label);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetObjectPtrLabel(
+    const void *ptr, GLsizei bufSize, GLsizei *length, GLchar *label)
+{
+    _ptrc_glGetObjectPtrLabel =
+        (PFN_PTRC_GLGETOBJECTPTRLABELPROC)IntGetProcAddress(
+            "glGetObjectPtrLabel");
+    _ptrc_glGetObjectPtrLabel(ptr, bufSize, length, label);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetPointerv(GLenum pname, void **params)
+{
+    _ptrc_glGetPointerv =
+        (PFN_PTRC_GLGETPOINTERVPROC)IntGetProcAddress("glGetPointerv");
+    _ptrc_glGetPointerv(pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_ObjectLabel(
+    GLenum identifier, GLuint name, GLsizei length, const GLchar *label)
+{
+    _ptrc_glObjectLabel =
+        (PFN_PTRC_GLOBJECTLABELPROC)IntGetProcAddress("glObjectLabel");
+    _ptrc_glObjectLabel(identifier, name, length, label);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ObjectPtrLabel(const void *ptr, GLsizei length, const GLchar *label)
+{
+    _ptrc_glObjectPtrLabel =
+        (PFN_PTRC_GLOBJECTPTRLABELPROC)IntGetProcAddress("glObjectPtrLabel");
+    _ptrc_glObjectPtrLabel(ptr, length, label);
+}
+
+static void CODEGEN_FUNCPTR Switch_PopDebugGroup(void)
+{
+    _ptrc_glPopDebugGroup =
+        (PFN_PTRC_GLPOPDEBUGGROUPPROC)IntGetProcAddress("glPopDebugGroup");
+    _ptrc_glPopDebugGroup();
+}
+
+static void CODEGEN_FUNCPTR Switch_PushDebugGroup(
+    GLenum source, GLuint id, GLsizei length, const GLchar *message)
+{
+    _ptrc_glPushDebugGroup =
+        (PFN_PTRC_GLPUSHDEBUGGROUPPROC)IntGetProcAddress("glPushDebugGroup");
+    _ptrc_glPushDebugGroup(source, id, length, message);
+}
+
+/* Extension: ARB_buffer_storage*/
+static void CODEGEN_FUNCPTR Switch_BufferStorage(
+    GLenum target, GLsizeiptr size, const void *data, GLbitfield flags)
+{
+    _ptrc_glBufferStorage =
+        (PFN_PTRC_GLBUFFERSTORAGEPROC)IntGetProcAddress("glBufferStorage");
+    _ptrc_glBufferStorage(target, size, data, flags);
+}
+
+/* Extension: ARB_clear_texture*/
+static void CODEGEN_FUNCPTR Switch_ClearTexImage(
+    GLuint texture, GLint level, GLenum format, GLenum type, const void *data)
+{
+    _ptrc_glClearTexImage =
+        (PFN_PTRC_GLCLEARTEXIMAGEPROC)IntGetProcAddress("glClearTexImage");
+    _ptrc_glClearTexImage(texture, level, format, type, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearTexSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *data)
+{
+    _ptrc_glClearTexSubImage =
+        (PFN_PTRC_GLCLEARTEXSUBIMAGEPROC)IntGetProcAddress(
+            "glClearTexSubImage");
+    _ptrc_glClearTexSubImage(
+        texture, level, xoffset, yoffset, zoffset, width, height, depth, format,
+        type, data);
+}
+
+/* Extension: ARB_multi_bind*/
+static void CODEGEN_FUNCPTR Switch_BindBuffersBase(
+    GLenum target, GLuint first, GLsizei count, const GLuint *buffers)
+{
+    _ptrc_glBindBuffersBase =
+        (PFN_PTRC_GLBINDBUFFERSBASEPROC)IntGetProcAddress("glBindBuffersBase");
+    _ptrc_glBindBuffersBase(target, first, count, buffers);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindBuffersRange(
+    GLenum target, GLuint first, GLsizei count, const GLuint *buffers,
+    const GLintptr *offsets, const GLsizeiptr *sizes)
+{
+    _ptrc_glBindBuffersRange =
+        (PFN_PTRC_GLBINDBUFFERSRANGEPROC)IntGetProcAddress(
+            "glBindBuffersRange");
+    _ptrc_glBindBuffersRange(target, first, count, buffers, offsets, sizes);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindImageTextures(GLuint first, GLsizei count, const GLuint *textures)
+{
+    _ptrc_glBindImageTextures =
+        (PFN_PTRC_GLBINDIMAGETEXTURESPROC)IntGetProcAddress(
+            "glBindImageTextures");
+    _ptrc_glBindImageTextures(first, count, textures);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindSamplers(GLuint first, GLsizei count, const GLuint *samplers)
+{
+    _ptrc_glBindSamplers =
+        (PFN_PTRC_GLBINDSAMPLERSPROC)IntGetProcAddress("glBindSamplers");
+    _ptrc_glBindSamplers(first, count, samplers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindTextures(GLuint first, GLsizei count, const GLuint *textures)
+{
+    _ptrc_glBindTextures =
+        (PFN_PTRC_GLBINDTEXTURESPROC)IntGetProcAddress("glBindTextures");
+    _ptrc_glBindTextures(first, count, textures);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindVertexBuffers(
+    GLuint first, GLsizei count, const GLuint *buffers, const GLintptr *offsets,
+    const GLsizei *strides)
+{
+    _ptrc_glBindVertexBuffers =
+        (PFN_PTRC_GLBINDVERTEXBUFFERSPROC)IntGetProcAddress(
+            "glBindVertexBuffers");
+    _ptrc_glBindVertexBuffers(first, count, buffers, offsets, strides);
+}
+
+/* Extension: ARB_clip_control*/
+static void CODEGEN_FUNCPTR Switch_ClipControl(GLenum origin, GLenum depth)
+{
+    _ptrc_glClipControl =
+        (PFN_PTRC_GLCLIPCONTROLPROC)IntGetProcAddress("glClipControl");
+    _ptrc_glClipControl(origin, depth);
+}
+
+/* Extension: ARB_direct_state_access*/
+static void CODEGEN_FUNCPTR Switch_BindTextureUnit(GLuint unit, GLuint texture)
+{
+    _ptrc_glBindTextureUnit =
+        (PFN_PTRC_GLBINDTEXTUREUNITPROC)IntGetProcAddress("glBindTextureUnit");
+    _ptrc_glBindTextureUnit(unit, texture);
+}
+
+static void CODEGEN_FUNCPTR Switch_BlitNamedFramebuffer(
+    GLuint readFramebuffer, GLuint drawFramebuffer, GLint srcX0, GLint srcY0,
+    GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1,
+    GLint dstY1, GLbitfield mask, GLenum filter)
+{
+    _ptrc_glBlitNamedFramebuffer =
+        (PFN_PTRC_GLBLITNAMEDFRAMEBUFFERPROC)IntGetProcAddress(
+            "glBlitNamedFramebuffer");
+    _ptrc_glBlitNamedFramebuffer(
+        readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0,
+        dstY0, dstX1, dstY1, mask, filter);
+}
+
+static GLenum CODEGEN_FUNCPTR
+Switch_CheckNamedFramebufferStatus(GLuint framebuffer, GLenum target)
+{
+    _ptrc_glCheckNamedFramebufferStatus =
+        (PFN_PTRC_GLCHECKNAMEDFRAMEBUFFERSTATUSPROC)IntGetProcAddress(
+            "glCheckNamedFramebufferStatus");
+    return _ptrc_glCheckNamedFramebufferStatus(framebuffer, target);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearNamedBufferData(
+    GLuint buffer, GLenum internalformat, GLenum format, GLenum type,
+    const void *data)
+{
+    _ptrc_glClearNamedBufferData =
+        (PFN_PTRC_GLCLEARNAMEDBUFFERDATAPROC)IntGetProcAddress(
+            "glClearNamedBufferData");
+    _ptrc_glClearNamedBufferData(buffer, internalformat, format, type, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearNamedBufferSubData(
+    GLuint buffer, GLenum internalformat, GLintptr offset, GLsizeiptr size,
+    GLenum format, GLenum type, const void *data)
+{
+    _ptrc_glClearNamedBufferSubData =
+        (PFN_PTRC_GLCLEARNAMEDBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glClearNamedBufferSubData");
+    _ptrc_glClearNamedBufferSubData(
+        buffer, internalformat, offset, size, format, type, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferfi(
+    GLuint framebuffer, GLenum buffer, const GLfloat depth, GLint stencil)
+{
+    _ptrc_glClearNamedFramebufferfi =
+        (PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERFIPROC)IntGetProcAddress(
+            "glClearNamedFramebufferfi");
+    _ptrc_glClearNamedFramebufferfi(framebuffer, buffer, depth, stencil);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferfv(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLfloat *value)
+{
+    _ptrc_glClearNamedFramebufferfv =
+        (PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERFVPROC)IntGetProcAddress(
+            "glClearNamedFramebufferfv");
+    _ptrc_glClearNamedFramebufferfv(framebuffer, buffer, drawbuffer, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferiv(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLint *value)
+{
+    _ptrc_glClearNamedFramebufferiv =
+        (PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERIVPROC)IntGetProcAddress(
+            "glClearNamedFramebufferiv");
+    _ptrc_glClearNamedFramebufferiv(framebuffer, buffer, drawbuffer, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearNamedFramebufferuiv(
+    GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLuint *value)
+{
+    _ptrc_glClearNamedFramebufferuiv =
+        (PFN_PTRC_GLCLEARNAMEDFRAMEBUFFERUIVPROC)IntGetProcAddress(
+            "glClearNamedFramebufferuiv");
+    _ptrc_glClearNamedFramebufferuiv(framebuffer, buffer, drawbuffer, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTextureSubImage1D(
+    GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTextureSubImage1D =
+        (PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE1DPROC)IntGetProcAddress(
+            "glCompressedTextureSubImage1D");
+    _ptrc_glCompressedTextureSubImage1D(
+        texture, level, xoffset, width, format, imageSize, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTextureSubImage2D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTextureSubImage2D =
+        (PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE2DPROC)IntGetProcAddress(
+            "glCompressedTextureSubImage2D");
+    _ptrc_glCompressedTextureSubImage2D(
+        texture, level, xoffset, yoffset, width, height, format, imageSize,
+        data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTextureSubImage3D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format,
+    GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTextureSubImage3D =
+        (PFN_PTRC_GLCOMPRESSEDTEXTURESUBIMAGE3DPROC)IntGetProcAddress(
+            "glCompressedTextureSubImage3D");
+    _ptrc_glCompressedTextureSubImage3D(
+        texture, level, xoffset, yoffset, zoffset, width, height, depth, format,
+        imageSize, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyNamedBufferSubData(
+    GLuint readBuffer, GLuint writeBuffer, GLintptr readOffset,
+    GLintptr writeOffset, GLsizeiptr size)
+{
+    _ptrc_glCopyNamedBufferSubData =
+        (PFN_PTRC_GLCOPYNAMEDBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glCopyNamedBufferSubData");
+    _ptrc_glCopyNamedBufferSubData(
+        readBuffer, writeBuffer, readOffset, writeOffset, size);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTextureSubImage1D(
+    GLuint texture, GLint level, GLint xoffset, GLint x, GLint y, GLsizei width)
+{
+    _ptrc_glCopyTextureSubImage1D =
+        (PFN_PTRC_GLCOPYTEXTURESUBIMAGE1DPROC)IntGetProcAddress(
+            "glCopyTextureSubImage1D");
+    _ptrc_glCopyTextureSubImage1D(texture, level, xoffset, x, y, width);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTextureSubImage2D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+    GLsizei width, GLsizei height)
+{
+    _ptrc_glCopyTextureSubImage2D =
+        (PFN_PTRC_GLCOPYTEXTURESUBIMAGE2DPROC)IntGetProcAddress(
+            "glCopyTextureSubImage2D");
+    _ptrc_glCopyTextureSubImage2D(
+        texture, level, xoffset, yoffset, x, y, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTextureSubImage3D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    _ptrc_glCopyTextureSubImage3D =
+        (PFN_PTRC_GLCOPYTEXTURESUBIMAGE3DPROC)IntGetProcAddress(
+            "glCopyTextureSubImage3D");
+    _ptrc_glCopyTextureSubImage3D(
+        texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_CreateBuffers(GLsizei n, GLuint *buffers)
+{
+    _ptrc_glCreateBuffers =
+        (PFN_PTRC_GLCREATEBUFFERSPROC)IntGetProcAddress("glCreateBuffers");
+    _ptrc_glCreateBuffers(n, buffers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_CreateFramebuffers(GLsizei n, GLuint *framebuffers)
+{
+    _ptrc_glCreateFramebuffers =
+        (PFN_PTRC_GLCREATEFRAMEBUFFERSPROC)IntGetProcAddress(
+            "glCreateFramebuffers");
+    _ptrc_glCreateFramebuffers(n, framebuffers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_CreateProgramPipelines(GLsizei n, GLuint *pipelines)
+{
+    _ptrc_glCreateProgramPipelines =
+        (PFN_PTRC_GLCREATEPROGRAMPIPELINESPROC)IntGetProcAddress(
+            "glCreateProgramPipelines");
+    _ptrc_glCreateProgramPipelines(n, pipelines);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_CreateQueries(GLenum target, GLsizei n, GLuint *ids)
+{
+    _ptrc_glCreateQueries =
+        (PFN_PTRC_GLCREATEQUERIESPROC)IntGetProcAddress("glCreateQueries");
+    _ptrc_glCreateQueries(target, n, ids);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_CreateRenderbuffers(GLsizei n, GLuint *renderbuffers)
+{
+    _ptrc_glCreateRenderbuffers =
+        (PFN_PTRC_GLCREATERENDERBUFFERSPROC)IntGetProcAddress(
+            "glCreateRenderbuffers");
+    _ptrc_glCreateRenderbuffers(n, renderbuffers);
+}
+
+static void CODEGEN_FUNCPTR Switch_CreateSamplers(GLsizei n, GLuint *samplers)
+{
+    _ptrc_glCreateSamplers =
+        (PFN_PTRC_GLCREATESAMPLERSPROC)IntGetProcAddress("glCreateSamplers");
+    _ptrc_glCreateSamplers(n, samplers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_CreateTextures(GLenum target, GLsizei n, GLuint *textures)
+{
+    _ptrc_glCreateTextures =
+        (PFN_PTRC_GLCREATETEXTURESPROC)IntGetProcAddress("glCreateTextures");
+    _ptrc_glCreateTextures(target, n, textures);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_CreateTransformFeedbacks(GLsizei n, GLuint *ids)
+{
+    _ptrc_glCreateTransformFeedbacks =
+        (PFN_PTRC_GLCREATETRANSFORMFEEDBACKSPROC)IntGetProcAddress(
+            "glCreateTransformFeedbacks");
+    _ptrc_glCreateTransformFeedbacks(n, ids);
+}
+
+static void CODEGEN_FUNCPTR Switch_CreateVertexArrays(GLsizei n, GLuint *arrays)
+{
+    _ptrc_glCreateVertexArrays =
+        (PFN_PTRC_GLCREATEVERTEXARRAYSPROC)IntGetProcAddress(
+            "glCreateVertexArrays");
+    _ptrc_glCreateVertexArrays(n, arrays);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DisableVertexArrayAttrib(GLuint vaobj, GLuint index)
+{
+    _ptrc_glDisableVertexArrayAttrib =
+        (PFN_PTRC_GLDISABLEVERTEXARRAYATTRIBPROC)IntGetProcAddress(
+            "glDisableVertexArrayAttrib");
+    _ptrc_glDisableVertexArrayAttrib(vaobj, index);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_EnableVertexArrayAttrib(GLuint vaobj, GLuint index)
+{
+    _ptrc_glEnableVertexArrayAttrib =
+        (PFN_PTRC_GLENABLEVERTEXARRAYATTRIBPROC)IntGetProcAddress(
+            "glEnableVertexArrayAttrib");
+    _ptrc_glEnableVertexArrayAttrib(vaobj, index);
+}
+
+static void CODEGEN_FUNCPTR Switch_FlushMappedNamedBufferRange(
+    GLuint buffer, GLintptr offset, GLsizeiptr length)
+{
+    _ptrc_glFlushMappedNamedBufferRange =
+        (PFN_PTRC_GLFLUSHMAPPEDNAMEDBUFFERRANGEPROC)IntGetProcAddress(
+            "glFlushMappedNamedBufferRange");
+    _ptrc_glFlushMappedNamedBufferRange(buffer, offset, length);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenerateTextureMipmap(GLuint texture)
+{
+    _ptrc_glGenerateTextureMipmap =
+        (PFN_PTRC_GLGENERATETEXTUREMIPMAPPROC)IntGetProcAddress(
+            "glGenerateTextureMipmap");
+    _ptrc_glGenerateTextureMipmap(texture);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetCompressedTextureImage(
+    GLuint texture, GLint level, GLsizei bufSize, void *pixels)
+{
+    _ptrc_glGetCompressedTextureImage =
+        (PFN_PTRC_GLGETCOMPRESSEDTEXTUREIMAGEPROC)IntGetProcAddress(
+            "glGetCompressedTextureImage");
+    _ptrc_glGetCompressedTextureImage(texture, level, bufSize, pixels);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetNamedBufferParameteri64v(GLuint buffer, GLenum pname, GLint64 *params)
+{
+    _ptrc_glGetNamedBufferParameteri64v =
+        (PFN_PTRC_GLGETNAMEDBUFFERPARAMETERI64VPROC)IntGetProcAddress(
+            "glGetNamedBufferParameteri64v");
+    _ptrc_glGetNamedBufferParameteri64v(buffer, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetNamedBufferParameteriv(GLuint buffer, GLenum pname, GLint *params)
+{
+    _ptrc_glGetNamedBufferParameteriv =
+        (PFN_PTRC_GLGETNAMEDBUFFERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetNamedBufferParameteriv");
+    _ptrc_glGetNamedBufferParameteriv(buffer, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetNamedBufferPointerv(GLuint buffer, GLenum pname, void **params)
+{
+    _ptrc_glGetNamedBufferPointerv =
+        (PFN_PTRC_GLGETNAMEDBUFFERPOINTERVPROC)IntGetProcAddress(
+            "glGetNamedBufferPointerv");
+    _ptrc_glGetNamedBufferPointerv(buffer, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetNamedBufferSubData(
+    GLuint buffer, GLintptr offset, GLsizeiptr size, void *data)
+{
+    _ptrc_glGetNamedBufferSubData =
+        (PFN_PTRC_GLGETNAMEDBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glGetNamedBufferSubData");
+    _ptrc_glGetNamedBufferSubData(buffer, offset, size, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetNamedFramebufferAttachmentParameteriv(
+    GLuint framebuffer, GLenum attachment, GLenum pname, GLint *params)
+{
+    _ptrc_glGetNamedFramebufferAttachmentParameteriv =
+        (PFN_PTRC_GLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC)
+            IntGetProcAddress("glGetNamedFramebufferAttachmentParameteriv");
+    _ptrc_glGetNamedFramebufferAttachmentParameteriv(
+        framebuffer, attachment, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetNamedFramebufferParameteriv(
+    GLuint framebuffer, GLenum pname, GLint *param)
+{
+    _ptrc_glGetNamedFramebufferParameteriv =
+        (PFN_PTRC_GLGETNAMEDFRAMEBUFFERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetNamedFramebufferParameteriv");
+    _ptrc_glGetNamedFramebufferParameteriv(framebuffer, pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetNamedRenderbufferParameteriv(
+    GLuint renderbuffer, GLenum pname, GLint *params)
+{
+    _ptrc_glGetNamedRenderbufferParameteriv =
+        (PFN_PTRC_GLGETNAMEDRENDERBUFFERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetNamedRenderbufferParameteriv");
+    _ptrc_glGetNamedRenderbufferParameteriv(renderbuffer, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjecti64v(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset)
+{
+    _ptrc_glGetQueryBufferObjecti64v =
+        (PFN_PTRC_GLGETQUERYBUFFEROBJECTI64VPROC)IntGetProcAddress(
+            "glGetQueryBufferObjecti64v");
+    _ptrc_glGetQueryBufferObjecti64v(id, buffer, pname, offset);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjectiv(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset)
+{
+    _ptrc_glGetQueryBufferObjectiv =
+        (PFN_PTRC_GLGETQUERYBUFFEROBJECTIVPROC)IntGetProcAddress(
+            "glGetQueryBufferObjectiv");
+    _ptrc_glGetQueryBufferObjectiv(id, buffer, pname, offset);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjectui64v(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset)
+{
+    _ptrc_glGetQueryBufferObjectui64v =
+        (PFN_PTRC_GLGETQUERYBUFFEROBJECTUI64VPROC)IntGetProcAddress(
+            "glGetQueryBufferObjectui64v");
+    _ptrc_glGetQueryBufferObjectui64v(id, buffer, pname, offset);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetQueryBufferObjectuiv(
+    GLuint id, GLuint buffer, GLenum pname, GLintptr offset)
+{
+    _ptrc_glGetQueryBufferObjectuiv =
+        (PFN_PTRC_GLGETQUERYBUFFEROBJECTUIVPROC)IntGetProcAddress(
+            "glGetQueryBufferObjectuiv");
+    _ptrc_glGetQueryBufferObjectuiv(id, buffer, pname, offset);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTextureImage(
+    GLuint texture, GLint level, GLenum format, GLenum type, GLsizei bufSize,
+    void *pixels)
+{
+    _ptrc_glGetTextureImage =
+        (PFN_PTRC_GLGETTEXTUREIMAGEPROC)IntGetProcAddress("glGetTextureImage");
+    _ptrc_glGetTextureImage(texture, level, format, type, bufSize, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTextureLevelParameterfv(
+    GLuint texture, GLint level, GLenum pname, GLfloat *params)
+{
+    _ptrc_glGetTextureLevelParameterfv =
+        (PFN_PTRC_GLGETTEXTURELEVELPARAMETERFVPROC)IntGetProcAddress(
+            "glGetTextureLevelParameterfv");
+    _ptrc_glGetTextureLevelParameterfv(texture, level, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTextureLevelParameteriv(
+    GLuint texture, GLint level, GLenum pname, GLint *params)
+{
+    _ptrc_glGetTextureLevelParameteriv =
+        (PFN_PTRC_GLGETTEXTURELEVELPARAMETERIVPROC)IntGetProcAddress(
+            "glGetTextureLevelParameteriv");
+    _ptrc_glGetTextureLevelParameteriv(texture, level, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameterIiv(GLuint texture, GLenum pname, GLint *params)
+{
+    _ptrc_glGetTextureParameterIiv =
+        (PFN_PTRC_GLGETTEXTUREPARAMETERIIVPROC)IntGetProcAddress(
+            "glGetTextureParameterIiv");
+    _ptrc_glGetTextureParameterIiv(texture, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameterIuiv(GLuint texture, GLenum pname, GLuint *params)
+{
+    _ptrc_glGetTextureParameterIuiv =
+        (PFN_PTRC_GLGETTEXTUREPARAMETERIUIVPROC)IntGetProcAddress(
+            "glGetTextureParameterIuiv");
+    _ptrc_glGetTextureParameterIuiv(texture, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameterfv(GLuint texture, GLenum pname, GLfloat *params)
+{
+    _ptrc_glGetTextureParameterfv =
+        (PFN_PTRC_GLGETTEXTUREPARAMETERFVPROC)IntGetProcAddress(
+            "glGetTextureParameterfv");
+    _ptrc_glGetTextureParameterfv(texture, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTextureParameteriv(GLuint texture, GLenum pname, GLint *params)
+{
+    _ptrc_glGetTextureParameteriv =
+        (PFN_PTRC_GLGETTEXTUREPARAMETERIVPROC)IntGetProcAddress(
+            "glGetTextureParameteriv");
+    _ptrc_glGetTextureParameteriv(texture, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTransformFeedbacki64_v(
+    GLuint xfb, GLenum pname, GLuint index, GLint64 *param)
+{
+    _ptrc_glGetTransformFeedbacki64_v =
+        (PFN_PTRC_GLGETTRANSFORMFEEDBACKI64_VPROC)IntGetProcAddress(
+            "glGetTransformFeedbacki64_v");
+    _ptrc_glGetTransformFeedbacki64_v(xfb, pname, index, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTransformFeedbacki_v(
+    GLuint xfb, GLenum pname, GLuint index, GLint *param)
+{
+    _ptrc_glGetTransformFeedbacki_v =
+        (PFN_PTRC_GLGETTRANSFORMFEEDBACKI_VPROC)IntGetProcAddress(
+            "glGetTransformFeedbacki_v");
+    _ptrc_glGetTransformFeedbacki_v(xfb, pname, index, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTransformFeedbackiv(GLuint xfb, GLenum pname, GLint *param)
+{
+    _ptrc_glGetTransformFeedbackiv =
+        (PFN_PTRC_GLGETTRANSFORMFEEDBACKIVPROC)IntGetProcAddress(
+            "glGetTransformFeedbackiv");
+    _ptrc_glGetTransformFeedbackiv(xfb, pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetVertexArrayIndexed64iv(
+    GLuint vaobj, GLuint index, GLenum pname, GLint64 *param)
+{
+    _ptrc_glGetVertexArrayIndexed64iv =
+        (PFN_PTRC_GLGETVERTEXARRAYINDEXED64IVPROC)IntGetProcAddress(
+            "glGetVertexArrayIndexed64iv");
+    _ptrc_glGetVertexArrayIndexed64iv(vaobj, index, pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetVertexArrayIndexediv(
+    GLuint vaobj, GLuint index, GLenum pname, GLint *param)
+{
+    _ptrc_glGetVertexArrayIndexediv =
+        (PFN_PTRC_GLGETVERTEXARRAYINDEXEDIVPROC)IntGetProcAddress(
+            "glGetVertexArrayIndexediv");
+    _ptrc_glGetVertexArrayIndexediv(vaobj, index, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexArrayiv(GLuint vaobj, GLenum pname, GLint *param)
+{
+    _ptrc_glGetVertexArrayiv =
+        (PFN_PTRC_GLGETVERTEXARRAYIVPROC)IntGetProcAddress(
+            "glGetVertexArrayiv");
+    _ptrc_glGetVertexArrayiv(vaobj, pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_InvalidateNamedFramebufferData(
+    GLuint framebuffer, GLsizei numAttachments, const GLenum *attachments)
+{
+    _ptrc_glInvalidateNamedFramebufferData =
+        (PFN_PTRC_GLINVALIDATENAMEDFRAMEBUFFERDATAPROC)IntGetProcAddress(
+            "glInvalidateNamedFramebufferData");
+    _ptrc_glInvalidateNamedFramebufferData(
+        framebuffer, numAttachments, attachments);
+}
+
+static void CODEGEN_FUNCPTR Switch_InvalidateNamedFramebufferSubData(
+    GLuint framebuffer, GLsizei numAttachments, const GLenum *attachments,
+    GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    _ptrc_glInvalidateNamedFramebufferSubData =
+        (PFN_PTRC_GLINVALIDATENAMEDFRAMEBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glInvalidateNamedFramebufferSubData");
+    _ptrc_glInvalidateNamedFramebufferSubData(
+        framebuffer, numAttachments, attachments, x, y, width, height);
+}
+
+static void *CODEGEN_FUNCPTR Switch_MapNamedBuffer(GLuint buffer, GLenum access)
+{
+    _ptrc_glMapNamedBuffer =
+        (PFN_PTRC_GLMAPNAMEDBUFFERPROC)IntGetProcAddress("glMapNamedBuffer");
+    return _ptrc_glMapNamedBuffer(buffer, access);
+}
+
+static void *CODEGEN_FUNCPTR Switch_MapNamedBufferRange(
+    GLuint buffer, GLintptr offset, GLsizeiptr length, GLbitfield access)
+{
+    _ptrc_glMapNamedBufferRange =
+        (PFN_PTRC_GLMAPNAMEDBUFFERRANGEPROC)IntGetProcAddress(
+            "glMapNamedBufferRange");
+    return _ptrc_glMapNamedBufferRange(buffer, offset, length, access);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedBufferData(
+    GLuint buffer, GLsizeiptr size, const void *data, GLenum usage)
+{
+    _ptrc_glNamedBufferData =
+        (PFN_PTRC_GLNAMEDBUFFERDATAPROC)IntGetProcAddress("glNamedBufferData");
+    _ptrc_glNamedBufferData(buffer, size, data, usage);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedBufferStorage(
+    GLuint buffer, GLsizeiptr size, const void *data, GLbitfield flags)
+{
+    _ptrc_glNamedBufferStorage =
+        (PFN_PTRC_GLNAMEDBUFFERSTORAGEPROC)IntGetProcAddress(
+            "glNamedBufferStorage");
+    _ptrc_glNamedBufferStorage(buffer, size, data, flags);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedBufferSubData(
+    GLuint buffer, GLintptr offset, GLsizeiptr size, const void *data)
+{
+    _ptrc_glNamedBufferSubData =
+        (PFN_PTRC_GLNAMEDBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glNamedBufferSubData");
+    _ptrc_glNamedBufferSubData(buffer, offset, size, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_NamedFramebufferDrawBuffer(GLuint framebuffer, GLenum buf)
+{
+    _ptrc_glNamedFramebufferDrawBuffer =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERDRAWBUFFERPROC)IntGetProcAddress(
+            "glNamedFramebufferDrawBuffer");
+    _ptrc_glNamedFramebufferDrawBuffer(framebuffer, buf);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferDrawBuffers(
+    GLuint framebuffer, GLsizei n, const GLenum *bufs)
+{
+    _ptrc_glNamedFramebufferDrawBuffers =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERDRAWBUFFERSPROC)IntGetProcAddress(
+            "glNamedFramebufferDrawBuffers");
+    _ptrc_glNamedFramebufferDrawBuffers(framebuffer, n, bufs);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_NamedFramebufferParameteri(GLuint framebuffer, GLenum pname, GLint param)
+{
+    _ptrc_glNamedFramebufferParameteri =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERPARAMETERIPROC)IntGetProcAddress(
+            "glNamedFramebufferParameteri");
+    _ptrc_glNamedFramebufferParameteri(framebuffer, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_NamedFramebufferReadBuffer(GLuint framebuffer, GLenum src)
+{
+    _ptrc_glNamedFramebufferReadBuffer =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERREADBUFFERPROC)IntGetProcAddress(
+            "glNamedFramebufferReadBuffer");
+    _ptrc_glNamedFramebufferReadBuffer(framebuffer, src);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferRenderbuffer(
+    GLuint framebuffer, GLenum attachment, GLenum renderbuffertarget,
+    GLuint renderbuffer)
+{
+    _ptrc_glNamedFramebufferRenderbuffer =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERRENDERBUFFERPROC)IntGetProcAddress(
+            "glNamedFramebufferRenderbuffer");
+    _ptrc_glNamedFramebufferRenderbuffer(
+        framebuffer, attachment, renderbuffertarget, renderbuffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferTexture(
+    GLuint framebuffer, GLenum attachment, GLuint texture, GLint level)
+{
+    _ptrc_glNamedFramebufferTexture =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERTEXTUREPROC)IntGetProcAddress(
+            "glNamedFramebufferTexture");
+    _ptrc_glNamedFramebufferTexture(framebuffer, attachment, texture, level);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedFramebufferTextureLayer(
+    GLuint framebuffer, GLenum attachment, GLuint texture, GLint level,
+    GLint layer)
+{
+    _ptrc_glNamedFramebufferTextureLayer =
+        (PFN_PTRC_GLNAMEDFRAMEBUFFERTEXTURELAYERPROC)IntGetProcAddress(
+            "glNamedFramebufferTextureLayer");
+    _ptrc_glNamedFramebufferTextureLayer(
+        framebuffer, attachment, texture, level, layer);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedRenderbufferStorage(
+    GLuint renderbuffer, GLenum internalformat, GLsizei width, GLsizei height)
+{
+    _ptrc_glNamedRenderbufferStorage =
+        (PFN_PTRC_GLNAMEDRENDERBUFFERSTORAGEPROC)IntGetProcAddress(
+            "glNamedRenderbufferStorage");
+    _ptrc_glNamedRenderbufferStorage(
+        renderbuffer, internalformat, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_NamedRenderbufferStorageMultisample(
+    GLuint renderbuffer, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height)
+{
+    _ptrc_glNamedRenderbufferStorageMultisample =
+        (PFN_PTRC_GLNAMEDRENDERBUFFERSTORAGEMULTISAMPLEPROC)IntGetProcAddress(
+            "glNamedRenderbufferStorageMultisample");
+    _ptrc_glNamedRenderbufferStorageMultisample(
+        renderbuffer, samples, internalformat, width, height);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureBuffer(GLuint texture, GLenum internalformat, GLuint buffer)
+{
+    _ptrc_glTextureBuffer =
+        (PFN_PTRC_GLTEXTUREBUFFERPROC)IntGetProcAddress("glTextureBuffer");
+    _ptrc_glTextureBuffer(texture, internalformat, buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureBufferRange(
+    GLuint texture, GLenum internalformat, GLuint buffer, GLintptr offset,
+    GLsizeiptr size)
+{
+    _ptrc_glTextureBufferRange =
+        (PFN_PTRC_GLTEXTUREBUFFERRANGEPROC)IntGetProcAddress(
+            "glTextureBufferRange");
+    _ptrc_glTextureBufferRange(texture, internalformat, buffer, offset, size);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterIiv(GLuint texture, GLenum pname, const GLint *params)
+{
+    _ptrc_glTextureParameterIiv =
+        (PFN_PTRC_GLTEXTUREPARAMETERIIVPROC)IntGetProcAddress(
+            "glTextureParameterIiv");
+    _ptrc_glTextureParameterIiv(texture, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterIuiv(GLuint texture, GLenum pname, const GLuint *params)
+{
+    _ptrc_glTextureParameterIuiv =
+        (PFN_PTRC_GLTEXTUREPARAMETERIUIVPROC)IntGetProcAddress(
+            "glTextureParameterIuiv");
+    _ptrc_glTextureParameterIuiv(texture, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterf(GLuint texture, GLenum pname, GLfloat param)
+{
+    _ptrc_glTextureParameterf =
+        (PFN_PTRC_GLTEXTUREPARAMETERFPROC)IntGetProcAddress(
+            "glTextureParameterf");
+    _ptrc_glTextureParameterf(texture, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureParameterfv(GLuint texture, GLenum pname, const GLfloat *param)
+{
+    _ptrc_glTextureParameterfv =
+        (PFN_PTRC_GLTEXTUREPARAMETERFVPROC)IntGetProcAddress(
+            "glTextureParameterfv");
+    _ptrc_glTextureParameterfv(texture, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureParameteri(GLuint texture, GLenum pname, GLint param)
+{
+    _ptrc_glTextureParameteri =
+        (PFN_PTRC_GLTEXTUREPARAMETERIPROC)IntGetProcAddress(
+            "glTextureParameteri");
+    _ptrc_glTextureParameteri(texture, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TextureParameteriv(GLuint texture, GLenum pname, const GLint *param)
+{
+    _ptrc_glTextureParameteriv =
+        (PFN_PTRC_GLTEXTUREPARAMETERIVPROC)IntGetProcAddress(
+            "glTextureParameteriv");
+    _ptrc_glTextureParameteriv(texture, pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureStorage1D(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width)
+{
+    _ptrc_glTextureStorage1D =
+        (PFN_PTRC_GLTEXTURESTORAGE1DPROC)IntGetProcAddress(
+            "glTextureStorage1D");
+    _ptrc_glTextureStorage1D(texture, levels, internalformat, width);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureStorage2D(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height)
+{
+    _ptrc_glTextureStorage2D =
+        (PFN_PTRC_GLTEXTURESTORAGE2DPROC)IntGetProcAddress(
+            "glTextureStorage2D");
+    _ptrc_glTextureStorage2D(texture, levels, internalformat, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureStorage2DMultisample(
+    GLuint texture, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations)
+{
+    _ptrc_glTextureStorage2DMultisample =
+        (PFN_PTRC_GLTEXTURESTORAGE2DMULTISAMPLEPROC)IntGetProcAddress(
+            "glTextureStorage2DMultisample");
+    _ptrc_glTextureStorage2DMultisample(
+        texture, samples, internalformat, width, height, fixedsamplelocations);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureStorage3D(
+    GLuint texture, GLsizei levels, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth)
+{
+    _ptrc_glTextureStorage3D =
+        (PFN_PTRC_GLTEXTURESTORAGE3DPROC)IntGetProcAddress(
+            "glTextureStorage3D");
+    _ptrc_glTextureStorage3D(
+        texture, levels, internalformat, width, height, depth);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureStorage3DMultisample(
+    GLuint texture, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations)
+{
+    _ptrc_glTextureStorage3DMultisample =
+        (PFN_PTRC_GLTEXTURESTORAGE3DMULTISAMPLEPROC)IntGetProcAddress(
+            "glTextureStorage3DMultisample");
+    _ptrc_glTextureStorage3DMultisample(
+        texture, samples, internalformat, width, height, depth,
+        fixedsamplelocations);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureSubImage1D(
+    GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLenum type, const void *pixels)
+{
+    _ptrc_glTextureSubImage1D =
+        (PFN_PTRC_GLTEXTURESUBIMAGE1DPROC)IntGetProcAddress(
+            "glTextureSubImage1D");
+    _ptrc_glTextureSubImage1D(
+        texture, level, xoffset, width, format, type, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureSubImage2D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLenum type, const void *pixels)
+{
+    _ptrc_glTextureSubImage2D =
+        (PFN_PTRC_GLTEXTURESUBIMAGE2DPROC)IntGetProcAddress(
+            "glTextureSubImage2D");
+    _ptrc_glTextureSubImage2D(
+        texture, level, xoffset, yoffset, width, height, format, type, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_TextureSubImage3D(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *pixels)
+{
+    _ptrc_glTextureSubImage3D =
+        (PFN_PTRC_GLTEXTURESUBIMAGE3DPROC)IntGetProcAddress(
+            "glTextureSubImage3D");
+    _ptrc_glTextureSubImage3D(
+        texture, level, xoffset, yoffset, zoffset, width, height, depth, format,
+        type, pixels);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TransformFeedbackBufferBase(GLuint xfb, GLuint index, GLuint buffer)
+{
+    _ptrc_glTransformFeedbackBufferBase =
+        (PFN_PTRC_GLTRANSFORMFEEDBACKBUFFERBASEPROC)IntGetProcAddress(
+            "glTransformFeedbackBufferBase");
+    _ptrc_glTransformFeedbackBufferBase(xfb, index, buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_TransformFeedbackBufferRange(
+    GLuint xfb, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size)
+{
+    _ptrc_glTransformFeedbackBufferRange =
+        (PFN_PTRC_GLTRANSFORMFEEDBACKBUFFERRANGEPROC)IntGetProcAddress(
+            "glTransformFeedbackBufferRange");
+    _ptrc_glTransformFeedbackBufferRange(xfb, index, buffer, offset, size);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_UnmapNamedBuffer(GLuint buffer)
+{
+    _ptrc_glUnmapNamedBuffer =
+        (PFN_PTRC_GLUNMAPNAMEDBUFFERPROC)IntGetProcAddress(
+            "glUnmapNamedBuffer");
+    return _ptrc_glUnmapNamedBuffer(buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribBinding(
+    GLuint vaobj, GLuint attribindex, GLuint bindingindex)
+{
+    _ptrc_glVertexArrayAttribBinding =
+        (PFN_PTRC_GLVERTEXARRAYATTRIBBINDINGPROC)IntGetProcAddress(
+            "glVertexArrayAttribBinding");
+    _ptrc_glVertexArrayAttribBinding(vaobj, attribindex, bindingindex);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribFormat(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLboolean normalized, GLuint relativeoffset)
+{
+    _ptrc_glVertexArrayAttribFormat =
+        (PFN_PTRC_GLVERTEXARRAYATTRIBFORMATPROC)IntGetProcAddress(
+            "glVertexArrayAttribFormat");
+    _ptrc_glVertexArrayAttribFormat(
+        vaobj, attribindex, size, type, normalized, relativeoffset);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribIFormat(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLuint relativeoffset)
+{
+    _ptrc_glVertexArrayAttribIFormat =
+        (PFN_PTRC_GLVERTEXARRAYATTRIBIFORMATPROC)IntGetProcAddress(
+            "glVertexArrayAttribIFormat");
+    _ptrc_glVertexArrayAttribIFormat(
+        vaobj, attribindex, size, type, relativeoffset);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayAttribLFormat(
+    GLuint vaobj, GLuint attribindex, GLint size, GLenum type,
+    GLuint relativeoffset)
+{
+    _ptrc_glVertexArrayAttribLFormat =
+        (PFN_PTRC_GLVERTEXARRAYATTRIBLFORMATPROC)IntGetProcAddress(
+            "glVertexArrayAttribLFormat");
+    _ptrc_glVertexArrayAttribLFormat(
+        vaobj, attribindex, size, type, relativeoffset);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayBindingDivisor(
+    GLuint vaobj, GLuint bindingindex, GLuint divisor)
+{
+    _ptrc_glVertexArrayBindingDivisor =
+        (PFN_PTRC_GLVERTEXARRAYBINDINGDIVISORPROC)IntGetProcAddress(
+            "glVertexArrayBindingDivisor");
+    _ptrc_glVertexArrayBindingDivisor(vaobj, bindingindex, divisor);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexArrayElementBuffer(GLuint vaobj, GLuint buffer)
+{
+    _ptrc_glVertexArrayElementBuffer =
+        (PFN_PTRC_GLVERTEXARRAYELEMENTBUFFERPROC)IntGetProcAddress(
+            "glVertexArrayElementBuffer");
+    _ptrc_glVertexArrayElementBuffer(vaobj, buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayVertexBuffer(
+    GLuint vaobj, GLuint bindingindex, GLuint buffer, GLintptr offset,
+    GLsizei stride)
+{
+    _ptrc_glVertexArrayVertexBuffer =
+        (PFN_PTRC_GLVERTEXARRAYVERTEXBUFFERPROC)IntGetProcAddress(
+            "glVertexArrayVertexBuffer");
+    _ptrc_glVertexArrayVertexBuffer(
+        vaobj, bindingindex, buffer, offset, stride);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexArrayVertexBuffers(
+    GLuint vaobj, GLuint first, GLsizei count, const GLuint *buffers,
+    const GLintptr *offsets, const GLsizei *strides)
+{
+    _ptrc_glVertexArrayVertexBuffers =
+        (PFN_PTRC_GLVERTEXARRAYVERTEXBUFFERSPROC)IntGetProcAddress(
+            "glVertexArrayVertexBuffers");
+    _ptrc_glVertexArrayVertexBuffers(
+        vaobj, first, count, buffers, offsets, strides);
+}
+
+/* Extension: ARB_get_texture_sub_image*/
+static void CODEGEN_FUNCPTR Switch_GetCompressedTextureSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLsizei bufSize, void *pixels)
+{
+    _ptrc_glGetCompressedTextureSubImage =
+        (PFN_PTRC_GLGETCOMPRESSEDTEXTURESUBIMAGEPROC)IntGetProcAddress(
+            "glGetCompressedTextureSubImage");
+    _ptrc_glGetCompressedTextureSubImage(
+        texture, level, xoffset, yoffset, zoffset, width, height, depth,
+        bufSize, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTextureSubImage(
+    GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    GLsizei bufSize, void *pixels)
+{
+    _ptrc_glGetTextureSubImage =
+        (PFN_PTRC_GLGETTEXTURESUBIMAGEPROC)IntGetProcAddress(
+            "glGetTextureSubImage");
+    _ptrc_glGetTextureSubImage(
+        texture, level, xoffset, yoffset, zoffset, width, height, depth, format,
+        type, bufSize, pixels);
+}
+
+/* Extension: ARB_texture_barrier*/
+static void CODEGEN_FUNCPTR Switch_TextureBarrier(void)
+{
+    _ptrc_glTextureBarrier =
+        (PFN_PTRC_GLTEXTUREBARRIERPROC)IntGetProcAddress("glTextureBarrier");
+    _ptrc_glTextureBarrier();
+}
+
+/* Extension: KHR_robustness*/
+static GLenum CODEGEN_FUNCPTR Switch_GetGraphicsResetStatus(void)
+{
+    _ptrc_glGetGraphicsResetStatus =
+        (PFN_PTRC_GLGETGRAPHICSRESETSTATUSPROC)IntGetProcAddress(
+            "glGetGraphicsResetStatus");
+    return _ptrc_glGetGraphicsResetStatus();
+}
+
+static void CODEGEN_FUNCPTR Switch_GetnUniformfv(
+    GLuint program, GLint location, GLsizei bufSize, GLfloat *params)
+{
+    _ptrc_glGetnUniformfv =
+        (PFN_PTRC_GLGETNUNIFORMFVPROC)IntGetProcAddress("glGetnUniformfv");
+    _ptrc_glGetnUniformfv(program, location, bufSize, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetnUniformiv(
+    GLuint program, GLint location, GLsizei bufSize, GLint *params)
+{
+    _ptrc_glGetnUniformiv =
+        (PFN_PTRC_GLGETNUNIFORMIVPROC)IntGetProcAddress("glGetnUniformiv");
+    _ptrc_glGetnUniformiv(program, location, bufSize, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetnUniformuiv(
+    GLuint program, GLint location, GLsizei bufSize, GLuint *params)
+{
+    _ptrc_glGetnUniformuiv =
+        (PFN_PTRC_GLGETNUNIFORMUIVPROC)IntGetProcAddress("glGetnUniformuiv");
+    _ptrc_glGetnUniformuiv(program, location, bufSize, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_ReadnPixels(
+    GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    GLsizei bufSize, void *data)
+{
+    _ptrc_glReadnPixels =
+        (PFN_PTRC_GLREADNPIXELSPROC)IntGetProcAddress("glReadnPixels");
+    _ptrc_glReadnPixels(x, y, width, height, format, type, bufSize, data);
+}
+
+/* Extension: 1.0*/
+static void CODEGEN_FUNCPTR Switch_BlendFunc(GLenum sfactor, GLenum dfactor)
+{
+    _ptrc_glBlendFunc =
+        (PFN_PTRC_GLBLENDFUNCPROC)IntGetProcAddress("glBlendFunc");
+    _ptrc_glBlendFunc(sfactor, dfactor);
+}
+
+static void CODEGEN_FUNCPTR Switch_Clear(GLbitfield mask)
+{
+    _ptrc_glClear = (PFN_PTRC_GLCLEARPROC)IntGetProcAddress("glClear");
+    _ptrc_glClear(mask);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
+{
+    _ptrc_glClearColor =
+        (PFN_PTRC_GLCLEARCOLORPROC)IntGetProcAddress("glClearColor");
+    _ptrc_glClearColor(red, green, blue, alpha);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearDepth(GLdouble depth)
+{
+    _ptrc_glClearDepth =
+        (PFN_PTRC_GLCLEARDEPTHPROC)IntGetProcAddress("glClearDepth");
+    _ptrc_glClearDepth(depth);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearStencil(GLint s)
+{
+    _ptrc_glClearStencil =
+        (PFN_PTRC_GLCLEARSTENCILPROC)IntGetProcAddress("glClearStencil");
+    _ptrc_glClearStencil(s);
+}
+
+static void CODEGEN_FUNCPTR Switch_ColorMask(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)
+{
+    _ptrc_glColorMask =
+        (PFN_PTRC_GLCOLORMASKPROC)IntGetProcAddress("glColorMask");
+    _ptrc_glColorMask(red, green, blue, alpha);
+}
+
+static void CODEGEN_FUNCPTR Switch_CullFace(GLenum mode)
+{
+    _ptrc_glCullFace = (PFN_PTRC_GLCULLFACEPROC)IntGetProcAddress("glCullFace");
+    _ptrc_glCullFace(mode);
+}
+
+static void CODEGEN_FUNCPTR Switch_DepthFunc(GLenum func)
+{
+    _ptrc_glDepthFunc =
+        (PFN_PTRC_GLDEPTHFUNCPROC)IntGetProcAddress("glDepthFunc");
+    _ptrc_glDepthFunc(func);
+}
+
+static void CODEGEN_FUNCPTR Switch_DepthMask(GLboolean flag)
+{
+    _ptrc_glDepthMask =
+        (PFN_PTRC_GLDEPTHMASKPROC)IntGetProcAddress("glDepthMask");
+    _ptrc_glDepthMask(flag);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DepthRange(GLdouble ren_near, GLdouble ren_far)
+{
+    _ptrc_glDepthRange =
+        (PFN_PTRC_GLDEPTHRANGEPROC)IntGetProcAddress("glDepthRange");
+    _ptrc_glDepthRange(ren_near, ren_far);
+}
+
+static void CODEGEN_FUNCPTR Switch_Disable(GLenum cap)
+{
+    _ptrc_glDisable = (PFN_PTRC_GLDISABLEPROC)IntGetProcAddress("glDisable");
+    _ptrc_glDisable(cap);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawBuffer(GLenum buf)
+{
+    _ptrc_glDrawBuffer =
+        (PFN_PTRC_GLDRAWBUFFERPROC)IntGetProcAddress("glDrawBuffer");
+    _ptrc_glDrawBuffer(buf);
+}
+
+static void CODEGEN_FUNCPTR Switch_Enable(GLenum cap)
+{
+    _ptrc_glEnable = (PFN_PTRC_GLENABLEPROC)IntGetProcAddress("glEnable");
+    _ptrc_glEnable(cap);
+}
+
+static void CODEGEN_FUNCPTR Switch_Finish(void)
+{
+    _ptrc_glFinish = (PFN_PTRC_GLFINISHPROC)IntGetProcAddress("glFinish");
+    _ptrc_glFinish();
+}
+
+static void CODEGEN_FUNCPTR Switch_Flush(void)
+{
+    _ptrc_glFlush = (PFN_PTRC_GLFLUSHPROC)IntGetProcAddress("glFlush");
+    _ptrc_glFlush();
+}
+
+static void CODEGEN_FUNCPTR Switch_FrontFace(GLenum mode)
+{
+    _ptrc_glFrontFace =
+        (PFN_PTRC_GLFRONTFACEPROC)IntGetProcAddress("glFrontFace");
+    _ptrc_glFrontFace(mode);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetBooleanv(GLenum pname, GLboolean *data)
+{
+    _ptrc_glGetBooleanv =
+        (PFN_PTRC_GLGETBOOLEANVPROC)IntGetProcAddress("glGetBooleanv");
+    _ptrc_glGetBooleanv(pname, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetDoublev(GLenum pname, GLdouble *data)
+{
+    _ptrc_glGetDoublev =
+        (PFN_PTRC_GLGETDOUBLEVPROC)IntGetProcAddress("glGetDoublev");
+    _ptrc_glGetDoublev(pname, data);
+}
+
+static GLenum CODEGEN_FUNCPTR Switch_GetError(void)
+{
+    _ptrc_glGetError = (PFN_PTRC_GLGETERRORPROC)IntGetProcAddress("glGetError");
+    return _ptrc_glGetError();
+}
+
+static void CODEGEN_FUNCPTR Switch_GetFloatv(GLenum pname, GLfloat *data)
+{
+    _ptrc_glGetFloatv =
+        (PFN_PTRC_GLGETFLOATVPROC)IntGetProcAddress("glGetFloatv");
+    _ptrc_glGetFloatv(pname, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetIntegerv(GLenum pname, GLint *data)
+{
+    _ptrc_glGetIntegerv =
+        (PFN_PTRC_GLGETINTEGERVPROC)IntGetProcAddress("glGetIntegerv");
+    _ptrc_glGetIntegerv(pname, data);
+}
+
+static const GLubyte *CODEGEN_FUNCPTR Switch_GetString(GLenum name)
+{
+    _ptrc_glGetString =
+        (PFN_PTRC_GLGETSTRINGPROC)IntGetProcAddress("glGetString");
+    return _ptrc_glGetString(name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTexImage(
+    GLenum target, GLint level, GLenum format, GLenum type, void *pixels)
+{
+    _ptrc_glGetTexImage =
+        (PFN_PTRC_GLGETTEXIMAGEPROC)IntGetProcAddress("glGetTexImage");
+    _ptrc_glGetTexImage(target, level, format, type, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTexLevelParameterfv(
+    GLenum target, GLint level, GLenum pname, GLfloat *params)
+{
+    _ptrc_glGetTexLevelParameterfv =
+        (PFN_PTRC_GLGETTEXLEVELPARAMETERFVPROC)IntGetProcAddress(
+            "glGetTexLevelParameterfv");
+    _ptrc_glGetTexLevelParameterfv(target, level, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTexLevelParameteriv(
+    GLenum target, GLint level, GLenum pname, GLint *params)
+{
+    _ptrc_glGetTexLevelParameteriv =
+        (PFN_PTRC_GLGETTEXLEVELPARAMETERIVPROC)IntGetProcAddress(
+            "glGetTexLevelParameteriv");
+    _ptrc_glGetTexLevelParameteriv(target, level, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameterfv(GLenum target, GLenum pname, GLfloat *params)
+{
+    _ptrc_glGetTexParameterfv =
+        (PFN_PTRC_GLGETTEXPARAMETERFVPROC)IntGetProcAddress(
+            "glGetTexParameterfv");
+    _ptrc_glGetTexParameterfv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameteriv(GLenum target, GLenum pname, GLint *params)
+{
+    _ptrc_glGetTexParameteriv =
+        (PFN_PTRC_GLGETTEXPARAMETERIVPROC)IntGetProcAddress(
+            "glGetTexParameteriv");
+    _ptrc_glGetTexParameteriv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_Hint(GLenum target, GLenum mode)
+{
+    _ptrc_glHint = (PFN_PTRC_GLHINTPROC)IntGetProcAddress("glHint");
+    _ptrc_glHint(target, mode);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsEnabled(GLenum cap)
+{
+    _ptrc_glIsEnabled =
+        (PFN_PTRC_GLISENABLEDPROC)IntGetProcAddress("glIsEnabled");
+    return _ptrc_glIsEnabled(cap);
+}
+
+static void CODEGEN_FUNCPTR Switch_LineWidth(GLfloat width)
+{
+    _ptrc_glLineWidth =
+        (PFN_PTRC_GLLINEWIDTHPROC)IntGetProcAddress("glLineWidth");
+    _ptrc_glLineWidth(width);
+}
+
+static void CODEGEN_FUNCPTR Switch_LogicOp(GLenum opcode)
+{
+    _ptrc_glLogicOp = (PFN_PTRC_GLLOGICOPPROC)IntGetProcAddress("glLogicOp");
+    _ptrc_glLogicOp(opcode);
+}
+
+static void CODEGEN_FUNCPTR Switch_PixelStoref(GLenum pname, GLfloat param)
+{
+    _ptrc_glPixelStoref =
+        (PFN_PTRC_GLPIXELSTOREFPROC)IntGetProcAddress("glPixelStoref");
+    _ptrc_glPixelStoref(pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_PixelStorei(GLenum pname, GLint param)
+{
+    _ptrc_glPixelStorei =
+        (PFN_PTRC_GLPIXELSTOREIPROC)IntGetProcAddress("glPixelStorei");
+    _ptrc_glPixelStorei(pname, param);
+}
+
+static void CODEGEN_FUNCPTR Switch_PointSize(GLfloat size)
+{
+    _ptrc_glPointSize =
+        (PFN_PTRC_GLPOINTSIZEPROC)IntGetProcAddress("glPointSize");
+    _ptrc_glPointSize(size);
+}
+
+static void CODEGEN_FUNCPTR Switch_PolygonMode(GLenum face, GLenum mode)
+{
+    _ptrc_glPolygonMode =
+        (PFN_PTRC_GLPOLYGONMODEPROC)IntGetProcAddress("glPolygonMode");
+    _ptrc_glPolygonMode(face, mode);
+}
+
+static void CODEGEN_FUNCPTR Switch_ReadBuffer(GLenum src)
+{
+    _ptrc_glReadBuffer =
+        (PFN_PTRC_GLREADBUFFERPROC)IntGetProcAddress("glReadBuffer");
+    _ptrc_glReadBuffer(src);
+}
+
+static void CODEGEN_FUNCPTR Switch_ReadPixels(
+    GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    void *pixels)
+{
+    _ptrc_glReadPixels =
+        (PFN_PTRC_GLREADPIXELSPROC)IntGetProcAddress("glReadPixels");
+    _ptrc_glReadPixels(x, y, width, height, format, type, pixels);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Scissor(GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    _ptrc_glScissor = (PFN_PTRC_GLSCISSORPROC)IntGetProcAddress("glScissor");
+    _ptrc_glScissor(x, y, width, height);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_StencilFunc(GLenum func, GLint ref, GLuint mask)
+{
+    _ptrc_glStencilFunc =
+        (PFN_PTRC_GLSTENCILFUNCPROC)IntGetProcAddress("glStencilFunc");
+    _ptrc_glStencilFunc(func, ref, mask);
+}
+
+static void CODEGEN_FUNCPTR Switch_StencilMask(GLuint mask)
+{
+    _ptrc_glStencilMask =
+        (PFN_PTRC_GLSTENCILMASKPROC)IntGetProcAddress("glStencilMask");
+    _ptrc_glStencilMask(mask);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_StencilOp(GLenum fail, GLenum zfail, GLenum zpass)
+{
+    _ptrc_glStencilOp =
+        (PFN_PTRC_GLSTENCILOPPROC)IntGetProcAddress("glStencilOp");
+    _ptrc_glStencilOp(fail, zfail, zpass);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexImage1D(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLint border, GLenum format, GLenum type, const void *pixels)
+{
+    _ptrc_glTexImage1D =
+        (PFN_PTRC_GLTEXIMAGE1DPROC)IntGetProcAddress("glTexImage1D");
+    _ptrc_glTexImage1D(
+        target, level, internalformat, width, border, format, type, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexImage2D(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLsizei height, GLint border, GLenum format, GLenum type,
+    const void *pixels)
+{
+    _ptrc_glTexImage2D =
+        (PFN_PTRC_GLTEXIMAGE2DPROC)IntGetProcAddress("glTexImage2D");
+    _ptrc_glTexImage2D(
+        target, level, internalformat, width, height, border, format, type,
+        pixels);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexParameterf(GLenum target, GLenum pname, GLfloat param)
+{
+    _ptrc_glTexParameterf =
+        (PFN_PTRC_GLTEXPARAMETERFPROC)IntGetProcAddress("glTexParameterf");
+    _ptrc_glTexParameterf(target, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexParameterfv(GLenum target, GLenum pname, const GLfloat *params)
+{
+    _ptrc_glTexParameterfv =
+        (PFN_PTRC_GLTEXPARAMETERFVPROC)IntGetProcAddress("glTexParameterfv");
+    _ptrc_glTexParameterfv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexParameteri(GLenum target, GLenum pname, GLint param)
+{
+    _ptrc_glTexParameteri =
+        (PFN_PTRC_GLTEXPARAMETERIPROC)IntGetProcAddress("glTexParameteri");
+    _ptrc_glTexParameteri(target, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexParameteriv(GLenum target, GLenum pname, const GLint *params)
+{
+    _ptrc_glTexParameteriv =
+        (PFN_PTRC_GLTEXPARAMETERIVPROC)IntGetProcAddress("glTexParameteriv");
+    _ptrc_glTexParameteriv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Viewport(GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    _ptrc_glViewport = (PFN_PTRC_GLVIEWPORTPROC)IntGetProcAddress("glViewport");
+    _ptrc_glViewport(x, y, width, height);
+}
+
+/* Extension: 1.1*/
+static void CODEGEN_FUNCPTR Switch_BindTexture(GLenum target, GLuint texture)
+{
+    _ptrc_glBindTexture =
+        (PFN_PTRC_GLBINDTEXTUREPROC)IntGetProcAddress("glBindTexture");
+    _ptrc_glBindTexture(target, texture);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTexImage1D(
+    GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+    GLsizei width, GLint border)
+{
+    _ptrc_glCopyTexImage1D =
+        (PFN_PTRC_GLCOPYTEXIMAGE1DPROC)IntGetProcAddress("glCopyTexImage1D");
+    _ptrc_glCopyTexImage1D(target, level, internalformat, x, y, width, border);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTexImage2D(
+    GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+    GLsizei width, GLsizei height, GLint border)
+{
+    _ptrc_glCopyTexImage2D =
+        (PFN_PTRC_GLCOPYTEXIMAGE2DPROC)IntGetProcAddress("glCopyTexImage2D");
+    _ptrc_glCopyTexImage2D(
+        target, level, internalformat, x, y, width, height, border);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTexSubImage1D(
+    GLenum target, GLint level, GLint xoffset, GLint x, GLint y, GLsizei width)
+{
+    _ptrc_glCopyTexSubImage1D =
+        (PFN_PTRC_GLCOPYTEXSUBIMAGE1DPROC)IntGetProcAddress(
+            "glCopyTexSubImage1D");
+    _ptrc_glCopyTexSubImage1D(target, level, xoffset, x, y, width);
+}
+
+static void CODEGEN_FUNCPTR Switch_CopyTexSubImage2D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+    GLsizei width, GLsizei height)
+{
+    _ptrc_glCopyTexSubImage2D =
+        (PFN_PTRC_GLCOPYTEXSUBIMAGE2DPROC)IntGetProcAddress(
+            "glCopyTexSubImage2D");
+    _ptrc_glCopyTexSubImage2D(
+        target, level, xoffset, yoffset, x, y, width, height);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteTextures(GLsizei n, const GLuint *textures)
+{
+    _ptrc_glDeleteTextures =
+        (PFN_PTRC_GLDELETETEXTURESPROC)IntGetProcAddress("glDeleteTextures");
+    _ptrc_glDeleteTextures(n, textures);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DrawArrays(GLenum mode, GLint first, GLsizei count)
+{
+    _ptrc_glDrawArrays =
+        (PFN_PTRC_GLDRAWARRAYSPROC)IntGetProcAddress("glDrawArrays");
+    _ptrc_glDrawArrays(mode, first, count);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawElements(
+    GLenum mode, GLsizei count, GLenum type, const void *indices)
+{
+    _ptrc_glDrawElements =
+        (PFN_PTRC_GLDRAWELEMENTSPROC)IntGetProcAddress("glDrawElements");
+    _ptrc_glDrawElements(mode, count, type, indices);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenTextures(GLsizei n, GLuint *textures)
+{
+    _ptrc_glGenTextures =
+        (PFN_PTRC_GLGENTEXTURESPROC)IntGetProcAddress("glGenTextures");
+    _ptrc_glGenTextures(n, textures);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsTexture(GLuint texture)
+{
+    _ptrc_glIsTexture =
+        (PFN_PTRC_GLISTEXTUREPROC)IntGetProcAddress("glIsTexture");
+    return _ptrc_glIsTexture(texture);
+}
+
+static void CODEGEN_FUNCPTR Switch_PolygonOffset(GLfloat factor, GLfloat units)
+{
+    _ptrc_glPolygonOffset =
+        (PFN_PTRC_GLPOLYGONOFFSETPROC)IntGetProcAddress("glPolygonOffset");
+    _ptrc_glPolygonOffset(factor, units);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexSubImage1D(
+    GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLenum type, const void *pixels)
+{
+    _ptrc_glTexSubImage1D =
+        (PFN_PTRC_GLTEXSUBIMAGE1DPROC)IntGetProcAddress("glTexSubImage1D");
+    _ptrc_glTexSubImage1D(target, level, xoffset, width, format, type, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexSubImage2D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLenum type, const void *pixels)
+{
+    _ptrc_glTexSubImage2D =
+        (PFN_PTRC_GLTEXSUBIMAGE2DPROC)IntGetProcAddress("glTexSubImage2D");
+    _ptrc_glTexSubImage2D(
+        target, level, xoffset, yoffset, width, height, format, type, pixels);
+}
+
+/* Extension: 1.2*/
+static void CODEGEN_FUNCPTR Switch_CopyTexSubImage3D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    _ptrc_glCopyTexSubImage3D =
+        (PFN_PTRC_GLCOPYTEXSUBIMAGE3DPROC)IntGetProcAddress(
+            "glCopyTexSubImage3D");
+    _ptrc_glCopyTexSubImage3D(
+        target, level, xoffset, yoffset, zoffset, x, y, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawRangeElements(
+    GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type,
+    const void *indices)
+{
+    _ptrc_glDrawRangeElements =
+        (PFN_PTRC_GLDRAWRANGEELEMENTSPROC)IntGetProcAddress(
+            "glDrawRangeElements");
+    _ptrc_glDrawRangeElements(mode, start, end, count, type, indices);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexImage3D(
+    GLenum target, GLint level, GLint internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
+    const void *pixels)
+{
+    _ptrc_glTexImage3D =
+        (PFN_PTRC_GLTEXIMAGE3DPROC)IntGetProcAddress("glTexImage3D");
+    _ptrc_glTexImage3D(
+        target, level, internalformat, width, height, depth, border, format,
+        type, pixels);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexSubImage3D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
+    const void *pixels)
+{
+    _ptrc_glTexSubImage3D =
+        (PFN_PTRC_GLTEXSUBIMAGE3DPROC)IntGetProcAddress("glTexSubImage3D");
+    _ptrc_glTexSubImage3D(
+        target, level, xoffset, yoffset, zoffset, width, height, depth, format,
+        type, pixels);
+}
+
+/* Extension: 1.3*/
+static void CODEGEN_FUNCPTR Switch_ActiveTexture(GLenum texture)
+{
+    _ptrc_glActiveTexture =
+        (PFN_PTRC_GLACTIVETEXTUREPROC)IntGetProcAddress("glActiveTexture");
+    _ptrc_glActiveTexture(texture);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTexImage1D(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLint border, GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTexImage1D =
+        (PFN_PTRC_GLCOMPRESSEDTEXIMAGE1DPROC)IntGetProcAddress(
+            "glCompressedTexImage1D");
+    _ptrc_glCompressedTexImage1D(
+        target, level, internalformat, width, border, imageSize, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTexImage2D(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLsizei height, GLint border, GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTexImage2D =
+        (PFN_PTRC_GLCOMPRESSEDTEXIMAGE2DPROC)IntGetProcAddress(
+            "glCompressedTexImage2D");
+    _ptrc_glCompressedTexImage2D(
+        target, level, internalformat, width, height, border, imageSize, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTexImage3D(
+    GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLint border, GLsizei imageSize,
+    const void *data)
+{
+    _ptrc_glCompressedTexImage3D =
+        (PFN_PTRC_GLCOMPRESSEDTEXIMAGE3DPROC)IntGetProcAddress(
+            "glCompressedTexImage3D");
+    _ptrc_glCompressedTexImage3D(
+        target, level, internalformat, width, height, depth, border, imageSize,
+        data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTexSubImage1D(
+    GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format,
+    GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTexSubImage1D =
+        (PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE1DPROC)IntGetProcAddress(
+            "glCompressedTexSubImage1D");
+    _ptrc_glCompressedTexSubImage1D(
+        target, level, xoffset, width, format, imageSize, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTexSubImage2D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    GLsizei height, GLenum format, GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTexSubImage2D =
+        (PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE2DPROC)IntGetProcAddress(
+            "glCompressedTexSubImage2D");
+    _ptrc_glCompressedTexSubImage2D(
+        target, level, xoffset, yoffset, width, height, format, imageSize,
+        data);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompressedTexSubImage3D(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    GLsizei width, GLsizei height, GLsizei depth, GLenum format,
+    GLsizei imageSize, const void *data)
+{
+    _ptrc_glCompressedTexSubImage3D =
+        (PFN_PTRC_GLCOMPRESSEDTEXSUBIMAGE3DPROC)IntGetProcAddress(
+            "glCompressedTexSubImage3D");
+    _ptrc_glCompressedTexSubImage3D(
+        target, level, xoffset, yoffset, zoffset, width, height, depth, format,
+        imageSize, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetCompressedTexImage(GLenum target, GLint level, void *img)
+{
+    _ptrc_glGetCompressedTexImage =
+        (PFN_PTRC_GLGETCOMPRESSEDTEXIMAGEPROC)IntGetProcAddress(
+            "glGetCompressedTexImage");
+    _ptrc_glGetCompressedTexImage(target, level, img);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SampleCoverage(GLfloat value, GLboolean invert)
+{
+    _ptrc_glSampleCoverage =
+        (PFN_PTRC_GLSAMPLECOVERAGEPROC)IntGetProcAddress("glSampleCoverage");
+    _ptrc_glSampleCoverage(value, invert);
+}
+
+/* Extension: 1.4*/
+static void CODEGEN_FUNCPTR Switch_BlendFuncSeparate(
+    GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha,
+    GLenum dfactorAlpha)
+{
+    _ptrc_glBlendFuncSeparate =
+        (PFN_PTRC_GLBLENDFUNCSEPARATEPROC)IntGetProcAddress(
+            "glBlendFuncSeparate");
+    _ptrc_glBlendFuncSeparate(
+        sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
+}
+
+static void CODEGEN_FUNCPTR Switch_MultiDrawArrays(
+    GLenum mode, const GLint *first, const GLsizei *count, GLsizei drawcount)
+{
+    _ptrc_glMultiDrawArrays =
+        (PFN_PTRC_GLMULTIDRAWARRAYSPROC)IntGetProcAddress("glMultiDrawArrays");
+    _ptrc_glMultiDrawArrays(mode, first, count, drawcount);
+}
+
+static void CODEGEN_FUNCPTR Switch_MultiDrawElements(
+    GLenum mode, const GLsizei *count, GLenum type, const void *const *indices,
+    GLsizei drawcount)
+{
+    _ptrc_glMultiDrawElements =
+        (PFN_PTRC_GLMULTIDRAWELEMENTSPROC)IntGetProcAddress(
+            "glMultiDrawElements");
+    _ptrc_glMultiDrawElements(mode, count, type, indices, drawcount);
+}
+
+static void CODEGEN_FUNCPTR Switch_PointParameterf(GLenum pname, GLfloat param)
+{
+    _ptrc_glPointParameterf =
+        (PFN_PTRC_GLPOINTPARAMETERFPROC)IntGetProcAddress("glPointParameterf");
+    _ptrc_glPointParameterf(pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_PointParameterfv(GLenum pname, const GLfloat *params)
+{
+    _ptrc_glPointParameterfv =
+        (PFN_PTRC_GLPOINTPARAMETERFVPROC)IntGetProcAddress(
+            "glPointParameterfv");
+    _ptrc_glPointParameterfv(pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_PointParameteri(GLenum pname, GLint param)
+{
+    _ptrc_glPointParameteri =
+        (PFN_PTRC_GLPOINTPARAMETERIPROC)IntGetProcAddress("glPointParameteri");
+    _ptrc_glPointParameteri(pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_PointParameteriv(GLenum pname, const GLint *params)
+{
+    _ptrc_glPointParameteriv =
+        (PFN_PTRC_GLPOINTPARAMETERIVPROC)IntGetProcAddress(
+            "glPointParameteriv");
+    _ptrc_glPointParameteriv(pname, params);
+}
+
+/* Extension: 1.5*/
+static void CODEGEN_FUNCPTR Switch_BeginQuery(GLenum target, GLuint id)
+{
+    _ptrc_glBeginQuery =
+        (PFN_PTRC_GLBEGINQUERYPROC)IntGetProcAddress("glBeginQuery");
+    _ptrc_glBeginQuery(target, id);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindBuffer(GLenum target, GLuint buffer)
+{
+    _ptrc_glBindBuffer =
+        (PFN_PTRC_GLBINDBUFFERPROC)IntGetProcAddress("glBindBuffer");
+    _ptrc_glBindBuffer(target, buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_BufferData(
+    GLenum target, GLsizeiptr size, const void *data, GLenum usage)
+{
+    _ptrc_glBufferData =
+        (PFN_PTRC_GLBUFFERDATAPROC)IntGetProcAddress("glBufferData");
+    _ptrc_glBufferData(target, size, data, usage);
+}
+
+static void CODEGEN_FUNCPTR Switch_BufferSubData(
+    GLenum target, GLintptr offset, GLsizeiptr size, const void *data)
+{
+    _ptrc_glBufferSubData =
+        (PFN_PTRC_GLBUFFERSUBDATAPROC)IntGetProcAddress("glBufferSubData");
+    _ptrc_glBufferSubData(target, offset, size, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteBuffers(GLsizei n, const GLuint *buffers)
+{
+    _ptrc_glDeleteBuffers =
+        (PFN_PTRC_GLDELETEBUFFERSPROC)IntGetProcAddress("glDeleteBuffers");
+    _ptrc_glDeleteBuffers(n, buffers);
+}
+
+static void CODEGEN_FUNCPTR Switch_DeleteQueries(GLsizei n, const GLuint *ids)
+{
+    _ptrc_glDeleteQueries =
+        (PFN_PTRC_GLDELETEQUERIESPROC)IntGetProcAddress("glDeleteQueries");
+    _ptrc_glDeleteQueries(n, ids);
+}
+
+static void CODEGEN_FUNCPTR Switch_EndQuery(GLenum target)
+{
+    _ptrc_glEndQuery = (PFN_PTRC_GLENDQUERYPROC)IntGetProcAddress("glEndQuery");
+    _ptrc_glEndQuery(target);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenBuffers(GLsizei n, GLuint *buffers)
+{
+    _ptrc_glGenBuffers =
+        (PFN_PTRC_GLGENBUFFERSPROC)IntGetProcAddress("glGenBuffers");
+    _ptrc_glGenBuffers(n, buffers);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenQueries(GLsizei n, GLuint *ids)
+{
+    _ptrc_glGenQueries =
+        (PFN_PTRC_GLGENQUERIESPROC)IntGetProcAddress("glGenQueries");
+    _ptrc_glGenQueries(n, ids);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetBufferParameteriv(GLenum target, GLenum pname, GLint *params)
+{
+    _ptrc_glGetBufferParameteriv =
+        (PFN_PTRC_GLGETBUFFERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetBufferParameteriv");
+    _ptrc_glGetBufferParameteriv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetBufferPointerv(GLenum target, GLenum pname, void **params)
+{
+    _ptrc_glGetBufferPointerv =
+        (PFN_PTRC_GLGETBUFFERPOINTERVPROC)IntGetProcAddress(
+            "glGetBufferPointerv");
+    _ptrc_glGetBufferPointerv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetBufferSubData(
+    GLenum target, GLintptr offset, GLsizeiptr size, void *data)
+{
+    _ptrc_glGetBufferSubData =
+        (PFN_PTRC_GLGETBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glGetBufferSubData");
+    _ptrc_glGetBufferSubData(target, offset, size, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjectiv(GLuint id, GLenum pname, GLint *params)
+{
+    _ptrc_glGetQueryObjectiv =
+        (PFN_PTRC_GLGETQUERYOBJECTIVPROC)IntGetProcAddress(
+            "glGetQueryObjectiv");
+    _ptrc_glGetQueryObjectiv(id, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjectuiv(GLuint id, GLenum pname, GLuint *params)
+{
+    _ptrc_glGetQueryObjectuiv =
+        (PFN_PTRC_GLGETQUERYOBJECTUIVPROC)IntGetProcAddress(
+            "glGetQueryObjectuiv");
+    _ptrc_glGetQueryObjectuiv(id, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetQueryiv(GLenum target, GLenum pname, GLint *params)
+{
+    _ptrc_glGetQueryiv =
+        (PFN_PTRC_GLGETQUERYIVPROC)IntGetProcAddress("glGetQueryiv");
+    _ptrc_glGetQueryiv(target, pname, params);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsBuffer(GLuint buffer)
+{
+    _ptrc_glIsBuffer = (PFN_PTRC_GLISBUFFERPROC)IntGetProcAddress("glIsBuffer");
+    return _ptrc_glIsBuffer(buffer);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsQuery(GLuint id)
+{
+    _ptrc_glIsQuery = (PFN_PTRC_GLISQUERYPROC)IntGetProcAddress("glIsQuery");
+    return _ptrc_glIsQuery(id);
+}
+
+static void *CODEGEN_FUNCPTR Switch_MapBuffer(GLenum target, GLenum access)
+{
+    _ptrc_glMapBuffer =
+        (PFN_PTRC_GLMAPBUFFERPROC)IntGetProcAddress("glMapBuffer");
+    return _ptrc_glMapBuffer(target, access);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_UnmapBuffer(GLenum target)
+{
+    _ptrc_glUnmapBuffer =
+        (PFN_PTRC_GLUNMAPBUFFERPROC)IntGetProcAddress("glUnmapBuffer");
+    return _ptrc_glUnmapBuffer(target);
+}
+
+/* Extension: 2.0*/
+static void CODEGEN_FUNCPTR Switch_AttachShader(GLuint program, GLuint shader)
+{
+    _ptrc_glAttachShader =
+        (PFN_PTRC_GLATTACHSHADERPROC)IntGetProcAddress("glAttachShader");
+    _ptrc_glAttachShader(program, shader);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindAttribLocation(GLuint program, GLuint index, const GLchar *name)
+{
+    _ptrc_glBindAttribLocation =
+        (PFN_PTRC_GLBINDATTRIBLOCATIONPROC)IntGetProcAddress(
+            "glBindAttribLocation");
+    _ptrc_glBindAttribLocation(program, index, name);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
+{
+    _ptrc_glBlendEquationSeparate =
+        (PFN_PTRC_GLBLENDEQUATIONSEPARATEPROC)IntGetProcAddress(
+            "glBlendEquationSeparate");
+    _ptrc_glBlendEquationSeparate(modeRGB, modeAlpha);
+}
+
+static void CODEGEN_FUNCPTR Switch_CompileShader(GLuint shader)
+{
+    _ptrc_glCompileShader =
+        (PFN_PTRC_GLCOMPILESHADERPROC)IntGetProcAddress("glCompileShader");
+    _ptrc_glCompileShader(shader);
+}
+
+static GLuint CODEGEN_FUNCPTR Switch_CreateProgram(void)
+{
+    _ptrc_glCreateProgram =
+        (PFN_PTRC_GLCREATEPROGRAMPROC)IntGetProcAddress("glCreateProgram");
+    return _ptrc_glCreateProgram();
+}
+
+static GLuint CODEGEN_FUNCPTR Switch_CreateShader(GLenum type)
+{
+    _ptrc_glCreateShader =
+        (PFN_PTRC_GLCREATESHADERPROC)IntGetProcAddress("glCreateShader");
+    return _ptrc_glCreateShader(type);
+}
+
+static void CODEGEN_FUNCPTR Switch_DeleteProgram(GLuint program)
+{
+    _ptrc_glDeleteProgram =
+        (PFN_PTRC_GLDELETEPROGRAMPROC)IntGetProcAddress("glDeleteProgram");
+    _ptrc_glDeleteProgram(program);
+}
+
+static void CODEGEN_FUNCPTR Switch_DeleteShader(GLuint shader)
+{
+    _ptrc_glDeleteShader =
+        (PFN_PTRC_GLDELETESHADERPROC)IntGetProcAddress("glDeleteShader");
+    _ptrc_glDeleteShader(shader);
+}
+
+static void CODEGEN_FUNCPTR Switch_DetachShader(GLuint program, GLuint shader)
+{
+    _ptrc_glDetachShader =
+        (PFN_PTRC_GLDETACHSHADERPROC)IntGetProcAddress("glDetachShader");
+    _ptrc_glDetachShader(program, shader);
+}
+
+static void CODEGEN_FUNCPTR Switch_DisableVertexAttribArray(GLuint index)
+{
+    _ptrc_glDisableVertexAttribArray =
+        (PFN_PTRC_GLDISABLEVERTEXATTRIBARRAYPROC)IntGetProcAddress(
+            "glDisableVertexAttribArray");
+    _ptrc_glDisableVertexAttribArray(index);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawBuffers(GLsizei n, const GLenum *bufs)
+{
+    _ptrc_glDrawBuffers =
+        (PFN_PTRC_GLDRAWBUFFERSPROC)IntGetProcAddress("glDrawBuffers");
+    _ptrc_glDrawBuffers(n, bufs);
+}
+
+static void CODEGEN_FUNCPTR Switch_EnableVertexAttribArray(GLuint index)
+{
+    _ptrc_glEnableVertexAttribArray =
+        (PFN_PTRC_GLENABLEVERTEXATTRIBARRAYPROC)IntGetProcAddress(
+            "glEnableVertexAttribArray");
+    _ptrc_glEnableVertexAttribArray(index);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetActiveAttrib(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+    GLenum *type, GLchar *name)
+{
+    _ptrc_glGetActiveAttrib =
+        (PFN_PTRC_GLGETACTIVEATTRIBPROC)IntGetProcAddress("glGetActiveAttrib");
+    _ptrc_glGetActiveAttrib(program, index, bufSize, length, size, type, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetActiveUniform(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+    GLenum *type, GLchar *name)
+{
+    _ptrc_glGetActiveUniform =
+        (PFN_PTRC_GLGETACTIVEUNIFORMPROC)IntGetProcAddress(
+            "glGetActiveUniform");
+    _ptrc_glGetActiveUniform(program, index, bufSize, length, size, type, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetAttachedShaders(
+    GLuint program, GLsizei maxCount, GLsizei *count, GLuint *shaders)
+{
+    _ptrc_glGetAttachedShaders =
+        (PFN_PTRC_GLGETATTACHEDSHADERSPROC)IntGetProcAddress(
+            "glGetAttachedShaders");
+    _ptrc_glGetAttachedShaders(program, maxCount, count, shaders);
+}
+
+static GLint CODEGEN_FUNCPTR
+Switch_GetAttribLocation(GLuint program, const GLchar *name)
+{
+    _ptrc_glGetAttribLocation =
+        (PFN_PTRC_GLGETATTRIBLOCATIONPROC)IntGetProcAddress(
+            "glGetAttribLocation");
+    return _ptrc_glGetAttribLocation(program, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetProgramInfoLog(
+    GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog)
+{
+    _ptrc_glGetProgramInfoLog =
+        (PFN_PTRC_GLGETPROGRAMINFOLOGPROC)IntGetProcAddress(
+            "glGetProgramInfoLog");
+    _ptrc_glGetProgramInfoLog(program, bufSize, length, infoLog);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetProgramiv(GLuint program, GLenum pname, GLint *params)
+{
+    _ptrc_glGetProgramiv =
+        (PFN_PTRC_GLGETPROGRAMIVPROC)IntGetProcAddress("glGetProgramiv");
+    _ptrc_glGetProgramiv(program, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetShaderInfoLog(
+    GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog)
+{
+    _ptrc_glGetShaderInfoLog =
+        (PFN_PTRC_GLGETSHADERINFOLOGPROC)IntGetProcAddress(
+            "glGetShaderInfoLog");
+    _ptrc_glGetShaderInfoLog(shader, bufSize, length, infoLog);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetShaderSource(
+    GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source)
+{
+    _ptrc_glGetShaderSource =
+        (PFN_PTRC_GLGETSHADERSOURCEPROC)IntGetProcAddress("glGetShaderSource");
+    _ptrc_glGetShaderSource(shader, bufSize, length, source);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetShaderiv(GLuint shader, GLenum pname, GLint *params)
+{
+    _ptrc_glGetShaderiv =
+        (PFN_PTRC_GLGETSHADERIVPROC)IntGetProcAddress("glGetShaderiv");
+    _ptrc_glGetShaderiv(shader, pname, params);
+}
+
+static GLint CODEGEN_FUNCPTR
+Switch_GetUniformLocation(GLuint program, const GLchar *name)
+{
+    _ptrc_glGetUniformLocation =
+        (PFN_PTRC_GLGETUNIFORMLOCATIONPROC)IntGetProcAddress(
+            "glGetUniformLocation");
+    return _ptrc_glGetUniformLocation(program, name);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetUniformfv(GLuint program, GLint location, GLfloat *params)
+{
+    _ptrc_glGetUniformfv =
+        (PFN_PTRC_GLGETUNIFORMFVPROC)IntGetProcAddress("glGetUniformfv");
+    _ptrc_glGetUniformfv(program, location, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetUniformiv(GLuint program, GLint location, GLint *params)
+{
+    _ptrc_glGetUniformiv =
+        (PFN_PTRC_GLGETUNIFORMIVPROC)IntGetProcAddress("glGetUniformiv");
+    _ptrc_glGetUniformiv(program, location, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribPointerv(GLuint index, GLenum pname, void **pointer)
+{
+    _ptrc_glGetVertexAttribPointerv =
+        (PFN_PTRC_GLGETVERTEXATTRIBPOINTERVPROC)IntGetProcAddress(
+            "glGetVertexAttribPointerv");
+    _ptrc_glGetVertexAttribPointerv(index, pname, pointer);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribdv(GLuint index, GLenum pname, GLdouble *params)
+{
+    _ptrc_glGetVertexAttribdv =
+        (PFN_PTRC_GLGETVERTEXATTRIBDVPROC)IntGetProcAddress(
+            "glGetVertexAttribdv");
+    _ptrc_glGetVertexAttribdv(index, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribfv(GLuint index, GLenum pname, GLfloat *params)
+{
+    _ptrc_glGetVertexAttribfv =
+        (PFN_PTRC_GLGETVERTEXATTRIBFVPROC)IntGetProcAddress(
+            "glGetVertexAttribfv");
+    _ptrc_glGetVertexAttribfv(index, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribiv(GLuint index, GLenum pname, GLint *params)
+{
+    _ptrc_glGetVertexAttribiv =
+        (PFN_PTRC_GLGETVERTEXATTRIBIVPROC)IntGetProcAddress(
+            "glGetVertexAttribiv");
+    _ptrc_glGetVertexAttribiv(index, pname, params);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsProgram(GLuint program)
+{
+    _ptrc_glIsProgram =
+        (PFN_PTRC_GLISPROGRAMPROC)IntGetProcAddress("glIsProgram");
+    return _ptrc_glIsProgram(program);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsShader(GLuint shader)
+{
+    _ptrc_glIsShader = (PFN_PTRC_GLISSHADERPROC)IntGetProcAddress("glIsShader");
+    return _ptrc_glIsShader(shader);
+}
+
+static void CODEGEN_FUNCPTR Switch_LinkProgram(GLuint program)
+{
+    _ptrc_glLinkProgram =
+        (PFN_PTRC_GLLINKPROGRAMPROC)IntGetProcAddress("glLinkProgram");
+    _ptrc_glLinkProgram(program);
+}
+
+static void CODEGEN_FUNCPTR Switch_ShaderSource(
+    GLuint shader, GLsizei count, const GLchar *const *string,
+    const GLint *length)
+{
+    _ptrc_glShaderSource =
+        (PFN_PTRC_GLSHADERSOURCEPROC)IntGetProcAddress("glShaderSource");
+    _ptrc_glShaderSource(shader, count, string, length);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_StencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask)
+{
+    _ptrc_glStencilFuncSeparate =
+        (PFN_PTRC_GLSTENCILFUNCSEPARATEPROC)IntGetProcAddress(
+            "glStencilFuncSeparate");
+    _ptrc_glStencilFuncSeparate(face, func, ref, mask);
+}
+
+static void CODEGEN_FUNCPTR Switch_StencilMaskSeparate(GLenum face, GLuint mask)
+{
+    _ptrc_glStencilMaskSeparate =
+        (PFN_PTRC_GLSTENCILMASKSEPARATEPROC)IntGetProcAddress(
+            "glStencilMaskSeparate");
+    _ptrc_glStencilMaskSeparate(face, mask);
+}
+
+static void CODEGEN_FUNCPTR Switch_StencilOpSeparate(
+    GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)
+{
+    _ptrc_glStencilOpSeparate =
+        (PFN_PTRC_GLSTENCILOPSEPARATEPROC)IntGetProcAddress(
+            "glStencilOpSeparate");
+    _ptrc_glStencilOpSeparate(face, sfail, dpfail, dppass);
+}
+
+static void CODEGEN_FUNCPTR Switch_Uniform1f(GLint location, GLfloat v0)
+{
+    _ptrc_glUniform1f =
+        (PFN_PTRC_GLUNIFORM1FPROC)IntGetProcAddress("glUniform1f");
+    _ptrc_glUniform1f(location, v0);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform1fv(GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glUniform1fv =
+        (PFN_PTRC_GLUNIFORM1FVPROC)IntGetProcAddress("glUniform1fv");
+    _ptrc_glUniform1fv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_Uniform1i(GLint location, GLint v0)
+{
+    _ptrc_glUniform1i =
+        (PFN_PTRC_GLUNIFORM1IPROC)IntGetProcAddress("glUniform1i");
+    _ptrc_glUniform1i(location, v0);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform1iv(GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glUniform1iv =
+        (PFN_PTRC_GLUNIFORM1IVPROC)IntGetProcAddress("glUniform1iv");
+    _ptrc_glUniform1iv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform2f(GLint location, GLfloat v0, GLfloat v1)
+{
+    _ptrc_glUniform2f =
+        (PFN_PTRC_GLUNIFORM2FPROC)IntGetProcAddress("glUniform2f");
+    _ptrc_glUniform2f(location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform2fv(GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glUniform2fv =
+        (PFN_PTRC_GLUNIFORM2FVPROC)IntGetProcAddress("glUniform2fv");
+    _ptrc_glUniform2fv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_Uniform2i(GLint location, GLint v0, GLint v1)
+{
+    _ptrc_glUniform2i =
+        (PFN_PTRC_GLUNIFORM2IPROC)IntGetProcAddress("glUniform2i");
+    _ptrc_glUniform2i(location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform2iv(GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glUniform2iv =
+        (PFN_PTRC_GLUNIFORM2IVPROC)IntGetProcAddress("glUniform2iv");
+    _ptrc_glUniform2iv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2)
+{
+    _ptrc_glUniform3f =
+        (PFN_PTRC_GLUNIFORM3FPROC)IntGetProcAddress("glUniform3f");
+    _ptrc_glUniform3f(location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform3fv(GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glUniform3fv =
+        (PFN_PTRC_GLUNIFORM3FVPROC)IntGetProcAddress("glUniform3fv");
+    _ptrc_glUniform3fv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform3i(GLint location, GLint v0, GLint v1, GLint v2)
+{
+    _ptrc_glUniform3i =
+        (PFN_PTRC_GLUNIFORM3IPROC)IntGetProcAddress("glUniform3i");
+    _ptrc_glUniform3i(location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform3iv(GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glUniform3iv =
+        (PFN_PTRC_GLUNIFORM3IVPROC)IntGetProcAddress("glUniform3iv");
+    _ptrc_glUniform3iv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3)
+{
+    _ptrc_glUniform4f =
+        (PFN_PTRC_GLUNIFORM4FPROC)IntGetProcAddress("glUniform4f");
+    _ptrc_glUniform4f(location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform4fv(GLint location, GLsizei count, const GLfloat *value)
+{
+    _ptrc_glUniform4fv =
+        (PFN_PTRC_GLUNIFORM4FVPROC)IntGetProcAddress("glUniform4fv");
+    _ptrc_glUniform4fv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform4i(GLint location, GLint v0, GLint v1, GLint v2, GLint v3)
+{
+    _ptrc_glUniform4i =
+        (PFN_PTRC_GLUNIFORM4IPROC)IntGetProcAddress("glUniform4i");
+    _ptrc_glUniform4i(location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform4iv(GLint location, GLsizei count, const GLint *value)
+{
+    _ptrc_glUniform4iv =
+        (PFN_PTRC_GLUNIFORM4IVPROC)IntGetProcAddress("glUniform4iv");
+    _ptrc_glUniform4iv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix2fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix2fv =
+        (PFN_PTRC_GLUNIFORMMATRIX2FVPROC)IntGetProcAddress(
+            "glUniformMatrix2fv");
+    _ptrc_glUniformMatrix2fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix3fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix3fv =
+        (PFN_PTRC_GLUNIFORMMATRIX3FVPROC)IntGetProcAddress(
+            "glUniformMatrix3fv");
+    _ptrc_glUniformMatrix3fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix4fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix4fv =
+        (PFN_PTRC_GLUNIFORMMATRIX4FVPROC)IntGetProcAddress(
+            "glUniformMatrix4fv");
+    _ptrc_glUniformMatrix4fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UseProgram(GLuint program)
+{
+    _ptrc_glUseProgram =
+        (PFN_PTRC_GLUSEPROGRAMPROC)IntGetProcAddress("glUseProgram");
+    _ptrc_glUseProgram(program);
+}
+
+static void CODEGEN_FUNCPTR Switch_ValidateProgram(GLuint program)
+{
+    _ptrc_glValidateProgram =
+        (PFN_PTRC_GLVALIDATEPROGRAMPROC)IntGetProcAddress("glValidateProgram");
+    _ptrc_glValidateProgram(program);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttrib1d(GLuint index, GLdouble x)
+{
+    _ptrc_glVertexAttrib1d =
+        (PFN_PTRC_GLVERTEXATTRIB1DPROC)IntGetProcAddress("glVertexAttrib1d");
+    _ptrc_glVertexAttrib1d(index, x);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib1dv(GLuint index, const GLdouble *v)
+{
+    _ptrc_glVertexAttrib1dv =
+        (PFN_PTRC_GLVERTEXATTRIB1DVPROC)IntGetProcAddress("glVertexAttrib1dv");
+    _ptrc_glVertexAttrib1dv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttrib1f(GLuint index, GLfloat x)
+{
+    _ptrc_glVertexAttrib1f =
+        (PFN_PTRC_GLVERTEXATTRIB1FPROC)IntGetProcAddress("glVertexAttrib1f");
+    _ptrc_glVertexAttrib1f(index, x);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib1fv(GLuint index, const GLfloat *v)
+{
+    _ptrc_glVertexAttrib1fv =
+        (PFN_PTRC_GLVERTEXATTRIB1FVPROC)IntGetProcAddress("glVertexAttrib1fv");
+    _ptrc_glVertexAttrib1fv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttrib1s(GLuint index, GLshort x)
+{
+    _ptrc_glVertexAttrib1s =
+        (PFN_PTRC_GLVERTEXATTRIB1SPROC)IntGetProcAddress("glVertexAttrib1s");
+    _ptrc_glVertexAttrib1s(index, x);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib1sv(GLuint index, const GLshort *v)
+{
+    _ptrc_glVertexAttrib1sv =
+        (PFN_PTRC_GLVERTEXATTRIB1SVPROC)IntGetProcAddress("glVertexAttrib1sv");
+    _ptrc_glVertexAttrib1sv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2d(GLuint index, GLdouble x, GLdouble y)
+{
+    _ptrc_glVertexAttrib2d =
+        (PFN_PTRC_GLVERTEXATTRIB2DPROC)IntGetProcAddress("glVertexAttrib2d");
+    _ptrc_glVertexAttrib2d(index, x, y);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2dv(GLuint index, const GLdouble *v)
+{
+    _ptrc_glVertexAttrib2dv =
+        (PFN_PTRC_GLVERTEXATTRIB2DVPROC)IntGetProcAddress("glVertexAttrib2dv");
+    _ptrc_glVertexAttrib2dv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2f(GLuint index, GLfloat x, GLfloat y)
+{
+    _ptrc_glVertexAttrib2f =
+        (PFN_PTRC_GLVERTEXATTRIB2FPROC)IntGetProcAddress("glVertexAttrib2f");
+    _ptrc_glVertexAttrib2f(index, x, y);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2fv(GLuint index, const GLfloat *v)
+{
+    _ptrc_glVertexAttrib2fv =
+        (PFN_PTRC_GLVERTEXATTRIB2FVPROC)IntGetProcAddress("glVertexAttrib2fv");
+    _ptrc_glVertexAttrib2fv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2s(GLuint index, GLshort x, GLshort y)
+{
+    _ptrc_glVertexAttrib2s =
+        (PFN_PTRC_GLVERTEXATTRIB2SPROC)IntGetProcAddress("glVertexAttrib2s");
+    _ptrc_glVertexAttrib2s(index, x, y);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib2sv(GLuint index, const GLshort *v)
+{
+    _ptrc_glVertexAttrib2sv =
+        (PFN_PTRC_GLVERTEXATTRIB2SVPROC)IntGetProcAddress("glVertexAttrib2sv");
+    _ptrc_glVertexAttrib2sv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3d(GLuint index, GLdouble x, GLdouble y, GLdouble z)
+{
+    _ptrc_glVertexAttrib3d =
+        (PFN_PTRC_GLVERTEXATTRIB3DPROC)IntGetProcAddress("glVertexAttrib3d");
+    _ptrc_glVertexAttrib3d(index, x, y, z);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3dv(GLuint index, const GLdouble *v)
+{
+    _ptrc_glVertexAttrib3dv =
+        (PFN_PTRC_GLVERTEXATTRIB3DVPROC)IntGetProcAddress("glVertexAttrib3dv");
+    _ptrc_glVertexAttrib3dv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3f(GLuint index, GLfloat x, GLfloat y, GLfloat z)
+{
+    _ptrc_glVertexAttrib3f =
+        (PFN_PTRC_GLVERTEXATTRIB3FPROC)IntGetProcAddress("glVertexAttrib3f");
+    _ptrc_glVertexAttrib3f(index, x, y, z);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3fv(GLuint index, const GLfloat *v)
+{
+    _ptrc_glVertexAttrib3fv =
+        (PFN_PTRC_GLVERTEXATTRIB3FVPROC)IntGetProcAddress("glVertexAttrib3fv");
+    _ptrc_glVertexAttrib3fv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3s(GLuint index, GLshort x, GLshort y, GLshort z)
+{
+    _ptrc_glVertexAttrib3s =
+        (PFN_PTRC_GLVERTEXATTRIB3SPROC)IntGetProcAddress("glVertexAttrib3s");
+    _ptrc_glVertexAttrib3s(index, x, y, z);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib3sv(GLuint index, const GLshort *v)
+{
+    _ptrc_glVertexAttrib3sv =
+        (PFN_PTRC_GLVERTEXATTRIB3SVPROC)IntGetProcAddress("glVertexAttrib3sv");
+    _ptrc_glVertexAttrib3sv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nbv(GLuint index, const GLbyte *v)
+{
+    _ptrc_glVertexAttrib4Nbv =
+        (PFN_PTRC_GLVERTEXATTRIB4NBVPROC)IntGetProcAddress(
+            "glVertexAttrib4Nbv");
+    _ptrc_glVertexAttrib4Nbv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Niv(GLuint index, const GLint *v)
+{
+    _ptrc_glVertexAttrib4Niv =
+        (PFN_PTRC_GLVERTEXATTRIB4NIVPROC)IntGetProcAddress(
+            "glVertexAttrib4Niv");
+    _ptrc_glVertexAttrib4Niv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nsv(GLuint index, const GLshort *v)
+{
+    _ptrc_glVertexAttrib4Nsv =
+        (PFN_PTRC_GLVERTEXATTRIB4NSVPROC)IntGetProcAddress(
+            "glVertexAttrib4Nsv");
+    _ptrc_glVertexAttrib4Nsv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttrib4Nub(
+    GLuint index, GLubyte x, GLubyte y, GLubyte z, GLubyte w)
+{
+    _ptrc_glVertexAttrib4Nub =
+        (PFN_PTRC_GLVERTEXATTRIB4NUBPROC)IntGetProcAddress(
+            "glVertexAttrib4Nub");
+    _ptrc_glVertexAttrib4Nub(index, x, y, z, w);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nubv(GLuint index, const GLubyte *v)
+{
+    _ptrc_glVertexAttrib4Nubv =
+        (PFN_PTRC_GLVERTEXATTRIB4NUBVPROC)IntGetProcAddress(
+            "glVertexAttrib4Nubv");
+    _ptrc_glVertexAttrib4Nubv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nuiv(GLuint index, const GLuint *v)
+{
+    _ptrc_glVertexAttrib4Nuiv =
+        (PFN_PTRC_GLVERTEXATTRIB4NUIVPROC)IntGetProcAddress(
+            "glVertexAttrib4Nuiv");
+    _ptrc_glVertexAttrib4Nuiv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4Nusv(GLuint index, const GLushort *v)
+{
+    _ptrc_glVertexAttrib4Nusv =
+        (PFN_PTRC_GLVERTEXATTRIB4NUSVPROC)IntGetProcAddress(
+            "glVertexAttrib4Nusv");
+    _ptrc_glVertexAttrib4Nusv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4bv(GLuint index, const GLbyte *v)
+{
+    _ptrc_glVertexAttrib4bv =
+        (PFN_PTRC_GLVERTEXATTRIB4BVPROC)IntGetProcAddress("glVertexAttrib4bv");
+    _ptrc_glVertexAttrib4bv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttrib4d(
+    GLuint index, GLdouble x, GLdouble y, GLdouble z, GLdouble w)
+{
+    _ptrc_glVertexAttrib4d =
+        (PFN_PTRC_GLVERTEXATTRIB4DPROC)IntGetProcAddress("glVertexAttrib4d");
+    _ptrc_glVertexAttrib4d(index, x, y, z, w);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4dv(GLuint index, const GLdouble *v)
+{
+    _ptrc_glVertexAttrib4dv =
+        (PFN_PTRC_GLVERTEXATTRIB4DVPROC)IntGetProcAddress("glVertexAttrib4dv");
+    _ptrc_glVertexAttrib4dv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4f(GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w)
+{
+    _ptrc_glVertexAttrib4f =
+        (PFN_PTRC_GLVERTEXATTRIB4FPROC)IntGetProcAddress("glVertexAttrib4f");
+    _ptrc_glVertexAttrib4f(index, x, y, z, w);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4fv(GLuint index, const GLfloat *v)
+{
+    _ptrc_glVertexAttrib4fv =
+        (PFN_PTRC_GLVERTEXATTRIB4FVPROC)IntGetProcAddress("glVertexAttrib4fv");
+    _ptrc_glVertexAttrib4fv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttrib4iv(GLuint index, const GLint *v)
+{
+    _ptrc_glVertexAttrib4iv =
+        (PFN_PTRC_GLVERTEXATTRIB4IVPROC)IntGetProcAddress("glVertexAttrib4iv");
+    _ptrc_glVertexAttrib4iv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4s(GLuint index, GLshort x, GLshort y, GLshort z, GLshort w)
+{
+    _ptrc_glVertexAttrib4s =
+        (PFN_PTRC_GLVERTEXATTRIB4SPROC)IntGetProcAddress("glVertexAttrib4s");
+    _ptrc_glVertexAttrib4s(index, x, y, z, w);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4sv(GLuint index, const GLshort *v)
+{
+    _ptrc_glVertexAttrib4sv =
+        (PFN_PTRC_GLVERTEXATTRIB4SVPROC)IntGetProcAddress("glVertexAttrib4sv");
+    _ptrc_glVertexAttrib4sv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4ubv(GLuint index, const GLubyte *v)
+{
+    _ptrc_glVertexAttrib4ubv =
+        (PFN_PTRC_GLVERTEXATTRIB4UBVPROC)IntGetProcAddress(
+            "glVertexAttrib4ubv");
+    _ptrc_glVertexAttrib4ubv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4uiv(GLuint index, const GLuint *v)
+{
+    _ptrc_glVertexAttrib4uiv =
+        (PFN_PTRC_GLVERTEXATTRIB4UIVPROC)IntGetProcAddress(
+            "glVertexAttrib4uiv");
+    _ptrc_glVertexAttrib4uiv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttrib4usv(GLuint index, const GLushort *v)
+{
+    _ptrc_glVertexAttrib4usv =
+        (PFN_PTRC_GLVERTEXATTRIB4USVPROC)IntGetProcAddress(
+            "glVertexAttrib4usv");
+    _ptrc_glVertexAttrib4usv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribPointer(
+    GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride,
+    const void *pointer)
+{
+    _ptrc_glVertexAttribPointer =
+        (PFN_PTRC_GLVERTEXATTRIBPOINTERPROC)IntGetProcAddress(
+            "glVertexAttribPointer");
+    _ptrc_glVertexAttribPointer(index, size, type, normalized, stride, pointer);
+}
+
+/* Extension: 2.1*/
+static void CODEGEN_FUNCPTR Switch_UniformMatrix2x3fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix2x3fv =
+        (PFN_PTRC_GLUNIFORMMATRIX2X3FVPROC)IntGetProcAddress(
+            "glUniformMatrix2x3fv");
+    _ptrc_glUniformMatrix2x3fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix2x4fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix2x4fv =
+        (PFN_PTRC_GLUNIFORMMATRIX2X4FVPROC)IntGetProcAddress(
+            "glUniformMatrix2x4fv");
+    _ptrc_glUniformMatrix2x4fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix3x2fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix3x2fv =
+        (PFN_PTRC_GLUNIFORMMATRIX3X2FVPROC)IntGetProcAddress(
+            "glUniformMatrix3x2fv");
+    _ptrc_glUniformMatrix3x2fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix3x4fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix3x4fv =
+        (PFN_PTRC_GLUNIFORMMATRIX3X4FVPROC)IntGetProcAddress(
+            "glUniformMatrix3x4fv");
+    _ptrc_glUniformMatrix3x4fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix4x2fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix4x2fv =
+        (PFN_PTRC_GLUNIFORMMATRIX4X2FVPROC)IntGetProcAddress(
+            "glUniformMatrix4x2fv");
+    _ptrc_glUniformMatrix4x2fv(location, count, transpose, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformMatrix4x3fv(
+    GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    _ptrc_glUniformMatrix4x3fv =
+        (PFN_PTRC_GLUNIFORMMATRIX4X3FVPROC)IntGetProcAddress(
+            "glUniformMatrix4x3fv");
+    _ptrc_glUniformMatrix4x3fv(location, count, transpose, value);
+}
+
+/* Extension: 3.0*/
+static void CODEGEN_FUNCPTR
+Switch_BeginConditionalRender(GLuint id, GLenum mode)
+{
+    _ptrc_glBeginConditionalRender =
+        (PFN_PTRC_GLBEGINCONDITIONALRENDERPROC)IntGetProcAddress(
+            "glBeginConditionalRender");
+    _ptrc_glBeginConditionalRender(id, mode);
+}
+
+static void CODEGEN_FUNCPTR Switch_BeginTransformFeedback(GLenum primitiveMode)
+{
+    _ptrc_glBeginTransformFeedback =
+        (PFN_PTRC_GLBEGINTRANSFORMFEEDBACKPROC)IntGetProcAddress(
+            "glBeginTransformFeedback");
+    _ptrc_glBeginTransformFeedback(primitiveMode);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindBufferBase(GLenum target, GLuint index, GLuint buffer)
+{
+    _ptrc_glBindBufferBase =
+        (PFN_PTRC_GLBINDBUFFERBASEPROC)IntGetProcAddress("glBindBufferBase");
+    _ptrc_glBindBufferBase(target, index, buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindBufferRange(
+    GLenum target, GLuint index, GLuint buffer, GLintptr offset,
+    GLsizeiptr size)
+{
+    _ptrc_glBindBufferRange =
+        (PFN_PTRC_GLBINDBUFFERRANGEPROC)IntGetProcAddress("glBindBufferRange");
+    _ptrc_glBindBufferRange(target, index, buffer, offset, size);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindFragDataLocation(GLuint program, GLuint color, const GLchar *name)
+{
+    _ptrc_glBindFragDataLocation =
+        (PFN_PTRC_GLBINDFRAGDATALOCATIONPROC)IntGetProcAddress(
+            "glBindFragDataLocation");
+    _ptrc_glBindFragDataLocation(program, color, name);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindFramebuffer(GLenum target, GLuint framebuffer)
+{
+    _ptrc_glBindFramebuffer =
+        (PFN_PTRC_GLBINDFRAMEBUFFERPROC)IntGetProcAddress("glBindFramebuffer");
+    _ptrc_glBindFramebuffer(target, framebuffer);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_BindRenderbuffer(GLenum target, GLuint renderbuffer)
+{
+    _ptrc_glBindRenderbuffer =
+        (PFN_PTRC_GLBINDRENDERBUFFERPROC)IntGetProcAddress(
+            "glBindRenderbuffer");
+    _ptrc_glBindRenderbuffer(target, renderbuffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindVertexArray(GLuint ren_array)
+{
+    _ptrc_glBindVertexArray =
+        (PFN_PTRC_GLBINDVERTEXARRAYPROC)IntGetProcAddress("glBindVertexArray");
+    _ptrc_glBindVertexArray(ren_array);
+}
+
+static void CODEGEN_FUNCPTR Switch_BlitFramebuffer(
+    GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0,
+    GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)
+{
+    _ptrc_glBlitFramebuffer =
+        (PFN_PTRC_GLBLITFRAMEBUFFERPROC)IntGetProcAddress("glBlitFramebuffer");
+    _ptrc_glBlitFramebuffer(
+        srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+}
+
+static GLenum CODEGEN_FUNCPTR Switch_CheckFramebufferStatus(GLenum target)
+{
+    _ptrc_glCheckFramebufferStatus =
+        (PFN_PTRC_GLCHECKFRAMEBUFFERSTATUSPROC)IntGetProcAddress(
+            "glCheckFramebufferStatus");
+    return _ptrc_glCheckFramebufferStatus(target);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClampColor(GLenum target, GLenum clamp)
+{
+    _ptrc_glClampColor =
+        (PFN_PTRC_GLCLAMPCOLORPROC)IntGetProcAddress("glClampColor");
+    _ptrc_glClampColor(target, clamp);
+}
+
+static void CODEGEN_FUNCPTR Switch_ClearBufferfi(
+    GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)
+{
+    _ptrc_glClearBufferfi =
+        (PFN_PTRC_GLCLEARBUFFERFIPROC)IntGetProcAddress("glClearBufferfi");
+    _ptrc_glClearBufferfi(buffer, drawbuffer, depth, stencil);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ClearBufferfv(GLenum buffer, GLint drawbuffer, const GLfloat *value)
+{
+    _ptrc_glClearBufferfv =
+        (PFN_PTRC_GLCLEARBUFFERFVPROC)IntGetProcAddress("glClearBufferfv");
+    _ptrc_glClearBufferfv(buffer, drawbuffer, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ClearBufferiv(GLenum buffer, GLint drawbuffer, const GLint *value)
+{
+    _ptrc_glClearBufferiv =
+        (PFN_PTRC_GLCLEARBUFFERIVPROC)IntGetProcAddress("glClearBufferiv");
+    _ptrc_glClearBufferiv(buffer, drawbuffer, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_ClearBufferuiv(GLenum buffer, GLint drawbuffer, const GLuint *value)
+{
+    _ptrc_glClearBufferuiv =
+        (PFN_PTRC_GLCLEARBUFFERUIVPROC)IntGetProcAddress("glClearBufferuiv");
+    _ptrc_glClearBufferuiv(buffer, drawbuffer, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_ColorMaski(
+    GLuint index, GLboolean r, GLboolean g, GLboolean b, GLboolean a)
+{
+    _ptrc_glColorMaski =
+        (PFN_PTRC_GLCOLORMASKIPROC)IntGetProcAddress("glColorMaski");
+    _ptrc_glColorMaski(index, r, g, b, a);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteFramebuffers(GLsizei n, const GLuint *framebuffers)
+{
+    _ptrc_glDeleteFramebuffers =
+        (PFN_PTRC_GLDELETEFRAMEBUFFERSPROC)IntGetProcAddress(
+            "glDeleteFramebuffers");
+    _ptrc_glDeleteFramebuffers(n, framebuffers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteRenderbuffers(GLsizei n, const GLuint *renderbuffers)
+{
+    _ptrc_glDeleteRenderbuffers =
+        (PFN_PTRC_GLDELETERENDERBUFFERSPROC)IntGetProcAddress(
+            "glDeleteRenderbuffers");
+    _ptrc_glDeleteRenderbuffers(n, renderbuffers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteVertexArrays(GLsizei n, const GLuint *arrays)
+{
+    _ptrc_glDeleteVertexArrays =
+        (PFN_PTRC_GLDELETEVERTEXARRAYSPROC)IntGetProcAddress(
+            "glDeleteVertexArrays");
+    _ptrc_glDeleteVertexArrays(n, arrays);
+}
+
+static void CODEGEN_FUNCPTR Switch_Disablei(GLenum target, GLuint index)
+{
+    _ptrc_glDisablei = (PFN_PTRC_GLDISABLEIPROC)IntGetProcAddress("glDisablei");
+    _ptrc_glDisablei(target, index);
+}
+
+static void CODEGEN_FUNCPTR Switch_Enablei(GLenum target, GLuint index)
+{
+    _ptrc_glEnablei = (PFN_PTRC_GLENABLEIPROC)IntGetProcAddress("glEnablei");
+    _ptrc_glEnablei(target, index);
+}
+
+static void CODEGEN_FUNCPTR Switch_EndConditionalRender(void)
+{
+    _ptrc_glEndConditionalRender =
+        (PFN_PTRC_GLENDCONDITIONALRENDERPROC)IntGetProcAddress(
+            "glEndConditionalRender");
+    _ptrc_glEndConditionalRender();
+}
+
+static void CODEGEN_FUNCPTR Switch_EndTransformFeedback(void)
+{
+    _ptrc_glEndTransformFeedback =
+        (PFN_PTRC_GLENDTRANSFORMFEEDBACKPROC)IntGetProcAddress(
+            "glEndTransformFeedback");
+    _ptrc_glEndTransformFeedback();
+}
+
+static void CODEGEN_FUNCPTR
+Switch_FlushMappedBufferRange(GLenum target, GLintptr offset, GLsizeiptr length)
+{
+    _ptrc_glFlushMappedBufferRange =
+        (PFN_PTRC_GLFLUSHMAPPEDBUFFERRANGEPROC)IntGetProcAddress(
+            "glFlushMappedBufferRange");
+    _ptrc_glFlushMappedBufferRange(target, offset, length);
+}
+
+static void CODEGEN_FUNCPTR Switch_FramebufferRenderbuffer(
+    GLenum target, GLenum attachment, GLenum renderbuffertarget,
+    GLuint renderbuffer)
+{
+    _ptrc_glFramebufferRenderbuffer =
+        (PFN_PTRC_GLFRAMEBUFFERRENDERBUFFERPROC)IntGetProcAddress(
+            "glFramebufferRenderbuffer");
+    _ptrc_glFramebufferRenderbuffer(
+        target, attachment, renderbuffertarget, renderbuffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture1D(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level)
+{
+    _ptrc_glFramebufferTexture1D =
+        (PFN_PTRC_GLFRAMEBUFFERTEXTURE1DPROC)IntGetProcAddress(
+            "glFramebufferTexture1D");
+    _ptrc_glFramebufferTexture1D(target, attachment, textarget, texture, level);
+}
+
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture2D(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level)
+{
+    _ptrc_glFramebufferTexture2D =
+        (PFN_PTRC_GLFRAMEBUFFERTEXTURE2DPROC)IntGetProcAddress(
+            "glFramebufferTexture2D");
+    _ptrc_glFramebufferTexture2D(target, attachment, textarget, texture, level);
+}
+
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture3D(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
+    GLint level, GLint zoffset)
+{
+    _ptrc_glFramebufferTexture3D =
+        (PFN_PTRC_GLFRAMEBUFFERTEXTURE3DPROC)IntGetProcAddress(
+            "glFramebufferTexture3D");
+    _ptrc_glFramebufferTexture3D(
+        target, attachment, textarget, texture, level, zoffset);
+}
+
+static void CODEGEN_FUNCPTR Switch_FramebufferTextureLayer(
+    GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer)
+{
+    _ptrc_glFramebufferTextureLayer =
+        (PFN_PTRC_GLFRAMEBUFFERTEXTURELAYERPROC)IntGetProcAddress(
+            "glFramebufferTextureLayer");
+    _ptrc_glFramebufferTextureLayer(target, attachment, texture, level, layer);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GenFramebuffers(GLsizei n, GLuint *framebuffers)
+{
+    _ptrc_glGenFramebuffers =
+        (PFN_PTRC_GLGENFRAMEBUFFERSPROC)IntGetProcAddress("glGenFramebuffers");
+    _ptrc_glGenFramebuffers(n, framebuffers);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GenRenderbuffers(GLsizei n, GLuint *renderbuffers)
+{
+    _ptrc_glGenRenderbuffers =
+        (PFN_PTRC_GLGENRENDERBUFFERSPROC)IntGetProcAddress(
+            "glGenRenderbuffers");
+    _ptrc_glGenRenderbuffers(n, renderbuffers);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenVertexArrays(GLsizei n, GLuint *arrays)
+{
+    _ptrc_glGenVertexArrays =
+        (PFN_PTRC_GLGENVERTEXARRAYSPROC)IntGetProcAddress("glGenVertexArrays");
+    _ptrc_glGenVertexArrays(n, arrays);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenerateMipmap(GLenum target)
+{
+    _ptrc_glGenerateMipmap =
+        (PFN_PTRC_GLGENERATEMIPMAPPROC)IntGetProcAddress("glGenerateMipmap");
+    _ptrc_glGenerateMipmap(target);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetBooleani_v(GLenum target, GLuint index, GLboolean *data)
+{
+    _ptrc_glGetBooleani_v =
+        (PFN_PTRC_GLGETBOOLEANI_VPROC)IntGetProcAddress("glGetBooleani_v");
+    _ptrc_glGetBooleani_v(target, index, data);
+}
+
+static GLint CODEGEN_FUNCPTR
+Switch_GetFragDataLocation(GLuint program, const GLchar *name)
+{
+    _ptrc_glGetFragDataLocation =
+        (PFN_PTRC_GLGETFRAGDATALOCATIONPROC)IntGetProcAddress(
+            "glGetFragDataLocation");
+    return _ptrc_glGetFragDataLocation(program, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetFramebufferAttachmentParameteriv(
+    GLenum target, GLenum attachment, GLenum pname, GLint *params)
+{
+    _ptrc_glGetFramebufferAttachmentParameteriv =
+        (PFN_PTRC_GLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC)IntGetProcAddress(
+            "glGetFramebufferAttachmentParameteriv");
+    _ptrc_glGetFramebufferAttachmentParameteriv(
+        target, attachment, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetIntegeri_v(GLenum target, GLuint index, GLint *data)
+{
+    _ptrc_glGetIntegeri_v =
+        (PFN_PTRC_GLGETINTEGERI_VPROC)IntGetProcAddress("glGetIntegeri_v");
+    _ptrc_glGetIntegeri_v(target, index, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetRenderbufferParameteriv(GLenum target, GLenum pname, GLint *params)
+{
+    _ptrc_glGetRenderbufferParameteriv =
+        (PFN_PTRC_GLGETRENDERBUFFERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetRenderbufferParameteriv");
+    _ptrc_glGetRenderbufferParameteriv(target, pname, params);
+}
+
+static const GLubyte *CODEGEN_FUNCPTR
+Switch_GetStringi(GLenum name, GLuint index)
+{
+    _ptrc_glGetStringi =
+        (PFN_PTRC_GLGETSTRINGIPROC)IntGetProcAddress("glGetStringi");
+    return _ptrc_glGetStringi(name, index);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameterIiv(GLenum target, GLenum pname, GLint *params)
+{
+    _ptrc_glGetTexParameterIiv =
+        (PFN_PTRC_GLGETTEXPARAMETERIIVPROC)IntGetProcAddress(
+            "glGetTexParameterIiv");
+    _ptrc_glGetTexParameterIiv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetTexParameterIuiv(GLenum target, GLenum pname, GLuint *params)
+{
+    _ptrc_glGetTexParameterIuiv =
+        (PFN_PTRC_GLGETTEXPARAMETERIUIVPROC)IntGetProcAddress(
+            "glGetTexParameterIuiv");
+    _ptrc_glGetTexParameterIuiv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetTransformFeedbackVarying(
+    GLuint program, GLuint index, GLsizei bufSize, GLsizei *length,
+    GLsizei *size, GLenum *type, GLchar *name)
+{
+    _ptrc_glGetTransformFeedbackVarying =
+        (PFN_PTRC_GLGETTRANSFORMFEEDBACKVARYINGPROC)IntGetProcAddress(
+            "glGetTransformFeedbackVarying");
+    _ptrc_glGetTransformFeedbackVarying(
+        program, index, bufSize, length, size, type, name);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetUniformuiv(GLuint program, GLint location, GLuint *params)
+{
+    _ptrc_glGetUniformuiv =
+        (PFN_PTRC_GLGETUNIFORMUIVPROC)IntGetProcAddress("glGetUniformuiv");
+    _ptrc_glGetUniformuiv(program, location, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribIiv(GLuint index, GLenum pname, GLint *params)
+{
+    _ptrc_glGetVertexAttribIiv =
+        (PFN_PTRC_GLGETVERTEXATTRIBIIVPROC)IntGetProcAddress(
+            "glGetVertexAttribIiv");
+    _ptrc_glGetVertexAttribIiv(index, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetVertexAttribIuiv(GLuint index, GLenum pname, GLuint *params)
+{
+    _ptrc_glGetVertexAttribIuiv =
+        (PFN_PTRC_GLGETVERTEXATTRIBIUIVPROC)IntGetProcAddress(
+            "glGetVertexAttribIuiv");
+    _ptrc_glGetVertexAttribIuiv(index, pname, params);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsEnabledi(GLenum target, GLuint index)
+{
+    _ptrc_glIsEnabledi =
+        (PFN_PTRC_GLISENABLEDIPROC)IntGetProcAddress("glIsEnabledi");
+    return _ptrc_glIsEnabledi(target, index);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsFramebuffer(GLuint framebuffer)
+{
+    _ptrc_glIsFramebuffer =
+        (PFN_PTRC_GLISFRAMEBUFFERPROC)IntGetProcAddress("glIsFramebuffer");
+    return _ptrc_glIsFramebuffer(framebuffer);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsRenderbuffer(GLuint renderbuffer)
+{
+    _ptrc_glIsRenderbuffer =
+        (PFN_PTRC_GLISRENDERBUFFERPROC)IntGetProcAddress("glIsRenderbuffer");
+    return _ptrc_glIsRenderbuffer(renderbuffer);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsVertexArray(GLuint ren_array)
+{
+    _ptrc_glIsVertexArray =
+        (PFN_PTRC_GLISVERTEXARRAYPROC)IntGetProcAddress("glIsVertexArray");
+    return _ptrc_glIsVertexArray(ren_array);
+}
+
+static void *CODEGEN_FUNCPTR Switch_MapBufferRange(
+    GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access)
+{
+    _ptrc_glMapBufferRange =
+        (PFN_PTRC_GLMAPBUFFERRANGEPROC)IntGetProcAddress("glMapBufferRange");
+    return _ptrc_glMapBufferRange(target, offset, length, access);
+}
+
+static void CODEGEN_FUNCPTR Switch_RenderbufferStorage(
+    GLenum target, GLenum internalformat, GLsizei width, GLsizei height)
+{
+    _ptrc_glRenderbufferStorage =
+        (PFN_PTRC_GLRENDERBUFFERSTORAGEPROC)IntGetProcAddress(
+            "glRenderbufferStorage");
+    _ptrc_glRenderbufferStorage(target, internalformat, width, height);
+}
+
+static void CODEGEN_FUNCPTR Switch_RenderbufferStorageMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height)
+{
+    _ptrc_glRenderbufferStorageMultisample =
+        (PFN_PTRC_GLRENDERBUFFERSTORAGEMULTISAMPLEPROC)IntGetProcAddress(
+            "glRenderbufferStorageMultisample");
+    _ptrc_glRenderbufferStorageMultisample(
+        target, samples, internalformat, width, height);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexParameterIiv(GLenum target, GLenum pname, const GLint *params)
+{
+    _ptrc_glTexParameterIiv =
+        (PFN_PTRC_GLTEXPARAMETERIIVPROC)IntGetProcAddress("glTexParameterIiv");
+    _ptrc_glTexParameterIiv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexParameterIuiv(GLenum target, GLenum pname, const GLuint *params)
+{
+    _ptrc_glTexParameterIuiv =
+        (PFN_PTRC_GLTEXPARAMETERIUIVPROC)IntGetProcAddress(
+            "glTexParameterIuiv");
+    _ptrc_glTexParameterIuiv(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_TransformFeedbackVaryings(
+    GLuint program, GLsizei count, const GLchar *const *varyings,
+    GLenum bufferMode)
+{
+    _ptrc_glTransformFeedbackVaryings =
+        (PFN_PTRC_GLTRANSFORMFEEDBACKVARYINGSPROC)IntGetProcAddress(
+            "glTransformFeedbackVaryings");
+    _ptrc_glTransformFeedbackVaryings(program, count, varyings, bufferMode);
+}
+
+static void CODEGEN_FUNCPTR Switch_Uniform1ui(GLint location, GLuint v0)
+{
+    _ptrc_glUniform1ui =
+        (PFN_PTRC_GLUNIFORM1UIPROC)IntGetProcAddress("glUniform1ui");
+    _ptrc_glUniform1ui(location, v0);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform1uiv(GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glUniform1uiv =
+        (PFN_PTRC_GLUNIFORM1UIVPROC)IntGetProcAddress("glUniform1uiv");
+    _ptrc_glUniform1uiv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform2ui(GLint location, GLuint v0, GLuint v1)
+{
+    _ptrc_glUniform2ui =
+        (PFN_PTRC_GLUNIFORM2UIPROC)IntGetProcAddress("glUniform2ui");
+    _ptrc_glUniform2ui(location, v0, v1);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform2uiv(GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glUniform2uiv =
+        (PFN_PTRC_GLUNIFORM2UIVPROC)IntGetProcAddress("glUniform2uiv");
+    _ptrc_glUniform2uiv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform3ui(GLint location, GLuint v0, GLuint v1, GLuint v2)
+{
+    _ptrc_glUniform3ui =
+        (PFN_PTRC_GLUNIFORM3UIPROC)IntGetProcAddress("glUniform3ui");
+    _ptrc_glUniform3ui(location, v0, v1, v2);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform3uiv(GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glUniform3uiv =
+        (PFN_PTRC_GLUNIFORM3UIVPROC)IntGetProcAddress("glUniform3uiv");
+    _ptrc_glUniform3uiv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform4ui(GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3)
+{
+    _ptrc_glUniform4ui =
+        (PFN_PTRC_GLUNIFORM4UIPROC)IntGetProcAddress("glUniform4ui");
+    _ptrc_glUniform4ui(location, v0, v1, v2, v3);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_Uniform4uiv(GLint location, GLsizei count, const GLuint *value)
+{
+    _ptrc_glUniform4uiv =
+        (PFN_PTRC_GLUNIFORM4UIVPROC)IntGetProcAddress("glUniform4uiv");
+    _ptrc_glUniform4uiv(location, count, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribI1i(GLuint index, GLint x)
+{
+    _ptrc_glVertexAttribI1i =
+        (PFN_PTRC_GLVERTEXATTRIBI1IPROC)IntGetProcAddress("glVertexAttribI1i");
+    _ptrc_glVertexAttribI1i(index, x);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI1iv(GLuint index, const GLint *v)
+{
+    _ptrc_glVertexAttribI1iv =
+        (PFN_PTRC_GLVERTEXATTRIBI1IVPROC)IntGetProcAddress(
+            "glVertexAttribI1iv");
+    _ptrc_glVertexAttribI1iv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribI1ui(GLuint index, GLuint x)
+{
+    _ptrc_glVertexAttribI1ui =
+        (PFN_PTRC_GLVERTEXATTRIBI1UIPROC)IntGetProcAddress(
+            "glVertexAttribI1ui");
+    _ptrc_glVertexAttribI1ui(index, x);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI1uiv(GLuint index, const GLuint *v)
+{
+    _ptrc_glVertexAttribI1uiv =
+        (PFN_PTRC_GLVERTEXATTRIBI1UIVPROC)IntGetProcAddress(
+            "glVertexAttribI1uiv");
+    _ptrc_glVertexAttribI1uiv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2i(GLuint index, GLint x, GLint y)
+{
+    _ptrc_glVertexAttribI2i =
+        (PFN_PTRC_GLVERTEXATTRIBI2IPROC)IntGetProcAddress("glVertexAttribI2i");
+    _ptrc_glVertexAttribI2i(index, x, y);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2iv(GLuint index, const GLint *v)
+{
+    _ptrc_glVertexAttribI2iv =
+        (PFN_PTRC_GLVERTEXATTRIBI2IVPROC)IntGetProcAddress(
+            "glVertexAttribI2iv");
+    _ptrc_glVertexAttribI2iv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2ui(GLuint index, GLuint x, GLuint y)
+{
+    _ptrc_glVertexAttribI2ui =
+        (PFN_PTRC_GLVERTEXATTRIBI2UIPROC)IntGetProcAddress(
+            "glVertexAttribI2ui");
+    _ptrc_glVertexAttribI2ui(index, x, y);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI2uiv(GLuint index, const GLuint *v)
+{
+    _ptrc_glVertexAttribI2uiv =
+        (PFN_PTRC_GLVERTEXATTRIBI2UIVPROC)IntGetProcAddress(
+            "glVertexAttribI2uiv");
+    _ptrc_glVertexAttribI2uiv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3i(GLuint index, GLint x, GLint y, GLint z)
+{
+    _ptrc_glVertexAttribI3i =
+        (PFN_PTRC_GLVERTEXATTRIBI3IPROC)IntGetProcAddress("glVertexAttribI3i");
+    _ptrc_glVertexAttribI3i(index, x, y, z);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3iv(GLuint index, const GLint *v)
+{
+    _ptrc_glVertexAttribI3iv =
+        (PFN_PTRC_GLVERTEXATTRIBI3IVPROC)IntGetProcAddress(
+            "glVertexAttribI3iv");
+    _ptrc_glVertexAttribI3iv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3ui(GLuint index, GLuint x, GLuint y, GLuint z)
+{
+    _ptrc_glVertexAttribI3ui =
+        (PFN_PTRC_GLVERTEXATTRIBI3UIPROC)IntGetProcAddress(
+            "glVertexAttribI3ui");
+    _ptrc_glVertexAttribI3ui(index, x, y, z);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI3uiv(GLuint index, const GLuint *v)
+{
+    _ptrc_glVertexAttribI3uiv =
+        (PFN_PTRC_GLVERTEXATTRIBI3UIVPROC)IntGetProcAddress(
+            "glVertexAttribI3uiv");
+    _ptrc_glVertexAttribI3uiv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4bv(GLuint index, const GLbyte *v)
+{
+    _ptrc_glVertexAttribI4bv =
+        (PFN_PTRC_GLVERTEXATTRIBI4BVPROC)IntGetProcAddress(
+            "glVertexAttribI4bv");
+    _ptrc_glVertexAttribI4bv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w)
+{
+    _ptrc_glVertexAttribI4i =
+        (PFN_PTRC_GLVERTEXATTRIBI4IPROC)IntGetProcAddress("glVertexAttribI4i");
+    _ptrc_glVertexAttribI4i(index, x, y, z, w);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4iv(GLuint index, const GLint *v)
+{
+    _ptrc_glVertexAttribI4iv =
+        (PFN_PTRC_GLVERTEXATTRIBI4IVPROC)IntGetProcAddress(
+            "glVertexAttribI4iv");
+    _ptrc_glVertexAttribI4iv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4sv(GLuint index, const GLshort *v)
+{
+    _ptrc_glVertexAttribI4sv =
+        (PFN_PTRC_GLVERTEXATTRIBI4SVPROC)IntGetProcAddress(
+            "glVertexAttribI4sv");
+    _ptrc_glVertexAttribI4sv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4ubv(GLuint index, const GLubyte *v)
+{
+    _ptrc_glVertexAttribI4ubv =
+        (PFN_PTRC_GLVERTEXATTRIBI4UBVPROC)IntGetProcAddress(
+            "glVertexAttribI4ubv");
+    _ptrc_glVertexAttribI4ubv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w)
+{
+    _ptrc_glVertexAttribI4ui =
+        (PFN_PTRC_GLVERTEXATTRIBI4UIPROC)IntGetProcAddress(
+            "glVertexAttribI4ui");
+    _ptrc_glVertexAttribI4ui(index, x, y, z, w);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4uiv(GLuint index, const GLuint *v)
+{
+    _ptrc_glVertexAttribI4uiv =
+        (PFN_PTRC_GLVERTEXATTRIBI4UIVPROC)IntGetProcAddress(
+            "glVertexAttribI4uiv");
+    _ptrc_glVertexAttribI4uiv(index, v);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribI4usv(GLuint index, const GLushort *v)
+{
+    _ptrc_glVertexAttribI4usv =
+        (PFN_PTRC_GLVERTEXATTRIBI4USVPROC)IntGetProcAddress(
+            "glVertexAttribI4usv");
+    _ptrc_glVertexAttribI4usv(index, v);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribIPointer(
+    GLuint index, GLint size, GLenum type, GLsizei stride, const void *pointer)
+{
+    _ptrc_glVertexAttribIPointer =
+        (PFN_PTRC_GLVERTEXATTRIBIPOINTERPROC)IntGetProcAddress(
+            "glVertexAttribIPointer");
+    _ptrc_glVertexAttribIPointer(index, size, type, stride, pointer);
+}
+
+/* Extension: 3.1*/
+static void CODEGEN_FUNCPTR Switch_CopyBufferSubData(
+    GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
+    GLintptr writeOffset, GLsizeiptr size)
+{
+    _ptrc_glCopyBufferSubData =
+        (PFN_PTRC_GLCOPYBUFFERSUBDATAPROC)IntGetProcAddress(
+            "glCopyBufferSubData");
+    _ptrc_glCopyBufferSubData(
+        readTarget, writeTarget, readOffset, writeOffset, size);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawArraysInstanced(
+    GLenum mode, GLint first, GLsizei count, GLsizei instancecount)
+{
+    _ptrc_glDrawArraysInstanced =
+        (PFN_PTRC_GLDRAWARRAYSINSTANCEDPROC)IntGetProcAddress(
+            "glDrawArraysInstanced");
+    _ptrc_glDrawArraysInstanced(mode, first, count, instancecount);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawElementsInstanced(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLsizei instancecount)
+{
+    _ptrc_glDrawElementsInstanced =
+        (PFN_PTRC_GLDRAWELEMENTSINSTANCEDPROC)IntGetProcAddress(
+            "glDrawElementsInstanced");
+    _ptrc_glDrawElementsInstanced(mode, count, type, indices, instancecount);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformBlockName(
+    GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length,
+    GLchar *uniformBlockName)
+{
+    _ptrc_glGetActiveUniformBlockName =
+        (PFN_PTRC_GLGETACTIVEUNIFORMBLOCKNAMEPROC)IntGetProcAddress(
+            "glGetActiveUniformBlockName");
+    _ptrc_glGetActiveUniformBlockName(
+        program, uniformBlockIndex, bufSize, length, uniformBlockName);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformBlockiv(
+    GLuint program, GLuint uniformBlockIndex, GLenum pname, GLint *params)
+{
+    _ptrc_glGetActiveUniformBlockiv =
+        (PFN_PTRC_GLGETACTIVEUNIFORMBLOCKIVPROC)IntGetProcAddress(
+            "glGetActiveUniformBlockiv");
+    _ptrc_glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformName(
+    GLuint program, GLuint uniformIndex, GLsizei bufSize, GLsizei *length,
+    GLchar *uniformName)
+{
+    _ptrc_glGetActiveUniformName =
+        (PFN_PTRC_GLGETACTIVEUNIFORMNAMEPROC)IntGetProcAddress(
+            "glGetActiveUniformName");
+    _ptrc_glGetActiveUniformName(
+        program, uniformIndex, bufSize, length, uniformName);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetActiveUniformsiv(
+    GLuint program, GLsizei uniformCount, const GLuint *uniformIndices,
+    GLenum pname, GLint *params)
+{
+    _ptrc_glGetActiveUniformsiv =
+        (PFN_PTRC_GLGETACTIVEUNIFORMSIVPROC)IntGetProcAddress(
+            "glGetActiveUniformsiv");
+    _ptrc_glGetActiveUniformsiv(
+        program, uniformCount, uniformIndices, pname, params);
+}
+
+static GLuint CODEGEN_FUNCPTR
+Switch_GetUniformBlockIndex(GLuint program, const GLchar *uniformBlockName)
+{
+    _ptrc_glGetUniformBlockIndex =
+        (PFN_PTRC_GLGETUNIFORMBLOCKINDEXPROC)IntGetProcAddress(
+            "glGetUniformBlockIndex");
+    return _ptrc_glGetUniformBlockIndex(program, uniformBlockName);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetUniformIndices(
+    GLuint program, GLsizei uniformCount, const GLchar *const *uniformNames,
+    GLuint *uniformIndices)
+{
+    _ptrc_glGetUniformIndices =
+        (PFN_PTRC_GLGETUNIFORMINDICESPROC)IntGetProcAddress(
+            "glGetUniformIndices");
+    _ptrc_glGetUniformIndices(
+        program, uniformCount, uniformNames, uniformIndices);
+}
+
+static void CODEGEN_FUNCPTR Switch_PrimitiveRestartIndex(GLuint index)
+{
+    _ptrc_glPrimitiveRestartIndex =
+        (PFN_PTRC_GLPRIMITIVERESTARTINDEXPROC)IntGetProcAddress(
+            "glPrimitiveRestartIndex");
+    _ptrc_glPrimitiveRestartIndex(index);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_TexBuffer(GLenum target, GLenum internalformat, GLuint buffer)
+{
+    _ptrc_glTexBuffer =
+        (PFN_PTRC_GLTEXBUFFERPROC)IntGetProcAddress("glTexBuffer");
+    _ptrc_glTexBuffer(target, internalformat, buffer);
+}
+
+static void CODEGEN_FUNCPTR Switch_UniformBlockBinding(
+    GLuint program, GLuint uniformBlockIndex, GLuint uniformBlockBinding)
+{
+    _ptrc_glUniformBlockBinding =
+        (PFN_PTRC_GLUNIFORMBLOCKBINDINGPROC)IntGetProcAddress(
+            "glUniformBlockBinding");
+    _ptrc_glUniformBlockBinding(
+        program, uniformBlockIndex, uniformBlockBinding);
+}
+
+/* Extension: 3.2*/
+static GLenum CODEGEN_FUNCPTR
+Switch_ClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
+{
+    _ptrc_glClientWaitSync =
+        (PFN_PTRC_GLCLIENTWAITSYNCPROC)IntGetProcAddress("glClientWaitSync");
+    return _ptrc_glClientWaitSync(sync, flags, timeout);
+}
+
+static void CODEGEN_FUNCPTR Switch_DeleteSync(GLsync sync)
+{
+    _ptrc_glDeleteSync =
+        (PFN_PTRC_GLDELETESYNCPROC)IntGetProcAddress("glDeleteSync");
+    _ptrc_glDeleteSync(sync);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawElementsBaseVertex(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLint basevertex)
+{
+    _ptrc_glDrawElementsBaseVertex =
+        (PFN_PTRC_GLDRAWELEMENTSBASEVERTEXPROC)IntGetProcAddress(
+            "glDrawElementsBaseVertex");
+    _ptrc_glDrawElementsBaseVertex(mode, count, type, indices, basevertex);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawElementsInstancedBaseVertex(
+    GLenum mode, GLsizei count, GLenum type, const void *indices,
+    GLsizei instancecount, GLint basevertex)
+{
+    _ptrc_glDrawElementsInstancedBaseVertex =
+        (PFN_PTRC_GLDRAWELEMENTSINSTANCEDBASEVERTEXPROC)IntGetProcAddress(
+            "glDrawElementsInstancedBaseVertex");
+    _ptrc_glDrawElementsInstancedBaseVertex(
+        mode, count, type, indices, instancecount, basevertex);
+}
+
+static void CODEGEN_FUNCPTR Switch_DrawRangeElementsBaseVertex(
+    GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type,
+    const void *indices, GLint basevertex)
+{
+    _ptrc_glDrawRangeElementsBaseVertex =
+        (PFN_PTRC_GLDRAWRANGEELEMENTSBASEVERTEXPROC)IntGetProcAddress(
+            "glDrawRangeElementsBaseVertex");
+    _ptrc_glDrawRangeElementsBaseVertex(
+        mode, start, end, count, type, indices, basevertex);
+}
+
+static GLsync CODEGEN_FUNCPTR
+Switch_FenceSync(GLenum condition, GLbitfield flags)
+{
+    _ptrc_glFenceSync =
+        (PFN_PTRC_GLFENCESYNCPROC)IntGetProcAddress("glFenceSync");
+    return _ptrc_glFenceSync(condition, flags);
+}
+
+static void CODEGEN_FUNCPTR Switch_FramebufferTexture(
+    GLenum target, GLenum attachment, GLuint texture, GLint level)
+{
+    _ptrc_glFramebufferTexture =
+        (PFN_PTRC_GLFRAMEBUFFERTEXTUREPROC)IntGetProcAddress(
+            "glFramebufferTexture");
+    _ptrc_glFramebufferTexture(target, attachment, texture, level);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetBufferParameteri64v(GLenum target, GLenum pname, GLint64 *params)
+{
+    _ptrc_glGetBufferParameteri64v =
+        (PFN_PTRC_GLGETBUFFERPARAMETERI64VPROC)IntGetProcAddress(
+            "glGetBufferParameteri64v");
+    _ptrc_glGetBufferParameteri64v(target, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetInteger64i_v(GLenum target, GLuint index, GLint64 *data)
+{
+    _ptrc_glGetInteger64i_v =
+        (PFN_PTRC_GLGETINTEGER64I_VPROC)IntGetProcAddress("glGetInteger64i_v");
+    _ptrc_glGetInteger64i_v(target, index, data);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetInteger64v(GLenum pname, GLint64 *data)
+{
+    _ptrc_glGetInteger64v =
+        (PFN_PTRC_GLGETINTEGER64VPROC)IntGetProcAddress("glGetInteger64v");
+    _ptrc_glGetInteger64v(pname, data);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetMultisamplefv(GLenum pname, GLuint index, GLfloat *val)
+{
+    _ptrc_glGetMultisamplefv =
+        (PFN_PTRC_GLGETMULTISAMPLEFVPROC)IntGetProcAddress(
+            "glGetMultisamplefv");
+    _ptrc_glGetMultisamplefv(pname, index, val);
+}
+
+static void CODEGEN_FUNCPTR Switch_GetSynciv(
+    GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values)
+{
+    _ptrc_glGetSynciv =
+        (PFN_PTRC_GLGETSYNCIVPROC)IntGetProcAddress("glGetSynciv");
+    _ptrc_glGetSynciv(sync, pname, bufSize, length, values);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsSync(GLsync sync)
+{
+    _ptrc_glIsSync = (PFN_PTRC_GLISSYNCPROC)IntGetProcAddress("glIsSync");
+    return _ptrc_glIsSync(sync);
+}
+
+static void CODEGEN_FUNCPTR Switch_MultiDrawElementsBaseVertex(
+    GLenum mode, const GLsizei *count, GLenum type, const void *const *indices,
+    GLsizei drawcount, const GLint *basevertex)
+{
+    _ptrc_glMultiDrawElementsBaseVertex =
+        (PFN_PTRC_GLMULTIDRAWELEMENTSBASEVERTEXPROC)IntGetProcAddress(
+            "glMultiDrawElementsBaseVertex");
+    _ptrc_glMultiDrawElementsBaseVertex(
+        mode, count, type, indices, drawcount, basevertex);
+}
+
+static void CODEGEN_FUNCPTR Switch_ProvokingVertex(GLenum mode)
+{
+    _ptrc_glProvokingVertex =
+        (PFN_PTRC_GLPROVOKINGVERTEXPROC)IntGetProcAddress("glProvokingVertex");
+    _ptrc_glProvokingVertex(mode);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SampleMaski(GLuint maskNumber, GLbitfield mask)
+{
+    _ptrc_glSampleMaski =
+        (PFN_PTRC_GLSAMPLEMASKIPROC)IntGetProcAddress("glSampleMaski");
+    _ptrc_glSampleMaski(maskNumber, mask);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexImage2DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLboolean fixedsamplelocations)
+{
+    _ptrc_glTexImage2DMultisample =
+        (PFN_PTRC_GLTEXIMAGE2DMULTISAMPLEPROC)IntGetProcAddress(
+            "glTexImage2DMultisample");
+    _ptrc_glTexImage2DMultisample(
+        target, samples, internalformat, width, height, fixedsamplelocations);
+}
+
+static void CODEGEN_FUNCPTR Switch_TexImage3DMultisample(
+    GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+    GLsizei height, GLsizei depth, GLboolean fixedsamplelocations)
+{
+    _ptrc_glTexImage3DMultisample =
+        (PFN_PTRC_GLTEXIMAGE3DMULTISAMPLEPROC)IntGetProcAddress(
+            "glTexImage3DMultisample");
+    _ptrc_glTexImage3DMultisample(
+        target, samples, internalformat, width, height, depth,
+        fixedsamplelocations);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_WaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
+{
+    _ptrc_glWaitSync = (PFN_PTRC_GLWAITSYNCPROC)IntGetProcAddress("glWaitSync");
+    _ptrc_glWaitSync(sync, flags, timeout);
+}
+
+/* Extension: 3.3*/
+static void CODEGEN_FUNCPTR Switch_BindFragDataLocationIndexed(
+    GLuint program, GLuint colorNumber, GLuint index, const GLchar *name)
+{
+    _ptrc_glBindFragDataLocationIndexed =
+        (PFN_PTRC_GLBINDFRAGDATALOCATIONINDEXEDPROC)IntGetProcAddress(
+            "glBindFragDataLocationIndexed");
+    _ptrc_glBindFragDataLocationIndexed(program, colorNumber, index, name);
+}
+
+static void CODEGEN_FUNCPTR Switch_BindSampler(GLuint unit, GLuint sampler)
+{
+    _ptrc_glBindSampler =
+        (PFN_PTRC_GLBINDSAMPLERPROC)IntGetProcAddress("glBindSampler");
+    _ptrc_glBindSampler(unit, sampler);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_DeleteSamplers(GLsizei count, const GLuint *samplers)
+{
+    _ptrc_glDeleteSamplers =
+        (PFN_PTRC_GLDELETESAMPLERSPROC)IntGetProcAddress("glDeleteSamplers");
+    _ptrc_glDeleteSamplers(count, samplers);
+}
+
+static void CODEGEN_FUNCPTR Switch_GenSamplers(GLsizei count, GLuint *samplers)
+{
+    _ptrc_glGenSamplers =
+        (PFN_PTRC_GLGENSAMPLERSPROC)IntGetProcAddress("glGenSamplers");
+    _ptrc_glGenSamplers(count, samplers);
+}
+
+static GLint CODEGEN_FUNCPTR
+Switch_GetFragDataIndex(GLuint program, const GLchar *name)
+{
+    _ptrc_glGetFragDataIndex =
+        (PFN_PTRC_GLGETFRAGDATAINDEXPROC)IntGetProcAddress(
+            "glGetFragDataIndex");
+    return _ptrc_glGetFragDataIndex(program, name);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjecti64v(GLuint id, GLenum pname, GLint64 *params)
+{
+    _ptrc_glGetQueryObjecti64v =
+        (PFN_PTRC_GLGETQUERYOBJECTI64VPROC)IntGetProcAddress(
+            "glGetQueryObjecti64v");
+    _ptrc_glGetQueryObjecti64v(id, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetQueryObjectui64v(GLuint id, GLenum pname, GLuint64 *params)
+{
+    _ptrc_glGetQueryObjectui64v =
+        (PFN_PTRC_GLGETQUERYOBJECTUI64VPROC)IntGetProcAddress(
+            "glGetQueryObjectui64v");
+    _ptrc_glGetQueryObjectui64v(id, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameterIiv(GLuint sampler, GLenum pname, GLint *params)
+{
+    _ptrc_glGetSamplerParameterIiv =
+        (PFN_PTRC_GLGETSAMPLERPARAMETERIIVPROC)IntGetProcAddress(
+            "glGetSamplerParameterIiv");
+    _ptrc_glGetSamplerParameterIiv(sampler, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameterIuiv(GLuint sampler, GLenum pname, GLuint *params)
+{
+    _ptrc_glGetSamplerParameterIuiv =
+        (PFN_PTRC_GLGETSAMPLERPARAMETERIUIVPROC)IntGetProcAddress(
+            "glGetSamplerParameterIuiv");
+    _ptrc_glGetSamplerParameterIuiv(sampler, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameterfv(GLuint sampler, GLenum pname, GLfloat *params)
+{
+    _ptrc_glGetSamplerParameterfv =
+        (PFN_PTRC_GLGETSAMPLERPARAMETERFVPROC)IntGetProcAddress(
+            "glGetSamplerParameterfv");
+    _ptrc_glGetSamplerParameterfv(sampler, pname, params);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_GetSamplerParameteriv(GLuint sampler, GLenum pname, GLint *params)
+{
+    _ptrc_glGetSamplerParameteriv =
+        (PFN_PTRC_GLGETSAMPLERPARAMETERIVPROC)IntGetProcAddress(
+            "glGetSamplerParameteriv");
+    _ptrc_glGetSamplerParameteriv(sampler, pname, params);
+}
+
+static GLboolean CODEGEN_FUNCPTR Switch_IsSampler(GLuint sampler)
+{
+    _ptrc_glIsSampler =
+        (PFN_PTRC_GLISSAMPLERPROC)IntGetProcAddress("glIsSampler");
+    return _ptrc_glIsSampler(sampler);
+}
+
+static void CODEGEN_FUNCPTR Switch_QueryCounter(GLuint id, GLenum target)
+{
+    _ptrc_glQueryCounter =
+        (PFN_PTRC_GLQUERYCOUNTERPROC)IntGetProcAddress("glQueryCounter");
+    _ptrc_glQueryCounter(id, target);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterIiv(GLuint sampler, GLenum pname, const GLint *param)
+{
+    _ptrc_glSamplerParameterIiv =
+        (PFN_PTRC_GLSAMPLERPARAMETERIIVPROC)IntGetProcAddress(
+            "glSamplerParameterIiv");
+    _ptrc_glSamplerParameterIiv(sampler, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterIuiv(GLuint sampler, GLenum pname, const GLuint *param)
+{
+    _ptrc_glSamplerParameterIuiv =
+        (PFN_PTRC_GLSAMPLERPARAMETERIUIVPROC)IntGetProcAddress(
+            "glSamplerParameterIuiv");
+    _ptrc_glSamplerParameterIuiv(sampler, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterf(GLuint sampler, GLenum pname, GLfloat param)
+{
+    _ptrc_glSamplerParameterf =
+        (PFN_PTRC_GLSAMPLERPARAMETERFPROC)IntGetProcAddress(
+            "glSamplerParameterf");
+    _ptrc_glSamplerParameterf(sampler, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameterfv(GLuint sampler, GLenum pname, const GLfloat *param)
+{
+    _ptrc_glSamplerParameterfv =
+        (PFN_PTRC_GLSAMPLERPARAMETERFVPROC)IntGetProcAddress(
+            "glSamplerParameterfv");
+    _ptrc_glSamplerParameterfv(sampler, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameteri(GLuint sampler, GLenum pname, GLint param)
+{
+    _ptrc_glSamplerParameteri =
+        (PFN_PTRC_GLSAMPLERPARAMETERIPROC)IntGetProcAddress(
+            "glSamplerParameteri");
+    _ptrc_glSamplerParameteri(sampler, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_SamplerParameteriv(GLuint sampler, GLenum pname, const GLint *param)
+{
+    _ptrc_glSamplerParameteriv =
+        (PFN_PTRC_GLSAMPLERPARAMETERIVPROC)IntGetProcAddress(
+            "glSamplerParameteriv");
+    _ptrc_glSamplerParameteriv(sampler, pname, param);
+}
+
+static void CODEGEN_FUNCPTR
+Switch_VertexAttribDivisor(GLuint index, GLuint divisor)
+{
+    _ptrc_glVertexAttribDivisor =
+        (PFN_PTRC_GLVERTEXATTRIBDIVISORPROC)IntGetProcAddress(
+            "glVertexAttribDivisor");
+    _ptrc_glVertexAttribDivisor(index, divisor);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP1ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value)
+{
+    _ptrc_glVertexAttribP1ui =
+        (PFN_PTRC_GLVERTEXATTRIBP1UIPROC)IntGetProcAddress(
+            "glVertexAttribP1ui");
+    _ptrc_glVertexAttribP1ui(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP1uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value)
+{
+    _ptrc_glVertexAttribP1uiv =
+        (PFN_PTRC_GLVERTEXATTRIBP1UIVPROC)IntGetProcAddress(
+            "glVertexAttribP1uiv");
+    _ptrc_glVertexAttribP1uiv(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP2ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value)
+{
+    _ptrc_glVertexAttribP2ui =
+        (PFN_PTRC_GLVERTEXATTRIBP2UIPROC)IntGetProcAddress(
+            "glVertexAttribP2ui");
+    _ptrc_glVertexAttribP2ui(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP2uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value)
+{
+    _ptrc_glVertexAttribP2uiv =
+        (PFN_PTRC_GLVERTEXATTRIBP2UIVPROC)IntGetProcAddress(
+            "glVertexAttribP2uiv");
+    _ptrc_glVertexAttribP2uiv(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP3ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value)
+{
+    _ptrc_glVertexAttribP3ui =
+        (PFN_PTRC_GLVERTEXATTRIBP3UIPROC)IntGetProcAddress(
+            "glVertexAttribP3ui");
+    _ptrc_glVertexAttribP3ui(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP3uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value)
+{
+    _ptrc_glVertexAttribP3uiv =
+        (PFN_PTRC_GLVERTEXATTRIBP3UIVPROC)IntGetProcAddress(
+            "glVertexAttribP3uiv");
+    _ptrc_glVertexAttribP3uiv(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP4ui(
+    GLuint index, GLenum type, GLboolean normalized, GLuint value)
+{
+    _ptrc_glVertexAttribP4ui =
+        (PFN_PTRC_GLVERTEXATTRIBP4UIPROC)IntGetProcAddress(
+            "glVertexAttribP4ui");
+    _ptrc_glVertexAttribP4ui(index, type, normalized, value);
+}
+
+static void CODEGEN_FUNCPTR Switch_VertexAttribP4uiv(
+    GLuint index, GLenum type, GLboolean normalized, const GLuint *value)
+{
+    _ptrc_glVertexAttribP4uiv =
+        (PFN_PTRC_GLVERTEXATTRIBP4UIVPROC)IntGetProcAddress(
+            "glVertexAttribP4uiv");
+    _ptrc_glVertexAttribP4uiv(index, type, normalized, value);
+}
+
+static void ClearExtensionVariables(void)
+{
+    ogl_ext_EXT_texture_compression_s3tc = 0;
+    ogl_ext_EXT_texture_sRGB = 0;
+    ogl_ext_EXT_texture_filter_anisotropic = 0;
+    ogl_ext_ARB_compressed_texture_pixel_storage = 0;
+    ogl_ext_ARB_conservative_depth = 0;
+    ogl_ext_ARB_ES2_compatibility = 0;
+    ogl_ext_ARB_get_program_binary = 0;
+    ogl_ext_ARB_explicit_uniform_location = 0;
+    ogl_ext_ARB_internalformat_query = 0;
+    ogl_ext_ARB_internalformat_query2 = 0;
+    ogl_ext_ARB_map_buffer_alignment = 0;
+    ogl_ext_ARB_program_interface_query = 0;
+    ogl_ext_ARB_separate_shader_objects = 0;
+    ogl_ext_ARB_shading_language_420pack = 0;
+    ogl_ext_ARB_shading_language_packing = 0;
+    ogl_ext_ARB_texture_buffer_range = 0;
+    ogl_ext_ARB_texture_storage = 0;
+    ogl_ext_ARB_texture_view = 0;
+    ogl_ext_ARB_vertex_attrib_binding = 0;
+    ogl_ext_ARB_viewport_array = 0;
+    ogl_ext_ARB_arrays_of_arrays = 0;
+    ogl_ext_ARB_clear_buffer_object = 0;
+    ogl_ext_ARB_copy_image = 0;
+    ogl_ext_ARB_ES3_compatibility = 0;
+    ogl_ext_ARB_fragment_layer_viewport = 0;
+    ogl_ext_ARB_framebuffer_no_attachments = 0;
+    ogl_ext_ARB_invalidate_subdata = 0;
+    ogl_ext_ARB_robust_buffer_access_behavior = 0;
+    ogl_ext_ARB_stencil_texturing = 0;
+    ogl_ext_ARB_texture_query_levels = 0;
+    ogl_ext_ARB_texture_storage_multisample = 0;
+    ogl_ext_KHR_debug = 0;
+    ogl_ext_ARB_buffer_storage = 0;
+    ogl_ext_ARB_clear_texture = 0;
+    ogl_ext_ARB_enhanced_layouts = 0;
+    ogl_ext_ARB_multi_bind = 0;
+    ogl_ext_ARB_query_buffer_object = 0;
+    ogl_ext_ARB_texture_mirror_clamp_to_edge = 0;
+    ogl_ext_ARB_texture_stencil8 = 0;
+    ogl_ext_ARB_vertex_type_10f_11f_11f_rev = 0;
+    ogl_ext_ARB_seamless_cubemap_per_texture = 0;
+    ogl_ext_ARB_clip_control = 0;
+    ogl_ext_ARB_conditional_render_inverted = 0;
+    ogl_ext_ARB_cull_distance = 0;
+    ogl_ext_ARB_derivative_control = 0;
+    ogl_ext_ARB_direct_state_access = 0;
+    ogl_ext_ARB_get_texture_sub_image = 0;
+    ogl_ext_ARB_shader_texture_image_samples = 0;
+    ogl_ext_ARB_texture_barrier = 0;
+    ogl_ext_KHR_context_flush_control = 0;
+    ogl_ext_KHR_robust_buffer_access_behavior = 0;
+    ogl_ext_KHR_robustness = 0;
+}
+
+typedef struct ogl_MapTable_s {
+    char *extName;
+    int *extVariable;
+} ogl_MapTable;
+
+static ogl_MapTable g_mappingTable[52] = {
+    { "GL_EXT_texture_compression_s3tc",
+      &ogl_ext_EXT_texture_compression_s3tc },
+    { "GL_EXT_texture_sRGB", &ogl_ext_EXT_texture_sRGB },
+    { "GL_EXT_texture_filter_anisotropic",
+      &ogl_ext_EXT_texture_filter_anisotropic },
+    { "GL_ARB_compressed_texture_pixel_storage",
+      &ogl_ext_ARB_compressed_texture_pixel_storage },
+    { "GL_ARB_conservative_depth", &ogl_ext_ARB_conservative_depth },
+    { "GL_ARB_ES2_compatibility", &ogl_ext_ARB_ES2_compatibility },
+    { "GL_ARB_get_program_binary", &ogl_ext_ARB_get_program_binary },
+    { "GL_ARB_explicit_uniform_location",
+      &ogl_ext_ARB_explicit_uniform_location },
+    { "GL_ARB_internalformat_query", &ogl_ext_ARB_internalformat_query },
+    { "GL_ARB_internalformat_query2", &ogl_ext_ARB_internalformat_query2 },
+    { "GL_ARB_map_buffer_alignment", &ogl_ext_ARB_map_buffer_alignment },
+    { "GL_ARB_program_interface_query", &ogl_ext_ARB_program_interface_query },
+    { "GL_ARB_separate_shader_objects", &ogl_ext_ARB_separate_shader_objects },
+    { "GL_ARB_shading_language_420pack",
+      &ogl_ext_ARB_shading_language_420pack },
+    { "GL_ARB_shading_language_packing",
+      &ogl_ext_ARB_shading_language_packing },
+    { "GL_ARB_texture_buffer_range", &ogl_ext_ARB_texture_buffer_range },
+    { "GL_ARB_texture_storage", &ogl_ext_ARB_texture_storage },
+    { "GL_ARB_texture_view", &ogl_ext_ARB_texture_view },
+    { "GL_ARB_vertex_attrib_binding", &ogl_ext_ARB_vertex_attrib_binding },
+    { "GL_ARB_viewport_array", &ogl_ext_ARB_viewport_array },
+    { "GL_ARB_arrays_of_arrays", &ogl_ext_ARB_arrays_of_arrays },
+    { "GL_ARB_clear_buffer_object", &ogl_ext_ARB_clear_buffer_object },
+    { "GL_ARB_copy_image", &ogl_ext_ARB_copy_image },
+    { "GL_ARB_ES3_compatibility", &ogl_ext_ARB_ES3_compatibility },
+    { "GL_ARB_fragment_layer_viewport", &ogl_ext_ARB_fragment_layer_viewport },
+    { "GL_ARB_framebuffer_no_attachments",
+      &ogl_ext_ARB_framebuffer_no_attachments },
+    { "GL_ARB_invalidate_subdata", &ogl_ext_ARB_invalidate_subdata },
+    { "GL_ARB_robust_buffer_access_behavior",
+      &ogl_ext_ARB_robust_buffer_access_behavior },
+    { "GL_ARB_stencil_texturing", &ogl_ext_ARB_stencil_texturing },
+    { "GL_ARB_texture_query_levels", &ogl_ext_ARB_texture_query_levels },
+    { "GL_ARB_texture_storage_multisample",
+      &ogl_ext_ARB_texture_storage_multisample },
+    { "GL_KHR_debug", &ogl_ext_KHR_debug },
+    { "GL_ARB_buffer_storage", &ogl_ext_ARB_buffer_storage },
+    { "GL_ARB_clear_texture", &ogl_ext_ARB_clear_texture },
+    { "GL_ARB_enhanced_layouts", &ogl_ext_ARB_enhanced_layouts },
+    { "GL_ARB_multi_bind", &ogl_ext_ARB_multi_bind },
+    { "GL_ARB_query_buffer_object", &ogl_ext_ARB_query_buffer_object },
+    { "GL_ARB_texture_mirror_clamp_to_edge",
+      &ogl_ext_ARB_texture_mirror_clamp_to_edge },
+    { "GL_ARB_texture_stencil8", &ogl_ext_ARB_texture_stencil8 },
+    { "GL_ARB_vertex_type_10f_11f_11f_rev",
+      &ogl_ext_ARB_vertex_type_10f_11f_11f_rev },
+    { "GL_ARB_seamless_cubemap_per_texture",
+      &ogl_ext_ARB_seamless_cubemap_per_texture },
+    { "GL_ARB_clip_control", &ogl_ext_ARB_clip_control },
+    { "GL_ARB_conditional_render_inverted",
+      &ogl_ext_ARB_conditional_render_inverted },
+    { "GL_ARB_cull_distance", &ogl_ext_ARB_cull_distance },
+    { "GL_ARB_derivative_control", &ogl_ext_ARB_derivative_control },
+    { "GL_ARB_direct_state_access", &ogl_ext_ARB_direct_state_access },
+    { "GL_ARB_get_texture_sub_image", &ogl_ext_ARB_get_texture_sub_image },
+    { "GL_ARB_shader_texture_image_samples",
+      &ogl_ext_ARB_shader_texture_image_samples },
+    { "GL_ARB_texture_barrier", &ogl_ext_ARB_texture_barrier },
+    { "GL_KHR_context_flush_control", &ogl_ext_KHR_context_flush_control },
+    { "GL_KHR_robust_buffer_access_behavior",
+      &ogl_ext_KHR_robust_buffer_access_behavior },
+    { "GL_KHR_robustness", &ogl_ext_KHR_robustness },
+};
+
+static void LoadExtByName(const char *extensionName)
+{
+    ogl_MapTable *tableEnd = &g_mappingTable[52];
+    ogl_MapTable *entry = &g_mappingTable[0];
+    for (; entry != tableEnd; ++entry) {
+        if (strcmp(entry->extName, extensionName) == 0)
+            break;
+    }
+
+    if (entry != tableEnd)
+        *(entry->extVariable) = 1;
+}
+
+void ProcExtsFromExtList(void)
+{
+    GLint iLoop;
+    GLint iNumExtensions = 0;
+    _ptrc_glGetIntegerv(GL_NUM_EXTENSIONS, &iNumExtensions);
+
+    for (iLoop = 0; iLoop < iNumExtensions; iLoop++) {
+        const char *strExtensionName =
+            (const char *)_ptrc_glGetStringi(GL_EXTENSIONS, iLoop);
+        LoadExtByName(strExtensionName);
+    }
+}
+
+void ogl_CheckExtensions(void)
+{
+    ClearExtensionVariables();
+
+    ProcExtsFromExtList();
+}
+
+#if __GNUC__ || __MINGW32__
+    #pragma GCC diagnostic pop
+#endif

--- a/src/gfx/gl/program.c
+++ b/src/gfx/gl/program.c
@@ -1,0 +1,204 @@
+#include "gfx/gl/program.h"
+
+#include "filesystem.h"
+#include "game/shell.h"
+#include "gfx/gl/utils.h"
+#include "log.h"
+#include "memory.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+bool GFX_GL_Program_Init(GFX_GL_Program *program)
+{
+    assert(program);
+    program->id = glCreateProgram();
+    GFX_GL_CheckError();
+    if (!program->id) {
+        LOG_ERROR("Can't create shader program");
+        return false;
+    }
+    return true;
+}
+
+void GFX_GL_Program_Close(GFX_GL_Program *program)
+{
+    if (program->id) {
+        glDeleteProgram(program->id);
+        GFX_GL_CheckError();
+        program->id = 0;
+    }
+}
+
+void GFX_GL_Program_Bind(GFX_GL_Program *program)
+{
+    glUseProgram(program->id);
+    GFX_GL_CheckError();
+}
+
+char *GFX_GL_Program_PreprocessShader(
+    const char *content, GLenum type, GFX_GL_BACKEND backend)
+{
+    const char *version_ogl21 =
+        "#version 120\n"
+        "#extension GL_ARB_explicit_attrib_location: enable\n"
+        "#extension GL_EXT_gpu_shader4: enable\n";
+    const char *version_ogl33c = "#version 330 core\n";
+    const char *define_vertex = "#define VERTEX\n";
+    const char *define_ogl33c = "#define OGL33C\n";
+
+    size_t bufsize = strlen(content) + 1;
+
+    if (backend == GFX_GL_33C) {
+        bufsize += strlen(version_ogl33c);
+        bufsize += strlen(define_ogl33c);
+    } else {
+        bufsize += strlen(version_ogl21);
+    }
+
+    if (type == GL_VERTEX_SHADER) {
+        bufsize += strlen(define_vertex);
+    }
+
+    char *processed_content = Memory_Alloc(bufsize);
+    if (!processed_content) {
+        return NULL;
+    }
+    processed_content[0] = '\0';
+
+    if (backend == GFX_GL_33C) {
+        strcpy(processed_content, version_ogl33c);
+        strcat(processed_content, define_ogl33c);
+    } else {
+        strcpy(processed_content, version_ogl21);
+    }
+
+    if (type == GL_VERTEX_SHADER) {
+        strcat(processed_content, define_vertex);
+    }
+
+    strcat(processed_content, content);
+    return processed_content;
+}
+
+void GFX_GL_Program_AttachShader(
+    GFX_GL_Program *program, GLenum type, const char *path)
+{
+    GLuint shader_id = glCreateShader(type);
+    GFX_GL_CheckError();
+    if (!shader_id) {
+        Shell_ExitSystem("Failed to create shader");
+    }
+
+    char *content = NULL;
+    if (!File_Load(path, &content, NULL)) {
+        Shell_ExitSystemFmt("Unable to find shader file: %s", path);
+    }
+
+    char *processed_content =
+        GFX_GL_Program_PreprocessShader(content, type, GFX_GL_DEFAULT_BACKEND);
+    Memory_FreePointer(&content);
+    if (!processed_content) {
+        Shell_ExitSystemFmt("Failed to pre-process shader source:  %s", path);
+    }
+
+    glShaderSource(shader_id, 1, (const char *const *)&processed_content, NULL);
+
+    GFX_GL_CheckError();
+    glCompileShader(shader_id);
+    GFX_GL_CheckError();
+
+    int compile_status;
+    glGetShaderiv(shader_id, GL_COMPILE_STATUS, &compile_status);
+    GFX_GL_CheckError();
+
+    if (compile_status != GL_TRUE) {
+        GLsizei info_log_size = 4096;
+        char info_log[info_log_size];
+        glGetShaderInfoLog(shader_id, info_log_size, &info_log_size, info_log);
+        GFX_GL_CheckError();
+
+        if (info_log[0]) {
+            Shell_ExitSystemFmt("Shader compilation failed:\n%s", info_log);
+        } else {
+            Shell_ExitSystemFmt("Shader compilation failed.");
+        }
+    }
+
+    Memory_FreePointer(&processed_content);
+
+    glAttachShader(program->id, shader_id);
+    GFX_GL_CheckError();
+
+    glDeleteShader(shader_id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Program_Link(GFX_GL_Program *program)
+{
+    glLinkProgram(program->id);
+    GFX_GL_CheckError();
+
+    GLint linkStatus;
+    glGetProgramiv(program->id, GL_LINK_STATUS, &linkStatus);
+    GFX_GL_CheckError();
+
+    if (!linkStatus) {
+        GLsizei info_log_size = 4096;
+        char info_log[info_log_size];
+        glGetProgramInfoLog(
+            program->id, info_log_size, &info_log_size, info_log);
+        GFX_GL_CheckError();
+        if (info_log[0]) {
+            Shell_ExitSystemFmt("Shader linking failed:\n%s", info_log);
+        } else {
+            Shell_ExitSystemFmt("Shader linking failed.");
+        }
+    }
+}
+
+void GFX_GL_Program_FragmentData(GFX_GL_Program *program, const char *name)
+{
+    glBindFragDataLocation(program->id, 0, name);
+    GFX_GL_CheckError();
+}
+
+GLint GFX_GL_Program_UniformLocation(GFX_GL_Program *program, const char *name)
+{
+    GLint location = glGetUniformLocation(program->id, name);
+    GFX_GL_CheckError();
+    if (location == -1) {
+        LOG_INFO("Shader uniform not found: %s", name);
+    }
+    return location;
+}
+
+void GFX_GL_Program_Uniform3f(
+    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2)
+{
+    glUniform3f(loc, v0, v1, v2);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Program_Uniform4f(
+    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
+    GLfloat v3)
+{
+    glUniform4f(loc, v0, v1, v2, v3);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Program_Uniform1i(GFX_GL_Program *program, GLint loc, GLint v0)
+{
+    glUniform1i(loc, v0);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Program_UniformMatrix4fv(
+    GFX_GL_Program *program, GLint loc, GLsizei count, GLboolean transpose,
+    const GLfloat *value)
+{
+    glUniformMatrix4fv(loc, count, transpose, value);
+    GFX_GL_CheckError();
+}

--- a/src/gfx/gl/sampler.c
+++ b/src/gfx/gl/sampler.c
@@ -1,0 +1,35 @@
+#include "gfx/gl/sampler.h"
+
+#include "gfx/gl/utils.h"
+
+void GFX_GL_Sampler_Init(GFX_GL_Sampler *sampler)
+{
+    glGenSamplers(1, &sampler->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Sampler_Close(GFX_GL_Sampler *sampler)
+{
+    glDeleteSamplers(1, &sampler->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Sampler_Bind(GFX_GL_Sampler *sampler, GLuint unit)
+{
+    glBindSampler(unit, sampler->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Sampler_Parameteri(
+    GFX_GL_Sampler *sampler, GLenum pname, GLint param)
+{
+    glSamplerParameteri(sampler->id, pname, param);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Sampler_Parameterf(
+    GFX_GL_Sampler *sampler, GLenum pname, GLfloat param)
+{
+    glSamplerParameterf(sampler->id, pname, param);
+    GFX_GL_CheckError();
+}

--- a/src/gfx/gl/texture.c
+++ b/src/gfx/gl/texture.c
@@ -1,0 +1,88 @@
+#include "gfx/gl/texture.h"
+
+#include "gfx/gl/utils.h"
+#include "memory.h"
+#include "utils.h"
+
+#include <assert.h>
+
+GFX_GL_Texture *GFX_GL_Texture_Create(GLenum target)
+{
+    GFX_GL_Texture *texture = Memory_Alloc(sizeof(GFX_GL_Texture));
+    GFX_GL_Texture_Init(texture, target);
+    return texture;
+}
+
+void GFX_GL_Texture_Free(GFX_GL_Texture *texture)
+{
+    if (texture != NULL) {
+        GFX_GL_Texture_Close(texture);
+        Memory_FreePointer(&texture);
+    }
+}
+
+void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target)
+{
+    assert(texture != NULL);
+    texture->target = target;
+    glGenTextures(1, &texture->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Texture_Close(GFX_GL_Texture *texture)
+{
+    assert(texture != NULL);
+    glDeleteTextures(1, &texture->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Texture_Bind(GFX_GL_Texture *texture)
+{
+    assert(texture != NULL);
+    glBindTexture(texture->target, texture->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Texture_Load(
+    GFX_GL_Texture *texture, const void *data, int width, int height,
+    GLint internal_format, GLint format)
+{
+    assert(texture != NULL);
+
+    GFX_GL_Texture_Bind(texture);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, internal_format, width, height, 0, format,
+        GL_UNSIGNED_BYTE, data);
+    GFX_GL_CheckError();
+
+    glGenerateMipmap(GL_TEXTURE_2D);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_Texture_LoadFromBackBuffer(GFX_GL_Texture *const texture)
+{
+    assert(texture != NULL);
+
+    GFX_GL_Texture_Bind(texture);
+
+    GLint viewport[4];
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    GFX_GL_CheckError();
+
+    const GLint vp_x = viewport[0];
+    const GLint vp_y = viewport[1];
+    const GLint vp_w = viewport[2];
+    const GLint vp_h = viewport[3];
+
+    const int32_t side = MIN(vp_w, vp_h);
+    const int32_t x = vp_x + (vp_w - side) / 2;
+    const int32_t y = vp_y + (vp_h - side) / 2;
+    const int32_t w = side;
+    const int32_t h = side;
+
+    glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, x, y, w, h, 0);
+    GFX_GL_CheckError();
+}

--- a/src/gfx/gl/utils.c
+++ b/src/gfx/gl/utils.c
@@ -1,0 +1,27 @@
+#include "gfx/gl/utils.h"
+
+#include "gfx/gl/gl_core_3_3.h"
+
+const char *GFX_GL_GetErrorString(GLenum err)
+{
+    switch (err) {
+    case GL_NO_ERROR:
+        return "GL_NO_ERROR";
+    case GL_INVALID_ENUM:
+        return "GL_INVALID_ENUM";
+    case GL_INVALID_VALUE:
+        return "GL_INVALID_VALUE";
+    case GL_INVALID_OPERATION:
+        return "GL_INVALID_OPERATION";
+    case GL_INVALID_FRAMEBUFFER_OPERATION:
+        return "GL_INVALID_FRAMEBUFFER_OPERATION";
+    case GL_OUT_OF_MEMORY:
+        return "GL_OUT_OF_MEMORY";
+    case GL_STACK_UNDERFLOW:
+        return "GL_STACK_UNDERFLOW";
+    case GL_STACK_OVERFLOW:
+        return "GL_STACK_OVERFLOW";
+    default:
+        return "UNKNOWN";
+    }
+}

--- a/src/gfx/gl/vertex_array.c
+++ b/src/gfx/gl/vertex_array.c
@@ -1,0 +1,40 @@
+#include "gfx/gl/vertex_array.h"
+
+#include "gfx/gl/utils.h"
+
+#include <assert.h>
+#include <stdint.h>
+
+void GFX_GL_VertexArray_Init(GFX_GL_VertexArray *array)
+{
+    assert(array);
+    glGenVertexArrays(1, &array->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_VertexArray_Close(GFX_GL_VertexArray *array)
+{
+    assert(array);
+    glDeleteVertexArrays(1, &array->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_VertexArray_Bind(GFX_GL_VertexArray *array)
+{
+    assert(array);
+    glBindVertexArray(array->id);
+    GFX_GL_CheckError();
+}
+
+void GFX_GL_VertexArray_Attribute(
+    GFX_GL_VertexArray *array, GLuint index, GLint size, GLenum type,
+    GLboolean normalized, GLsizei stride, GLsizei offset)
+{
+    assert(array);
+    glEnableVertexAttribArray(index);
+    GFX_GL_CheckError();
+
+    glVertexAttribPointer(
+        index, size, type, normalized, stride, (void *)(intptr_t)offset);
+    GFX_GL_CheckError();
+}

--- a/src/gfx/renderers/fbo_renderer.c
+++ b/src/gfx/renderers/fbo_renderer.c
@@ -1,0 +1,248 @@
+#include "gfx/renderers/fbo_renderer.h"
+
+#include "gfx/common.h"
+#include "gfx/context.h"
+#include "gfx/gl/buffer.h"
+#include "gfx/gl/gl_core_3_3.h"
+#include "gfx/gl/program.h"
+#include "gfx/gl/sampler.h"
+#include "gfx/gl/texture.h"
+#include "gfx/gl/utils.h"
+#include "gfx/gl/vertex_array.h"
+#include "gfx/screenshot.h"
+#include "log.h"
+#include "memory.h"
+
+#include <SDL2/SDL_video.h>
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    const GFX_CONFIG *config;
+
+    GLuint fbo;
+    GLuint rbo;
+
+    GFX_GL_VertexArray vertex_array;
+    GFX_GL_Buffer buffer;
+    GFX_GL_Texture texture;
+    GFX_GL_Sampler sampler;
+    GFX_GL_Program program;
+} GFX_Renderer_FBO_Context;
+
+static void GFX_Renderer_FBO_SwapBuffers(GFX_Renderer *renderer);
+static void GFX_Renderer_FBO_Init(
+    GFX_Renderer *renderer, const GFX_CONFIG *config);
+static void GFX_Renderer_FBO_Shutdown(GFX_Renderer *renderer);
+static void GFX_Renderer_FBO_Reset(GFX_Renderer *renderer);
+
+static void GFX_Renderer_FBO_Render(GFX_Renderer *renderer);
+static void GFX_Renderer_FBO_Bind(const GFX_Renderer *renderer);
+static void GFX_Renderer_FBO_Unbind(const GFX_Renderer *renderer);
+
+static void GFX_Renderer_FBO_SwapBuffers(GFX_Renderer *renderer)
+{
+    if (GFX_Context_GetScheduledScreenshotPath()) {
+        GFX_Screenshot_CaptureToFile(GFX_Context_GetScheduledScreenshotPath());
+        GFX_Context_ClearScheduledScreenshotPath();
+    }
+
+    GFX_Context_SwitchToWindowViewportAR();
+    GFX_Renderer_FBO_Render(renderer);
+
+    SDL_GL_SwapWindow(GFX_Context_GetWindowHandle());
+
+    GFX_Context_SwitchToWindowViewport();
+    GFX_Renderer_FBO_Unbind(renderer);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    GFX_GL_CheckError();
+
+    GFX_Renderer_FBO_Bind(renderer);
+    GFX_Context_SwitchToDisplayViewport();
+}
+
+static void GFX_Renderer_FBO_Init(
+    GFX_Renderer *const renderer, const GFX_CONFIG *const config)
+{
+    LOG_INFO("");
+
+    assert(renderer != NULL);
+    renderer->priv = (GFX_Renderer_FBO_Context *)Memory_Alloc(
+        sizeof(GFX_Renderer_FBO_Context));
+    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    assert(priv != NULL);
+
+    priv->config = config;
+
+    int32_t fbo_width = GFX_Context_GetDisplayWidth();
+    int32_t fbo_height = GFX_Context_GetDisplayHeight();
+
+    GFX_GL_Buffer_Init(&priv->buffer, GL_ARRAY_BUFFER);
+    GFX_GL_Buffer_Bind(&priv->buffer);
+    GLfloat verts[] = { 0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+                        0.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+    GFX_GL_Buffer_Data(&priv->buffer, sizeof(verts), verts, GL_STATIC_DRAW);
+
+    GFX_GL_VertexArray_Init(&priv->vertex_array);
+    GFX_GL_VertexArray_Bind(&priv->vertex_array);
+    GFX_GL_VertexArray_Attribute(
+        &priv->vertex_array, 0, 2, GL_FLOAT, GL_FALSE, 0, 0);
+
+    GFX_GL_Texture_Init(&priv->texture, GL_TEXTURE_2D);
+
+    GFX_GL_Sampler_Init(&priv->sampler);
+    GFX_GL_Sampler_Bind(&priv->sampler, 0);
+    GFX_GL_Sampler_Parameteri(&priv->sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GFX_GL_Sampler_Parameteri(&priv->sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GFX_GL_Sampler_Parameteri(
+        &priv->sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    GFX_GL_Sampler_Parameteri(
+        &priv->sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+
+    GFX_GL_Program_Init(&priv->program);
+    GFX_GL_Program_AttachShader(
+        &priv->program, GL_VERTEX_SHADER, "shaders/fbo.glsl");
+    GFX_GL_Program_AttachShader(
+        &priv->program, GL_FRAGMENT_SHADER, "shaders/fbo.glsl");
+    GFX_GL_Program_Link(&priv->program);
+    GFX_GL_Program_FragmentData(&priv->program, "fragColor");
+
+    glGenFramebuffers(1, &priv->fbo);
+    GFX_GL_CheckError();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, priv->fbo);
+    GFX_GL_CheckError();
+
+    GFX_GL_Texture_Load(
+        &priv->texture, NULL, fbo_width, fbo_height, GL_RGB, GL_RGB);
+
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, priv->texture.id,
+        0);
+    GFX_GL_CheckError();
+
+    glGenRenderbuffers(1, &priv->rbo);
+    GFX_GL_CheckError();
+
+    glBindRenderbuffer(GL_RENDERBUFFER, priv->rbo);
+    GFX_GL_CheckError();
+
+    glRenderbufferStorage(
+        GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, fbo_width, fbo_height);
+    GFX_GL_CheckError();
+
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    GFX_GL_CheckError();
+
+    glFramebufferRenderbuffer(
+        GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER,
+        priv->rbo);
+    GFX_GL_CheckError();
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_ERROR("framebuffer is not complete!");
+    }
+}
+
+static void GFX_Renderer_FBO_Shutdown(GFX_Renderer *renderer)
+{
+    LOG_INFO("");
+
+    assert(renderer != NULL);
+    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    assert(priv != NULL);
+
+    if (!priv->fbo) {
+        return;
+    }
+
+    glDeleteFramebuffers(1, &priv->fbo);
+    priv->fbo = 0;
+    GFX_GL_VertexArray_Close(&priv->vertex_array);
+    GFX_GL_Buffer_Close(&priv->buffer);
+    GFX_GL_Texture_Close(&priv->texture);
+    GFX_GL_Sampler_Close(&priv->sampler);
+    GFX_GL_Program_Close(&priv->program);
+
+    Memory_FreePointer(&renderer->priv);
+}
+
+static void GFX_Renderer_FBO_Reset(GFX_Renderer *renderer)
+{
+    GFX_Renderer_FBO_Context *const priv = renderer->priv;
+    const GFX_CONFIG *const config = priv->config;
+
+    renderer->shutdown(renderer);
+    renderer->init(renderer, config);
+}
+
+static void GFX_Renderer_FBO_Render(GFX_Renderer *renderer)
+{
+    assert(renderer != NULL);
+    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    assert(priv != NULL);
+
+    const GLuint filter = priv->config->display_filter == GFX_TF_BILINEAR
+        ? GL_LINEAR
+        : GL_NEAREST;
+
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    GFX_GL_CheckError();
+
+    GFX_GL_Program_Bind(&priv->program);
+    GFX_GL_Buffer_Bind(&priv->buffer);
+    GFX_GL_VertexArray_Bind(&priv->vertex_array);
+    GFX_GL_Texture_Bind(&priv->texture);
+    GFX_GL_Sampler_Bind(&priv->sampler, 0);
+
+    GFX_GL_Sampler_Parameteri(&priv->sampler, GL_TEXTURE_MAG_FILTER, filter);
+    GFX_GL_Sampler_Parameteri(&priv->sampler, GL_TEXTURE_MIN_FILTER, filter);
+
+    GLboolean blend = glIsEnabled(GL_BLEND);
+    if (blend) {
+        glDisable(GL_BLEND);
+    }
+
+    GLboolean depth_test = glIsEnabled(GL_DEPTH_TEST);
+    if (depth_test) {
+        glDisable(GL_DEPTH_TEST);
+    }
+
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    GFX_GL_CheckError();
+
+    if (blend) {
+        glEnable(GL_BLEND);
+    }
+
+    if (depth_test) {
+        glEnable(GL_DEPTH_TEST);
+    }
+    GFX_GL_CheckError();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, priv->fbo);
+    GFX_GL_CheckError();
+}
+
+static void GFX_Renderer_FBO_Bind(const GFX_Renderer *renderer)
+{
+    assert(renderer != NULL);
+    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    assert(priv != NULL);
+    glBindFramebuffer(GL_FRAMEBUFFER, priv->fbo);
+}
+
+static void GFX_Renderer_FBO_Unbind(const GFX_Renderer *renderer)
+{
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+GFX_Renderer g_GFX_Renderer_FBO = {
+    .swap_buffers = &GFX_Renderer_FBO_SwapBuffers,
+    .init = &GFX_Renderer_FBO_Init,
+    .shutdown = &GFX_Renderer_FBO_Shutdown,
+    .reset = &GFX_Renderer_FBO_Reset,
+};

--- a/src/gfx/renderers/legacy_renderer.c
+++ b/src/gfx/renderers/legacy_renderer.c
@@ -1,0 +1,35 @@
+#include "gfx/renderers/legacy_renderer.h"
+
+#include "gfx/context.h"
+#include "gfx/gl/utils.h"
+#include "gfx/screenshot.h"
+
+#include <SDL2/SDL_video.h>
+#include <assert.h>
+
+static void GFX_Renderer_Legacy_SwapBuffers(GFX_Renderer *renderer);
+
+static void GFX_Renderer_Legacy_SwapBuffers(GFX_Renderer *renderer)
+{
+    assert(renderer != NULL);
+
+    GFX_Context_SwitchToWindowViewportAR();
+    if (GFX_Context_GetScheduledScreenshotPath()) {
+        GFX_Screenshot_CaptureToFile(GFX_Context_GetScheduledScreenshotPath());
+        GFX_Context_ClearScheduledScreenshotPath();
+    }
+
+    SDL_GL_SwapWindow(GFX_Context_GetWindowHandle());
+
+    glDrawBuffer(GL_BACK);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    GFX_GL_CheckError();
+}
+
+GFX_Renderer g_GFX_Renderer_Legacy = {
+    .priv = NULL,
+    .swap_buffers = &GFX_Renderer_Legacy_SwapBuffers,
+    .init = NULL,
+    .reset = NULL,
+    .shutdown = NULL,
+};

--- a/src/gfx/screenshot.c
+++ b/src/gfx/screenshot.c
@@ -1,0 +1,76 @@
+#include "gfx/screenshot.h"
+
+#include "engine/image.h"
+#include "gfx/gl/utils.h"
+#include "memory.h"
+
+#include <assert.h>
+#include <string.h>
+
+bool GFX_Screenshot_CaptureToFile(const char *path)
+{
+    bool ret = false;
+
+    GLint width;
+    GLint height;
+    GFX_Screenshot_CaptureToBuffer(
+        NULL, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE, true);
+
+    IMAGE *image = Image_Create(width, height);
+    assert(image);
+
+    GFX_Screenshot_CaptureToBuffer(
+        (uint8_t *)image->data, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE,
+        true);
+
+    ret = Image_SaveToFile(image, path);
+
+    if (image) {
+        Image_Free(image);
+    }
+    return ret;
+}
+
+void GFX_Screenshot_CaptureToBuffer(
+    uint8_t *out_buffer, GLint *out_width, GLint *out_height, GLint depth,
+    GLenum format, GLenum type, bool vflip)
+{
+    assert(out_width);
+    assert(out_height);
+
+    GLint viewport[4];
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    GFX_GL_CheckError();
+
+    GLint x = viewport[0];
+    GLint y = viewport[1];
+    *out_width = viewport[2];
+    *out_height = viewport[3];
+
+    if (!out_buffer) {
+        return;
+    }
+
+    GLint pitch = *out_width * depth;
+
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    GFX_GL_CheckError();
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    GFX_GL_CheckError();
+
+    glReadBuffer(GL_BACK);
+    GFX_GL_CheckError();
+    glReadPixels(x, y, *out_width, *out_height, format, type, out_buffer);
+    GFX_GL_CheckError();
+
+    if (vflip) {
+        uint8_t *scanline = Memory_Alloc(pitch);
+        for (int y1 = 0, middle = *out_height / 2; y1 < middle; y1++) {
+            int y2 = *out_height - 1 - y1;
+            memcpy(scanline, &out_buffer[y1 * pitch], pitch);
+            memcpy(&out_buffer[y1 * pitch], &out_buffer[y2 * pitch], pitch);
+            memcpy(&out_buffer[y2 * pitch], scanline, pitch);
+        }
+        Memory_FreePointer(&scanline);
+    }
+}

--- a/tools/additional_lint
+++ b/tools/additional_lint
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 from libtrx.cli.additional_lint import run_script
 
-run_script()
+run_script(ignored_patterns=["*.patch", "*.bin", "gl_core_3_3.h"])


### PR DESCRIPTION
Mostly unchanged – only the imports had to be made relative due to the current architecture of libtrx.