### PR TITLE
Reusable game strings

### DIFF
--- a/include/libtrx/game/game_string.h
+++ b/include/libtrx/game/game_string.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define GS_DEFINE(id, value) GameString_Define(#id, value);
+#define GS(id) GameString_Get(#id)
+#define GS_ID(id) (#id)
+
+typedef const char *GAME_STRING_ID;
+
+void GameString_Define(const char *key, const char *value);
+bool GameString_IsKnown(const char *key);
+const char *GameString_Get(const char *key);
+void GameString_Clear(void);

--- a/meson.build
+++ b/meson.build
@@ -7,11 +7,11 @@ project(
   ],
 )
 
-fs = import('fs')
 staticdeps = get_option('staticdeps')
 tr_version = get_option('tr_version')
 gfx_gl_default_backend = get_option('gfx_gl_default_backend')
 
+fs = import('fs')
 c_compiler = meson.get_compiler('c')
 relative_dir = fs.relative_to(meson.current_source_dir(), meson.global_build_root())
 build_opts = [
@@ -32,6 +32,8 @@ add_project_arguments(build_opts, language: 'c')
 if host_machine.system() == 'darwin'
   staticdeps = false
 endif
+
+uthash = subproject('uthash', default_options: ['warning_level=0'])
 
 null_dep = dependency('', required: false)
 dep_avcodec = dependency('libavcodec', static: staticdeps)
@@ -64,6 +66,7 @@ sources = [
   'src/enum_str.c',
   'src/filesystem.c',
   'src/game/items.c',
+  'src/game/game_string.c',
   'src/gfx/2d/2d_renderer.c',
   'src/gfx/2d/2d_surface.c',
   'src/gfx/3d/3d_renderer.c',
@@ -102,6 +105,7 @@ dependencies = [
   dep_swscale,
   dep_zlib,
   dep_opengl,
+  uthash.get_variable('uthash_dep'),
 ]
 
 if dep_backtrace.found() and host_machine.system() == 'linux'

--- a/meson.build
+++ b/meson.build
@@ -44,9 +44,14 @@ dep_swscale = dependency('libswscale', static: staticdeps)
 dep_swresample = dependency('libswresample', static: staticdeps)
 
 dep_zlib = null_dep
-
 if not staticdeps
   dep_zlib = dependency('zlib', static: staticdeps)
+endif
+
+if host_machine.system() == 'windows'
+  dep_opengl = c_compiler.find_library('opengl32')
+else
+  dep_opengl = dependency('GL')
 endif
 
 sources = [
@@ -96,6 +101,7 @@ dependencies = [
   dep_swresample,
   dep_swscale,
   dep_zlib,
+  dep_opengl,
 ]
 
 if dep_backtrace.found() and host_machine.system() == 'linux'

--- a/src/game/game_string.c
+++ b/src/game/game_string.c
@@ -1,0 +1,57 @@
+#include "game/game_string.h"
+
+#include "memory.h"
+
+#include <uthash.h>
+
+typedef struct {
+    char *key;
+    char *value;
+    UT_hash_handle hh;
+} STRING_TABLE_ENTRY;
+
+static STRING_TABLE_ENTRY *m_StringTable = NULL;
+
+void GameString_Define(const char *key, const char *value)
+{
+    STRING_TABLE_ENTRY *entry;
+
+    HASH_FIND_STR(m_StringTable, key, entry);
+    if (entry == NULL) {
+        entry = (STRING_TABLE_ENTRY *)Memory_Alloc(sizeof(STRING_TABLE_ENTRY));
+        entry->key = Memory_DupStr(key);
+        entry->value = Memory_DupStr(value);
+        HASH_ADD_KEYPTR(
+            hh, m_StringTable, entry->key, strlen(entry->key), entry);
+    } else {
+        Memory_Free(entry->value);
+        entry->value = Memory_DupStr(value);
+    }
+}
+
+bool GameString_IsKnown(const char *key)
+{
+    STRING_TABLE_ENTRY *entry;
+    HASH_FIND_STR(m_StringTable, key, entry);
+    return entry != NULL;
+}
+
+const char *GameString_Get(const char *key)
+{
+    STRING_TABLE_ENTRY *entry;
+    HASH_FIND_STR(m_StringTable, key, entry);
+    return entry ? entry->value : NULL;
+}
+
+void GameString_Clear(void)
+{
+    STRING_TABLE_ENTRY *entry, *tmp;
+
+    HASH_ITER(hh, m_StringTable, entry, tmp)
+    {
+        HASH_DEL(m_StringTable, entry);
+        Memory_Free(entry->key);
+        Memory_Free(entry->value);
+        Memory_Free(entry);
+    }
+}

--- a/subprojects/uthash.wrap
+++ b/subprojects/uthash.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = uthash-2.3.0
+source_url = https://github.com/troydhanson/uthash/archive/v2.3.0.tar.gz
+source_filename = uthash-2.3.0.tar.gz
+source_hash = e10382ab75518bad8319eb922ad04f907cb20cccb451a3aa980c9d005e661acc
+patch_filename = uthash_2.3.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/uthash_2.3.0-1/get_patch
+patch_hash = d0b7cf9788c3735ee6a08bb649c58be1f5fad4b95e50e7681cbdf44882da9d7e
+
+[provide]
+uthash = uthash_dep

--- a/tools/libtrx/cli/game_docker_entrypoint.py
+++ b/tools/libtrx/cli/game_docker_entrypoint.py
@@ -45,9 +45,10 @@ class CompileCommand(BaseCommand):
     def run(self, args: argparse.Namespace, options: Options) -> None:
         pkg_config_path = os.environ.get("PKG_CONFIG_PATH")
 
-        if not Path("/app/build/linux/build.jinja").exists():
+        if not (options.build_root / "build.ninja").exists():
             command = [
                 "meson",
+                "setup",
                 "--buildtype",
                 options.target,
                 *options.compile_args,

--- a/tools/libtrx/cli/sort_imports.py
+++ b/tools/libtrx/cli/sort_imports.py
@@ -8,44 +8,6 @@ from subprocess import run
 from libtrx.files import find_versioned_files
 
 
-@functools.cache
-def get_fix_includes_exe_name() -> str:
-    return "fix_include" if which("fix_include") else "iwyu-fix-includes"
-
-
-def fix_imports(
-    path: Path,
-    root_dir: Path,
-    include_dirs: list[Path] | None = None,
-    system_include_dirs: list[Path] | None = None,
-) -> None:
-    cmdline = [
-        "include-what-you-use",
-    ]
-
-    if include_dirs:
-        for include_dir in include_dirs:
-            if include_dir != root_dir:
-                cmdline.extend(["-I", str(include_dir)])
-
-    if system_include_dirs:
-        for include_dir in system_include_dirs:
-            cmdline.extend(
-                [
-                    "-isystem",
-                    str(include_dir),
-                ]
-            )
-
-    cmdline.append(path)
-    iwyu_result = run(
-        cmdline, cwd=root_dir, capture_output=True, text=True
-    ).stderr
-
-    cmdline = [get_fix_includes_exe_name(), "--noblank_lines", "--noreorder"]
-    run(cmdline, cwd=root_dir, input=iwyu_result, text=True)
-
-
 def custom_sort(source: list[str], forced_order: list[str]) -> list[str]:
     def key_func(item: str) -> tuple[int, int, str]:
         if item in forced_order:
@@ -138,13 +100,6 @@ def run_script(
         )
 
     for path in paths:
-        fix_imports(
-            path,
-            root_dir=root_dir,
-            include_dirs=include_dirs,
-            system_include_dirs=system_include_dirs,
-        )
-
         sort_imports(
             path,
             root_dir=root_dir,


### PR DESCRIPTION
I know I've made refactors to the game string management several times, but I just keep encountering issues. Recently, while integrating game string support into libtrx, I realized there was no way to declare the `GAME_STRING_ID` enum in libtrx and allow users (TR1X, TR2X) to add their own strings (or the other way around).

To address this, this PR switches from using integers to strings for keys. It maintains existing macros for minimal disruption and includes the `uthash` library for performance.

As a result, the default string table initialization must occur at runtime, not compile time. Consumers need to declare their default strings at runtime using the new `GameString_Init` and `GameString_Shutdown()` functions.

libtrx will provide its own `game_string.def` table, which consumers will need to `#include` in their `GameString_Init` and `GameString_Shutdown()` routines.

Related changes:
- TR1X - https://github.com/LostArtefacts/TR1X/pull/1526
- TR2X - https://github.com/LostArtefacts/TR2X/pull/241
