### PR TITLE
misc: adopt M_ prefix for private functions

### DIFF
--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -5,7 +5,7 @@
 
 #include <SDL2/SDL_timer.h>
 
-static void Benchmark_Log(
+static void M_Log(
     BENCHMARK *const b, const char *file, int32_t line, const char *func,
     Uint64 current, const char *message)
 {
@@ -49,7 +49,7 @@ void Benchmark_Tick_Impl(
     const char *const func, const char *const message)
 {
     const Uint64 current = SDL_GetPerformanceCounter();
-    Benchmark_Log(b, file, line, func, current, message);
+    M_Log(b, file, line, func, current, message);
     b->last = current;
 }
 

--- a/src/engine/audio.c
+++ b/src/engine/audio.c
@@ -15,10 +15,9 @@ static size_t m_MixBufferCapacity = 0;
 static float *m_MixBuffer = NULL;
 static Uint8 m_Silence = 0;
 
-static void Audio_MixerCallback(
-    void *userdata, Uint8 *stream_data, int32_t len);
+static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len);
 
-static void Audio_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
+static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
 {
     memset(m_MixBuffer, m_Silence, len);
     Audio_Stream_Mix(m_MixBuffer, len);
@@ -46,7 +45,7 @@ bool Audio_Init(void)
     desired.format = AUDIO_WORKING_FORMAT;
     desired.channels = AUDIO_WORKING_CHANNELS;
     desired.samples = AUDIO_SAMPLES;
-    desired.callback = Audio_MixerCallback;
+    desired.callback = M_MixerCallback;
     desired.userdata = NULL;
 
     SDL_AudioSpec delivered;

--- a/src/engine/image.c
+++ b/src/engine/image.c
@@ -40,17 +40,16 @@ typedef struct {
     AVPacket *packet;
 } IMAGE_READER_CONTEXT;
 
-static bool Image_Reader_Init(const char *path, IMAGE_READER_CONTEXT *ctx);
-static void Image_Reader_Free(IMAGE_READER_CONTEXT *ctx);
-static IMAGE *Image_Reader_ConstructImage(
+static bool M_Init(const char *path, IMAGE_READER_CONTEXT *ctx);
+static void M_Free(IMAGE_READER_CONTEXT *ctx);
+static IMAGE *M_ConstructImage(
     IMAGE_READER_CONTEXT *ctx, int32_t target_width, int32_t target_height,
     IMAGE_FIT_MODE fit_mode);
-static IMAGE_BLIT Image_GetBlit(
+static IMAGE_BLIT M_GetBlit(
     int32_t source_width, int32_t source_height, int32_t target_width,
     int32_t target_height, IMAGE_FIT_MODE fit_mode);
 
-static bool Image_Reader_Init(
-    const char *const path, IMAGE_READER_CONTEXT *const ctx)
+static bool M_Init(const char *const path, IMAGE_READER_CONTEXT *const ctx)
 {
     assert(ctx != NULL);
     ctx->format_ctx = NULL;
@@ -149,14 +148,14 @@ finish:
     if (error_code != 0) {
         LOG_ERROR(
             "Error while opening image %s: %s", path, av_err2str(error_code));
-        Image_Reader_Free(ctx);
+        M_Free(ctx);
         return false;
     }
 
     return true;
 }
 
-static void Image_Reader_Free(IMAGE_READER_CONTEXT *const ctx)
+static void M_Free(IMAGE_READER_CONTEXT *const ctx)
 {
     if (ctx->packet != NULL) {
         av_packet_free(&ctx->packet);
@@ -186,7 +185,7 @@ IMAGE *Image_Create(const int width, const int height)
     return image;
 }
 
-static IMAGE *Image_Reader_ConstructImage(
+static IMAGE *M_ConstructImage(
     IMAGE_READER_CONTEXT *const ctx, const int32_t target_width,
     const int32_t target_height, IMAGE_FIT_MODE fit_mode)
 {
@@ -194,7 +193,7 @@ static IMAGE *Image_Reader_ConstructImage(
     assert(target_width > 0);
     assert(target_height > 0);
 
-    IMAGE_BLIT blit = Image_GetBlit(
+    IMAGE_BLIT blit = M_GetBlit(
         ctx->frame->width, ctx->frame->height, target_width, target_height,
         fit_mode);
 
@@ -230,7 +229,7 @@ static IMAGE *Image_Reader_ConstructImage(
     return target_image;
 }
 
-static IMAGE_BLIT Image_GetBlit(
+static IMAGE_BLIT M_GetBlit(
     const int32_t source_width, const int32_t source_height,
     const int32_t target_width, const int32_t target_height,
     IMAGE_FIT_MODE fit_mode)
@@ -315,14 +314,14 @@ IMAGE *Image_CreateFromFile(const char *const path)
     assert(path != NULL);
 
     IMAGE_READER_CONTEXT ctx;
-    if (!Image_Reader_Init(path, &ctx)) {
+    if (!M_Init(path, &ctx)) {
         return NULL;
     }
 
-    IMAGE *target_image = Image_Reader_ConstructImage(
+    IMAGE *target_image = M_ConstructImage(
         &ctx, ctx.frame->width, ctx.frame->height, IMAGE_FIT_STRETCH);
 
-    Image_Reader_Free(&ctx);
+    M_Free(&ctx);
 
     return target_image;
 }
@@ -334,14 +333,14 @@ IMAGE *Image_CreateFromFileInto(
     assert(path != NULL);
 
     IMAGE_READER_CONTEXT ctx;
-    if (!Image_Reader_Init(path, &ctx)) {
+    if (!M_Init(path, &ctx)) {
         return NULL;
     }
 
-    IMAGE *target_image = Image_Reader_ConstructImage(
-        &ctx, target_width, target_height, fit_mode);
+    IMAGE *target_image =
+        M_ConstructImage(&ctx, target_width, target_height, fit_mode);
 
-    Image_Reader_Free(&ctx);
+    M_Free(&ctx);
 
     return target_image;
 }
@@ -514,7 +513,7 @@ IMAGE *Image_Scale(
     assert(target_width > 0);
     assert(target_height > 0);
 
-    IMAGE_BLIT blit = Image_GetBlit(
+    IMAGE_BLIT blit = M_GetBlit(
         source_image->width, source_image->height, target_width, target_height,
         fit_mode);
 

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -24,30 +24,30 @@ struct MYFILE {
 
 const char *m_GameDir = NULL;
 
-static void File_PathAppendSeparator(char *path);
-static void File_PathAppendPart(char *path, const char *part);
-static char *File_CasePath(char const *path);
-static bool File_ExistsRaw(const char *path);
+static void M_PathAppendSeparator(char *path);
+static void M_PathAppendPart(char *path, const char *part);
+static char *M_CasePath(char const *path);
+static bool M_ExistsRaw(const char *path);
 
-static void File_PathAppendSeparator(char *path)
+static void M_PathAppendSeparator(char *path)
 {
     if (!String_EndsWith(path, PATH_SEPARATOR)) {
         strcat(path, PATH_SEPARATOR);
     }
 }
 
-static void File_PathAppendPart(char *path, const char *part)
+static void M_PathAppendPart(char *path, const char *part)
 {
-    File_PathAppendSeparator(path);
+    M_PathAppendSeparator(path);
     strcat(path, part);
 }
 
-static char *File_CasePath(char const *path)
+static char *M_CasePath(char const *path)
 {
     assert(path);
 
     char *path_copy = Memory_DupStr(path);
-    if (File_ExistsRaw(path)) {
+    if (M_ExistsRaw(path)) {
         return path_copy;
     }
 
@@ -82,7 +82,7 @@ static char *File_CasePath(char const *path)
         struct dirent *cur_file = readdir(path_dir);
         while (cur_file) {
             if (String_Equivalent(path_piece, cur_file->d_name)) {
-                File_PathAppendPart(current_path, cur_file->d_name);
+                M_PathAppendPart(current_path, cur_file->d_name);
                 break;
             }
             cur_file = readdir(path_dir);
@@ -90,7 +90,7 @@ static char *File_CasePath(char const *path)
         closedir(path_dir);
 
         if (!cur_file) {
-            File_PathAppendPart(current_path, path_piece);
+            M_PathAppendPart(current_path, path_piece);
         }
 
         if (delim) {
@@ -115,7 +115,7 @@ static char *File_CasePath(char const *path)
     return result;
 }
 
-static bool File_ExistsRaw(const char *path)
+static bool M_ExistsRaw(const char *path)
 {
     FILE *fp = fopen(path, "rb");
     if (fp) {
@@ -162,7 +162,7 @@ bool File_DirExists(const char *path)
 bool File_Exists(const char *path)
 {
     char *full_path = File_GetFullPath(path);
-    bool ret = File_ExistsRaw(full_path);
+    bool ret = M_ExistsRaw(full_path);
     Memory_FreePointer(&full_path);
     return ret;
 }
@@ -181,7 +181,7 @@ char *File_GetFullPath(const char *path)
         full_path = Memory_DupStr(path);
     }
 
-    char *case_path = File_CasePath(full_path);
+    char *case_path = M_CasePath(full_path);
     if (case_path) {
         Memory_FreePointer(&full_path);
         return case_path;

--- a/src/game/console/commands/heal.c
+++ b/src/game/console/commands/heal.c
@@ -5,7 +5,9 @@
 #include "game/lara/common.h"
 #include "game/lara/misc.h"
 
-static COMMAND_RESULT Console_Cmd_Heal(const char *const args)
+static COMMAND_RESULT M_Entrypoint(const char *args);
+
+static COMMAND_RESULT M_Entrypoint(const char *const args)
 {
     if (!Game_IsPlayable()) {
         return CR_UNAVAILABLE;
@@ -25,5 +27,5 @@ static COMMAND_RESULT Console_Cmd_Heal(const char *const args)
 
 CONSOLE_COMMAND g_Console_Cmd_Heal = {
     .prefix = "heal",
-    .proc = Console_Cmd_Heal,
+    .proc = M_Entrypoint,
 };

--- a/src/game/console/commands/pos.c
+++ b/src/game/console/commands/pos.c
@@ -6,9 +6,9 @@
 #include "game/lara/common.h"
 #include "game/objects/common.h"
 
-static COMMAND_RESULT Console_Cmd_Pos(const char *args);
+static COMMAND_RESULT M_Entrypoint(const char *args);
 
-static COMMAND_RESULT Console_Cmd_Pos(const char *const args)
+static COMMAND_RESULT M_Entrypoint(const char *const args)
 {
     const OBJECT_INFO *const object = Object_GetObject(O_LARA);
     if (!object->loaded) {
@@ -34,5 +34,5 @@ static COMMAND_RESULT Console_Cmd_Pos(const char *const args)
 
 CONSOLE_COMMAND g_Console_Cmd_Pos = {
     .prefix = "pos",
-    .proc = Console_Cmd_Pos,
+    .proc = M_Entrypoint,
 };

--- a/src/game/console/commands/set_health.c
+++ b/src/game/console/commands/set_health.c
@@ -8,9 +8,9 @@
 #include "strings.h"
 #include "utils.h"
 
-static COMMAND_RESULT Console_Cmd_SetHealth(const char *args);
+static COMMAND_RESULT M_Entrypoint(const char *args);
 
-static COMMAND_RESULT Console_Cmd_SetHealth(const char *const args)
+static COMMAND_RESULT M_Entrypoint(const char *const args)
 {
     if (!Game_IsPlayable()) {
         return CR_UNAVAILABLE;
@@ -35,5 +35,5 @@ static COMMAND_RESULT Console_Cmd_SetHealth(const char *const args)
 
 CONSOLE_COMMAND g_Console_Cmd_SetHealth = {
     .prefix = "hp",
-    .proc = Console_Cmd_SetHealth,
+    .proc = M_Entrypoint,
 };

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -7,11 +7,9 @@
 #include <assert.h>
 #include <stddef.h>
 
-static void GFX_3D_Renderer_SelectTextureImpl(
-    GFX_3D_Renderer *renderer, int texture_num);
+static void M_SelectTextureImpl(GFX_3D_Renderer *renderer, int texture_num);
 
-static void GFX_3D_Renderer_SelectTextureImpl(
-    GFX_3D_Renderer *renderer, int texture_num)
+static void M_SelectTextureImpl(GFX_3D_Renderer *renderer, int texture_num)
 {
     assert(renderer);
 
@@ -189,7 +187,7 @@ bool GFX_3D_Renderer_UnregisterEnvironmentMap(
 
     // unbind texture if currently bound
     if (renderer->selected_texture_num == texture_num) {
-        GFX_3D_Renderer_SelectTextureImpl(renderer, GFX_NO_TEXTURE);
+        M_SelectTextureImpl(renderer, GFX_NO_TEXTURE);
         renderer->selected_texture_num = GFX_NO_TEXTURE;
     }
 
@@ -248,7 +246,7 @@ bool GFX_3D_Renderer_UnregisterTexturePage(
 
     // unbind texture if currently bound
     if (texture_num == renderer->selected_texture_num) {
-        GFX_3D_Renderer_SelectTextureImpl(renderer, GFX_NO_TEXTURE);
+        M_SelectTextureImpl(renderer, GFX_NO_TEXTURE);
         renderer->selected_texture_num = GFX_NO_TEXTURE;
     }
 
@@ -287,13 +285,13 @@ void GFX_3D_Renderer_SelectTexture(GFX_3D_Renderer *renderer, int texture_num)
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
     renderer->selected_texture_num = texture_num;
-    GFX_3D_Renderer_SelectTextureImpl(renderer, texture_num);
+    M_SelectTextureImpl(renderer, texture_num);
 }
 
 void GFX_3D_Renderer_RestoreTexture(GFX_3D_Renderer *renderer)
 {
     assert(renderer);
-    GFX_3D_Renderer_SelectTextureImpl(renderer, renderer->selected_texture_num);
+    M_SelectTextureImpl(renderer, renderer->selected_texture_num);
 }
 
 void GFX_3D_Renderer_SetPrimType(

--- a/src/gfx/3d/vertex_stream.c
+++ b/src/gfx/3d/vertex_stream.c
@@ -10,10 +10,10 @@ static const GLenum GL_PRIM_MODES[] = {
     GL_TRIANGLES, // GFX_3D_PRIM_TRI
 };
 
-static void GFX_3D_VertexStream_PushVertex(
+static void M_PushVertex(
     GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertex);
 
-static void GFX_3D_VertexStream_PushVertex(
+static void M_PushVertex(
     GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertex)
 {
     if (vertex_stream->pending_vertices.count + 1
@@ -80,14 +80,14 @@ bool GFX_3D_VertexStream_PushPrimStrip(
 
     if (count <= 2) {
         for (int i = 0; i < count; i++) {
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+            M_PushVertex(vertex_stream, &vertices[i]);
         }
     } else {
         // convert strip to raw triangles
         for (int i = 2; i < count; i++) {
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i - 2]);
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i - 1]);
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+            M_PushVertex(vertex_stream, &vertices[i - 2]);
+            M_PushVertex(vertex_stream, &vertices[i - 1]);
+            M_PushVertex(vertex_stream, &vertices[i]);
         }
     }
 
@@ -104,14 +104,14 @@ bool GFX_3D_VertexStream_PushPrimFan(
 
     if (count <= 2) {
         for (int i = 0; i < count; i++) {
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+            M_PushVertex(vertex_stream, &vertices[i]);
         }
     } else {
         // convert fan to raw triangles
         for (int i = 2; i < count; i++) {
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[0]);
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i - 1]);
-            GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+            M_PushVertex(vertex_stream, &vertices[0]);
+            M_PushVertex(vertex_stream, &vertices[i - 1]);
+            M_PushVertex(vertex_stream, &vertices[i]);
         }
     }
 
@@ -122,7 +122,7 @@ bool GFX_3D_VertexStream_PushPrimList(
     GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
 {
     for (int i = 0; i < count; i++) {
-        GFX_3D_VertexStream_PushVertex(vertex_stream, &vertices[i]);
+        M_PushVertex(vertex_stream, &vertices[i]);
     }
     return true;
 }

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -31,10 +31,10 @@ typedef struct GFX_CONTEXT {
 
 static GFX_CONTEXT m_Context = { 0 };
 
-static bool GFX_Context_IsExtensionSupported(const char *name);
-static void GFX_Context_CheckExtensionSupport(const char *name);
+static bool M_IsExtensionSupported(const char *name);
+static void M_CheckExtensionSupport(const char *name);
 
-static bool GFX_Context_IsExtensionSupported(const char *name)
+static bool M_IsExtensionSupported(const char *name)
 {
     int number_of_extensions;
 
@@ -52,11 +52,10 @@ static bool GFX_Context_IsExtensionSupported(const char *name)
     return false;
 }
 
-static void GFX_Context_CheckExtensionSupport(const char *name)
+static void M_CheckExtensionSupport(const char *name)
 {
     LOG_INFO(
-        "%s supported: %s", name,
-        GFX_Context_IsExtensionSupported(name) ? "yes" : "no");
+        "%s supported: %s", name, M_IsExtensionSupported(name) ? "yes" : "no");
 }
 
 void GFX_Context_SwitchToWindowViewport(void)
@@ -150,8 +149,8 @@ void GFX_Context_Attach(void *window_handle)
 
     // Check the availability of non-Core Profile extensions for OpenGL 2.1
     if (GFX_GL_DEFAULT_BACKEND == GFX_GL_21) {
-        GFX_Context_CheckExtensionSupport("GL_ARB_explicit_attrib_location");
-        GFX_Context_CheckExtensionSupport("GL_EXT_gpu_shader4");
+        M_CheckExtensionSupport("GL_ARB_explicit_attrib_location");
+        M_CheckExtensionSupport("GL_EXT_gpu_shader4");
     }
 
     glClearColor(0, 0, 0, 0);

--- a/src/gfx/renderers/fbo_renderer.c
+++ b/src/gfx/renderers/fbo_renderer.c
@@ -32,17 +32,16 @@ typedef struct {
     GFX_GL_Program program;
 } GFX_Renderer_FBO_Context;
 
-static void GFX_Renderer_FBO_SwapBuffers(GFX_Renderer *renderer);
-static void GFX_Renderer_FBO_Init(
-    GFX_Renderer *renderer, const GFX_CONFIG *config);
-static void GFX_Renderer_FBO_Shutdown(GFX_Renderer *renderer);
-static void GFX_Renderer_FBO_Reset(GFX_Renderer *renderer);
+static void M_SwapBuffers(GFX_Renderer *renderer);
+static void M_Init(GFX_Renderer *renderer, const GFX_CONFIG *config);
+static void M_Shutdown(GFX_Renderer *renderer);
+static void M_Reset(GFX_Renderer *renderer);
 
-static void GFX_Renderer_FBO_Render(GFX_Renderer *renderer);
-static void GFX_Renderer_FBO_Bind(const GFX_Renderer *renderer);
-static void GFX_Renderer_FBO_Unbind(const GFX_Renderer *renderer);
+static void M_Render(GFX_Renderer *renderer);
+static void M_Bind(const GFX_Renderer *renderer);
+static void M_Unbind(const GFX_Renderer *renderer);
 
-static void GFX_Renderer_FBO_SwapBuffers(GFX_Renderer *renderer)
+static void M_SwapBuffers(GFX_Renderer *renderer)
 {
     if (GFX_Context_GetScheduledScreenshotPath()) {
         GFX_Screenshot_CaptureToFile(GFX_Context_GetScheduledScreenshotPath());
@@ -50,21 +49,20 @@ static void GFX_Renderer_FBO_SwapBuffers(GFX_Renderer *renderer)
     }
 
     GFX_Context_SwitchToWindowViewportAR();
-    GFX_Renderer_FBO_Render(renderer);
+    M_Render(renderer);
 
     SDL_GL_SwapWindow(GFX_Context_GetWindowHandle());
 
     GFX_Context_SwitchToWindowViewport();
-    GFX_Renderer_FBO_Unbind(renderer);
+    M_Unbind(renderer);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     GFX_GL_CheckError();
 
-    GFX_Renderer_FBO_Bind(renderer);
+    M_Bind(renderer);
     GFX_Context_SwitchToDisplayViewport();
 }
 
-static void GFX_Renderer_FBO_Init(
-    GFX_Renderer *const renderer, const GFX_CONFIG *const config)
+static void M_Init(GFX_Renderer *const renderer, const GFX_CONFIG *const config)
 {
     LOG_INFO("");
 
@@ -146,7 +144,7 @@ static void GFX_Renderer_FBO_Init(
     }
 }
 
-static void GFX_Renderer_FBO_Shutdown(GFX_Renderer *renderer)
+static void M_Shutdown(GFX_Renderer *renderer)
 {
     LOG_INFO("");
 
@@ -169,7 +167,7 @@ static void GFX_Renderer_FBO_Shutdown(GFX_Renderer *renderer)
     Memory_FreePointer(&renderer->priv);
 }
 
-static void GFX_Renderer_FBO_Reset(GFX_Renderer *renderer)
+static void M_Reset(GFX_Renderer *renderer)
 {
     GFX_Renderer_FBO_Context *const priv = renderer->priv;
     const GFX_CONFIG *const config = priv->config;
@@ -178,7 +176,7 @@ static void GFX_Renderer_FBO_Reset(GFX_Renderer *renderer)
     renderer->init(renderer, config);
 }
 
-static void GFX_Renderer_FBO_Render(GFX_Renderer *renderer)
+static void M_Render(GFX_Renderer *renderer)
 {
     assert(renderer != NULL);
     GFX_Renderer_FBO_Context *priv = renderer->priv;
@@ -227,7 +225,7 @@ static void GFX_Renderer_FBO_Render(GFX_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
-static void GFX_Renderer_FBO_Bind(const GFX_Renderer *renderer)
+static void M_Bind(const GFX_Renderer *renderer)
 {
     assert(renderer != NULL);
     GFX_Renderer_FBO_Context *priv = renderer->priv;
@@ -235,14 +233,14 @@ static void GFX_Renderer_FBO_Bind(const GFX_Renderer *renderer)
     glBindFramebuffer(GL_FRAMEBUFFER, priv->fbo);
 }
 
-static void GFX_Renderer_FBO_Unbind(const GFX_Renderer *renderer)
+static void M_Unbind(const GFX_Renderer *renderer)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
 GFX_Renderer g_GFX_Renderer_FBO = {
-    .swap_buffers = &GFX_Renderer_FBO_SwapBuffers,
-    .init = &GFX_Renderer_FBO_Init,
-    .shutdown = &GFX_Renderer_FBO_Shutdown,
-    .reset = &GFX_Renderer_FBO_Reset,
+    .swap_buffers = &M_SwapBuffers,
+    .init = &M_Init,
+    .shutdown = &M_Shutdown,
+    .reset = &M_Reset,
 };

--- a/src/gfx/renderers/legacy_renderer.c
+++ b/src/gfx/renderers/legacy_renderer.c
@@ -7,9 +7,9 @@
 #include <SDL2/SDL_video.h>
 #include <assert.h>
 
-static void GFX_Renderer_Legacy_SwapBuffers(GFX_Renderer *renderer);
+static void M_SwapBuffers(GFX_Renderer *renderer);
 
-static void GFX_Renderer_Legacy_SwapBuffers(GFX_Renderer *renderer)
+static void M_SwapBuffers(GFX_Renderer *renderer)
 {
     assert(renderer != NULL);
 
@@ -28,7 +28,7 @@ static void GFX_Renderer_Legacy_SwapBuffers(GFX_Renderer *renderer)
 
 GFX_Renderer g_GFX_Renderer_Legacy = {
     .priv = NULL,
-    .swap_buffers = &GFX_Renderer_Legacy_SwapBuffers,
+    .swap_buffers = &M_SwapBuffers,
     .init = NULL,
     .reset = NULL,
     .shutdown = NULL,

--- a/src/json/bson_parse.c
+++ b/src/json/bson_parse.c
@@ -22,53 +22,50 @@ struct bson_parse_state_s {
     size_t error;
 };
 
-static bool bson_parse_get_object_key_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_null_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_bool_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_int32_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_double_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_string_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_array_element_wrapped_size(
-    struct bson_parse_state_s *state);
-static bool bson_parse_get_array_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_array_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_object_element_wrapped_size(
-    struct bson_parse_state_s *state);
-static bool bson_parse_get_object_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_object_value_size(struct bson_parse_state_s *state);
-static bool bson_parse_get_value_size(
-    struct bson_parse_state_s *state, uint8_t marker);
-static bool bson_parse_get_root_size(struct bson_parse_state_s *state);
+static bool M_GetObjectKeySize(struct bson_parse_state_s *state);
+static bool M_GetNullValueSize(struct bson_parse_state_s *state);
+static bool M_GetBoolValueSize(struct bson_parse_state_s *state);
+static bool M_GetInt32ValueSize(struct bson_parse_state_s *state);
+static bool M_GetDoubleValueSize(struct bson_parse_state_s *state);
+static bool M_GetStringValueSize(struct bson_parse_state_s *state);
+static bool M_GetArrayElementWrappedSize(struct bson_parse_state_s *state);
+static bool M_GetArraySize(struct bson_parse_state_s *state);
+static bool M_GetArrayValueSize(struct bson_parse_state_s *state);
+static bool M_GetObjectElementWrappedSize(struct bson_parse_state_s *state);
+static bool M_GetObjectSize(struct bson_parse_state_s *state);
+static bool M_GetObjectValueSize(struct bson_parse_state_s *state);
+static bool M_GetValueSize(struct bson_parse_state_s *state, uint8_t marker);
+static bool m_GetRootSize(struct bson_parse_state_s *state);
 
-static void bson_parse_object_key(
+static void M_HandleObjectKey(
     struct bson_parse_state_s *state, struct json_string_s *string);
-static void bson_parse_null_value(
+static void M_HandleNullValue(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_bool_value(
+static void M_HandleBoolValue(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_int32_value(
+static void M_HandleInt32Value(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_double_value(
+static void M_HandleDoubleValue(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_string_value(
+static void M_HandleStringValue(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_array_element_wrapped(
+static void M_HandleArrayElementWrapped(
     struct bson_parse_state_s *state, struct json_array_element_s *element);
-static void bson_parse_array(
+static void M_HandleArray(
     struct bson_parse_state_s *state, struct json_array_s *array);
-static void bson_parse_array_value(
+static void M_HandleArrayValue(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_object_element_wrapped(
+static void M_HandleObjectElementWrapped(
     struct bson_parse_state_s *state, struct json_object_element_s *element);
-static void bson_parse_object(
+static void M_HandleObject(
     struct bson_parse_state_s *state, struct json_object_s *object);
-static void bson_parse_object_value(
+static void M_HandleObjectValue(
     struct bson_parse_state_s *state, struct json_value_s *value);
-static void bson_parse_value(
+static void M_HandleValue(
     struct bson_parse_state_s *state, struct json_value_s *value,
     uint8_t marker);
 
-static bool bson_parse_get_object_key_size(struct bson_parse_state_s *state)
+static bool M_GetObjectKeySize(struct bson_parse_state_s *state)
 {
     assert(state);
     while (state->src[state->offset]) {
@@ -80,13 +77,13 @@ static bool bson_parse_get_object_key_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_null_value_size(struct bson_parse_state_s *state)
+static bool M_GetNullValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
     return true;
 }
 
-static bool bson_parse_get_bool_value_size(struct bson_parse_state_s *state)
+static bool M_GetBoolValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
     if (state->offset + sizeof(uint8_t) > state->size) {
@@ -108,7 +105,7 @@ static bool bson_parse_get_bool_value_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_int32_value_size(struct bson_parse_state_s *state)
+static bool M_GetInt32ValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -124,7 +121,7 @@ static bool bson_parse_get_int32_value_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_double_value_size(struct bson_parse_state_s *state)
+static bool M_GetDoubleValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -140,7 +137,7 @@ static bool bson_parse_get_double_value_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_string_value_size(struct bson_parse_state_s *state)
+static bool M_GetStringValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -164,8 +161,7 @@ static bool bson_parse_get_string_value_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_array_element_wrapped_size(
-    struct bson_parse_state_s *state)
+static bool M_GetArrayElementWrappedSize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -178,15 +174,15 @@ static bool bson_parse_get_array_element_wrapped_size(
 
     // BSON arrays always use keys
     state->dom_size += sizeof(struct json_string_s);
-    if (!bson_parse_get_object_key_size(state)) {
+    if (!M_GetObjectKeySize(state)) {
         return false;
     }
 
     state->dom_size += sizeof(struct json_value_s);
-    return bson_parse_get_value_size(state, marker);
+    return M_GetValueSize(state, marker);
 }
 
-static bool bson_parse_get_array_size(struct bson_parse_state_s *state)
+static bool M_GetArraySize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -200,7 +196,7 @@ static bool bson_parse_get_array_size(struct bson_parse_state_s *state)
 
     while (state->offset < start_offset + size - 1) {
         state->dom_size += sizeof(struct json_array_element_s);
-        if (!bson_parse_get_array_element_wrapped_size(state)) {
+        if (!M_GetArrayElementWrappedSize(state)) {
             return false;
         }
     }
@@ -217,15 +213,14 @@ static bool bson_parse_get_array_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_array_value_size(struct bson_parse_state_s *state)
+static bool M_GetArrayValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
     state->dom_size += sizeof(struct json_array_s);
-    return bson_parse_get_array_size(state);
+    return M_GetArraySize(state);
 }
 
-static bool bson_parse_get_object_element_wrapped_size(
-    struct bson_parse_state_s *state)
+static bool M_GetObjectElementWrappedSize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -237,15 +232,15 @@ static bool bson_parse_get_object_element_wrapped_size(
     state->offset++;
 
     state->dom_size += sizeof(struct json_string_s);
-    if (!bson_parse_get_object_key_size(state)) {
+    if (!M_GetObjectKeySize(state)) {
         return false;
     }
 
     state->dom_size += sizeof(struct json_value_s);
-    return bson_parse_get_value_size(state, marker);
+    return M_GetValueSize(state, marker);
 }
 
-static bool bson_parse_get_object_size(struct bson_parse_state_s *state)
+static bool M_GetObjectSize(struct bson_parse_state_s *state)
 {
     assert(state);
 
@@ -259,7 +254,7 @@ static bool bson_parse_get_object_size(struct bson_parse_state_s *state)
 
     while (state->offset < start_offset + size - 1) {
         state->dom_size += sizeof(struct json_object_element_s);
-        if (!bson_parse_get_object_element_wrapped_size(state)) {
+        if (!M_GetObjectElementWrappedSize(state)) {
             return false;
         }
     }
@@ -276,46 +271,45 @@ static bool bson_parse_get_object_size(struct bson_parse_state_s *state)
     return true;
 }
 
-static bool bson_parse_get_object_value_size(struct bson_parse_state_s *state)
+static bool M_GetObjectValueSize(struct bson_parse_state_s *state)
 {
     assert(state);
     state->dom_size += sizeof(struct json_object_s);
-    return bson_parse_get_object_size(state);
+    return M_GetObjectSize(state);
 }
 
-static bool bson_parse_get_value_size(
-    struct bson_parse_state_s *state, uint8_t marker)
+static bool M_GetValueSize(struct bson_parse_state_s *state, uint8_t marker)
 {
     assert(state);
     switch (marker) {
     case 0x01:
-        return bson_parse_get_double_value_size(state);
+        return M_GetDoubleValueSize(state);
     case 0x02:
-        return bson_parse_get_string_value_size(state);
+        return M_GetStringValueSize(state);
     case 0x03:
-        return bson_parse_get_object_value_size(state);
+        return M_GetObjectValueSize(state);
     case 0x04:
-        return bson_parse_get_array_value_size(state);
+        return M_GetArrayValueSize(state);
     case 0x0A:
-        return bson_parse_get_null_value_size(state);
+        return M_GetNullValueSize(state);
     case 0x08:
-        return bson_parse_get_bool_value_size(state);
+        return M_GetBoolValueSize(state);
     case 0x10:
-        return bson_parse_get_int32_value_size(state);
+        return M_GetInt32ValueSize(state);
     default:
         state->error = bson_parse_error_invalid_value;
         return false;
     }
 }
 
-static bool bson_parse_get_root_size(struct bson_parse_state_s *state)
+static bool m_GetRootSize(struct bson_parse_state_s *state)
 {
     // assume the root element to be an object
     state->dom_size += sizeof(struct json_value_s);
-    return bson_parse_get_object_value_size(state);
+    return M_GetObjectValueSize(state);
 }
 
-static void bson_parse_object_key(
+static void M_HandleObjectKey(
     struct bson_parse_state_s *state, struct json_string_s *string)
 {
     assert(state);
@@ -331,7 +325,7 @@ static void bson_parse_object_key(
     state->data += size;
 }
 
-static void bson_parse_null_value(
+static void M_HandleNullValue(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -340,7 +334,7 @@ static void bson_parse_null_value(
     value->payload = json_null;
 }
 
-static void bson_parse_bool_value(
+static void M_HandleBoolValue(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -361,7 +355,7 @@ static void bson_parse_bool_value(
     state->offset++;
 }
 
-static void bson_parse_int32_value(
+static void M_HandleInt32Value(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -384,7 +378,7 @@ static void bson_parse_int32_value(
     value->payload = number;
 }
 
-static void bson_parse_double_value(
+static void M_HandleDoubleValue(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -416,7 +410,7 @@ static void bson_parse_double_value(
     value->payload = number;
 }
 
-static void bson_parse_string_value(
+static void M_HandleStringValue(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -441,7 +435,7 @@ static void bson_parse_string_value(
     value->payload = string;
 }
 
-static void bson_parse_array_element_wrapped(
+static void M_HandleArrayElementWrapped(
     struct bson_parse_state_s *state, struct json_array_element_s *element)
 {
     assert(state);
@@ -455,7 +449,7 @@ static void bson_parse_array_element_wrapped(
     struct json_string_s *key = (struct json_string_s *)state->dom;
     key->ref_count = 1;
     state->dom += sizeof(struct json_string_s);
-    bson_parse_object_key(state, key);
+    M_HandleObjectKey(state, key);
 
     struct json_value_s *value = (struct json_value_s *)state->dom;
     value->ref_count = 1;
@@ -463,10 +457,10 @@ static void bson_parse_array_element_wrapped(
 
     element->value = value;
 
-    bson_parse_value(state, value, marker);
+    M_HandleValue(state, value, marker);
 }
 
-static void bson_parse_array(
+static void M_HandleArray(
     struct bson_parse_state_s *state, struct json_array_s *array)
 {
     assert(state);
@@ -490,7 +484,7 @@ static void bson_parse_array(
             previous->next = element;
         }
         previous = element;
-        bson_parse_array_element_wrapped(state, element);
+        M_HandleArrayElementWrapped(state, element);
         count++;
     }
     if (previous) {
@@ -506,7 +500,7 @@ static void bson_parse_array(
     state->offset++;
 }
 
-static void bson_parse_array_value(
+static void M_HandleArrayValue(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -516,13 +510,13 @@ static void bson_parse_array_value(
     array->ref_count = 1;
     state->dom += sizeof(struct json_array_s);
 
-    bson_parse_array(state, array);
+    M_HandleArray(state, array);
 
     value->type = json_type_array;
     value->payload = array;
 }
 
-static void bson_parse_object_element_wrapped(
+static void M_HandleObjectElementWrapped(
     struct bson_parse_state_s *state, struct json_object_element_s *element)
 {
     assert(state);
@@ -535,7 +529,7 @@ static void bson_parse_object_element_wrapped(
     struct json_string_s *key = (struct json_string_s *)state->dom;
     key->ref_count = 1;
     state->dom += sizeof(struct json_string_s);
-    bson_parse_object_key(state, key);
+    M_HandleObjectKey(state, key);
 
     struct json_value_s *value = (struct json_value_s *)state->dom;
     value->ref_count = 1;
@@ -544,10 +538,10 @@ static void bson_parse_object_element_wrapped(
     element->name = key;
     element->value = value;
 
-    bson_parse_value(state, value, marker);
+    M_HandleValue(state, value, marker);
 }
 
-static void bson_parse_object(
+static void M_HandleObject(
     struct bson_parse_state_s *state, struct json_object_s *object)
 {
     assert(state);
@@ -571,7 +565,7 @@ static void bson_parse_object(
             previous->next = element;
         }
         previous = element;
-        bson_parse_object_element_wrapped(state, element);
+        M_HandleObjectElementWrapped(state, element);
         count++;
     }
     if (previous) {
@@ -587,7 +581,7 @@ static void bson_parse_object(
     state->offset++;
 }
 
-static void bson_parse_object_value(
+static void M_HandleObjectValue(
     struct bson_parse_state_s *state, struct json_value_s *value)
 {
     assert(state);
@@ -597,13 +591,13 @@ static void bson_parse_object_value(
     object->ref_count = 1;
     state->dom += sizeof(struct json_object_s);
 
-    bson_parse_object(state, object);
+    M_HandleObject(state, object);
 
     value->type = json_type_object;
     value->payload = object;
 }
 
-static void bson_parse_value(
+static void M_HandleValue(
     struct bson_parse_state_s *state, struct json_value_s *value,
     uint8_t marker)
 {
@@ -611,25 +605,25 @@ static void bson_parse_value(
     assert(value);
     switch (marker) {
     case 0x01:
-        bson_parse_double_value(state, value);
+        M_HandleDoubleValue(state, value);
         break;
     case 0x02:
-        bson_parse_string_value(state, value);
+        M_HandleStringValue(state, value);
         break;
     case 0x03:
-        bson_parse_object_value(state, value);
+        M_HandleObjectValue(state, value);
         break;
     case 0x04:
-        bson_parse_array_value(state, value);
+        M_HandleArrayValue(state, value);
         break;
     case 0x0A:
-        bson_parse_null_value(state, value);
+        M_HandleNullValue(state, value);
         break;
     case 0x08:
-        bson_parse_bool_value(state, value);
+        M_HandleBoolValue(state, value);
         break;
     case 0x10:
-        bson_parse_int32_value(state, value);
+        M_HandleInt32Value(state, value);
         break;
     default:
         assert(0);
@@ -665,7 +659,7 @@ struct json_value_s *bson_parse_ex(
     state.dom_size = 0;
     state.data_size = 0;
 
-    if (bson_parse_get_root_size(&state)) {
+    if (m_GetRootSize(&state)) {
         if (state.offset != state.size) {
             state.error = bson_parse_error_unexpected_trailing_bytes;
         }
@@ -693,7 +687,7 @@ struct json_value_s *bson_parse_ex(
     value = (struct json_value_s *)state.dom;
     value->ref_count = 0;
     state.dom += sizeof(struct json_value_s);
-    bson_parse_object_value(&state, value);
+    M_HandleObjectValue(&state, value);
 
     assert(state.dom == allocation + state.dom_size);
     assert(state.data == allocation + state.dom_size + state.data_size);

--- a/src/json/bson_write.c
+++ b/src/json/bson_write.c
@@ -11,59 +11,53 @@
 #include <stdlib.h>
 #include <string.h>
 
-static bool bson_write_get_marker_size(size_t *size, const char *key);
-static bool bson_write_get_null_wrapped(size_t *size, const char *key);
-static bool bson_write_get_boolean_wrapped_size(size_t *size, const char *key);
-static bool bson_write_get_int32_size(size_t *size);
-static bool bson_write_get_int32_wrapped_size(size_t *size, const char *key);
-static bool bson_write_get_double_size(size_t *size);
-static bool bson_write_get_double_wrapped_size(size_t *size, const char *key);
-static bool bson_write_get_number_wrapped_size(
+static bool M_GetMarkerSize(size_t *size, const char *key);
+static bool M_GetNullWrappedSize(size_t *size, const char *key);
+static bool M_GetBoolWrappedSize(size_t *size, const char *key);
+static bool M_GetInt32Size(size_t *size);
+static bool M_GetInt32WrappedSize(size_t *size, const char *key);
+static bool M_GetDoubleSize(size_t *size);
+static bool M_GetDoubleWrappedSize(size_t *size, const char *key);
+static bool M_GetNumberWrappedSize(
     size_t *size, const char *key, const struct json_number_s *number);
-static bool bson_write_get_string_size(
-    size_t *size, const struct json_string_s *string);
-static bool bson_write_get_string_wrapped_size(
+static bool M_GetStringSize(size_t *size, const struct json_string_s *string);
+static bool M_GetStringWrappedSize(
     size_t *size, const char *key, const struct json_string_s *string);
-static bool bson_write_get_array_size(
-    size_t *size, const struct json_array_s *array);
-static bool bson_write_get_array_wrapped_size(
+static bool M_GetArraySize(size_t *size, const struct json_array_s *array);
+static bool M_GetArrayWrappedSize(
     size_t *size, const char *key, const struct json_array_s *array);
-static bool bson_write_get_object_size(
-    size_t *size, const struct json_object_s *object);
-static bool bson_write_get_object_wrapped_size(
+static bool M_GetObjectSize(size_t *size, const struct json_object_s *object);
+static bool M_GetObjectWrappedSize(
     size_t *size, const char *key, const struct json_object_s *object);
-static bool bson_write_get_value_size(
-    size_t *size, const struct json_value_s *value);
-static bool bson_write_get_value_wrapped_size(
+static bool M_GetValueSize(size_t *size, const struct json_value_s *value);
+static bool M_GetValueWrappedSize(
     size_t *size, const char *key, const struct json_value_s *value);
 
-static char *bson_write_marker(
-    char *data, const char *key, const uint8_t marker);
-static char *bson_write_null_wrapped(char *data, const char *key);
-static char *bson_write_boolean_wrapped(
-    char *data, const char *key, bool value);
-static char *bson_write_int32(char *data, const int32_t value);
-static char *bson_write_int32_wrapped(
+static char *M_WriteMarker(char *data, const char *key, const uint8_t marker);
+static char *M_WriteNullWrapped(char *data, const char *key);
+static char *M_WriteBoolWrapped(char *data, const char *key, bool value);
+static char *M_WriteInt32(char *data, const int32_t value);
+static char *M_WriteInt32Wrapped(
     char *data, const char *key, const int32_t value);
-static char *bson_write_double(char *data, const double value);
-static char *bson_write_double_wrapped(
+static char *M_WriteDouble(char *data, const double value);
+static char *M_WriteDoubleWrapped(
     char *data, const char *key, const double value);
-static char *bson_write_number_wrapped(
+static char *M_WriteNumberWrapped(
     char *data, const char *key, const struct json_number_s *number);
-static char *bson_write_string(char *data, const struct json_string_s *string);
-static char *bson_write_string_wrapped(
+static char *M_WriteString(char *data, const struct json_string_s *string);
+static char *M_WriteStringWrapped(
     char *data, const char *key, const struct json_string_s *string);
-static char *bson_write_array(char *data, const struct json_array_s *array);
-static char *bson_write_array_wrapped(
+static char *M_WriteArray(char *data, const struct json_array_s *array);
+static char *M_WriteArrayWrapped(
     char *data, const char *key, const struct json_array_s *array);
-static char *bson_write_object(char *data, const struct json_object_s *object);
-static char *bson_write_object_wrapped(
+static char *M_WriteObject(char *data, const struct json_object_s *object);
+static char *M_WriteObjectWrapped(
     char *data, const char *key, const struct json_object_s *object);
-static char *bson_write_value(char *data, const struct json_value_s *value);
-static char *bson_write_value_wrapped(
+static char *M_WriteValue(char *data, const struct json_value_s *value);
+static char *M_WriteValueWrapped(
     char *data, const char *key, const struct json_value_s *value);
 
-static bool bson_write_get_marker_size(size_t *size, const char *key)
+static bool M_GetMarkerSize(size_t *size, const char *key)
 {
     assert(size);
     assert(key);
@@ -73,65 +67,65 @@ static bool bson_write_get_marker_size(size_t *size, const char *key)
     return true;
 }
 
-static bool bson_write_get_null_wrapped_size(size_t *size, const char *key)
+static bool M_GetNullWrappedSize(size_t *size, const char *key)
 {
     assert(size);
     assert(key);
-    return bson_write_get_marker_size(size, key);
+    return M_GetMarkerSize(size, key);
 }
 
-static bool bson_write_get_boolean_wrapped_size(size_t *size, const char *key)
+static bool M_GetBoolWrappedSize(size_t *size, const char *key)
 {
     assert(size);
     assert(key);
-    if (!bson_write_get_marker_size(size, key)) {
+    if (!M_GetMarkerSize(size, key)) {
         return false;
     }
     *size += 1;
     return true;
 }
 
-static bool bson_write_get_int32_size(size_t *size)
+static bool M_GetInt32Size(size_t *size)
 {
     assert(size);
     *size += sizeof(int32_t);
     return true;
 }
 
-static bool bson_write_get_int32_wrapped_size(size_t *size, const char *key)
+static bool M_GetInt32WrappedSize(size_t *size, const char *key)
 {
     assert(size);
     assert(key);
-    if (!bson_write_get_marker_size(size, key)) {
+    if (!M_GetMarkerSize(size, key)) {
         return false;
     }
-    if (!bson_write_get_int32_size(size)) {
+    if (!M_GetInt32Size(size)) {
         return false;
     }
     return true;
 }
 
-static bool bson_write_get_double_size(size_t *size)
+static bool M_GetDoubleSize(size_t *size)
 {
     assert(size);
     *size += sizeof(double);
     return true;
 }
 
-static bool bson_write_get_double_wrapped_size(size_t *size, const char *key)
+static bool M_GetDoubleWrappedSize(size_t *size, const char *key)
 {
     assert(size);
     assert(key);
-    if (!bson_write_get_marker_size(size, key)) {
+    if (!M_GetMarkerSize(size, key)) {
         return false;
     }
-    if (!bson_write_get_double_size(size)) {
+    if (!M_GetDoubleSize(size)) {
         return false;
     }
     return true;
 }
 
-static bool bson_write_get_number_wrapped_size(
+static bool M_GetNumberWrappedSize(
     size_t *size, const char *key, const struct json_number_s *number)
 {
     assert(size);
@@ -142,7 +136,7 @@ static bool bson_write_get_number_wrapped_size(
 
     // hexadecimal numbers
     if (number->number_size >= 2 && (str[1] == 'x' || str[1] == 'X')) {
-        return bson_write_get_int32_wrapped_size(size, key);
+        return M_GetInt32WrappedSize(size, key);
     }
 
     // skip leading sign
@@ -153,21 +147,20 @@ static bool bson_write_get_number_wrapped_size(
 
     if (!strcmp(str, "Infinity")) {
         // BSON does not support Infinity.
-        return bson_write_get_double_wrapped_size(size, key);
+        return M_GetDoubleWrappedSize(size, key);
     } else if (!strcmp(str, "NaN")) {
         // BSON does not support NaN.
-        return bson_write_get_int32_wrapped_size(size, key);
+        return M_GetInt32WrappedSize(size, key);
     } else if (strchr(str, '.')) {
-        return bson_write_get_double_wrapped_size(size, key);
+        return M_GetDoubleWrappedSize(size, key);
     } else {
-        return bson_write_get_int32_wrapped_size(size, key);
+        return M_GetInt32WrappedSize(size, key);
     }
 
     return false;
 }
 
-static bool bson_write_get_string_size(
-    size_t *size, const struct json_string_s *string)
+static bool M_GetStringSize(size_t *size, const struct json_string_s *string)
 {
     assert(size);
     assert(string);
@@ -177,23 +170,22 @@ static bool bson_write_get_string_size(
     return true;
 }
 
-static bool bson_write_get_string_wrapped_size(
+static bool M_GetStringWrappedSize(
     size_t *size, const char *key, const struct json_string_s *string)
 {
     assert(size);
     assert(key);
     assert(string);
-    if (!bson_write_get_marker_size(size, key)) {
+    if (!M_GetMarkerSize(size, key)) {
         return false;
     }
-    if (!bson_write_get_string_size(size, string)) {
+    if (!M_GetStringSize(size, string)) {
         return false;
     }
     return true;
 }
 
-static bool bson_write_get_array_size(
-    size_t *size, const struct json_array_s *array)
+static bool M_GetArraySize(size_t *size, const struct json_array_s *array)
 {
     assert(size);
     assert(array);
@@ -204,7 +196,7 @@ static bool bson_write_get_array_size(
          element != json_null; element = element->next) {
         sprintf(key, "%d", idx);
         idx++;
-        if (!bson_write_get_value_wrapped_size(size, key, element->value)) {
+        if (!M_GetValueWrappedSize(size, key, element->value)) {
             return false;
         }
     }
@@ -212,30 +204,29 @@ static bool bson_write_get_array_size(
     return true;
 }
 
-static bool bson_write_get_array_wrapped_size(
+static bool M_GetArrayWrappedSize(
     size_t *size, const char *key, const struct json_array_s *array)
 {
     assert(size);
     assert(key);
     assert(array);
-    if (!bson_write_get_marker_size(size, key)) {
+    if (!M_GetMarkerSize(size, key)) {
         return false;
     }
-    if (!bson_write_get_array_size(size, array)) {
+    if (!M_GetArraySize(size, array)) {
         return false;
     }
     return true;
 }
 
-static bool bson_write_get_object_size(
-    size_t *size, const struct json_object_s *object)
+static bool M_GetObjectSize(size_t *size, const struct json_object_s *object)
 {
     assert(size);
     assert(object);
     *size += sizeof(int32_t); // object size
     for (struct json_object_element_s *element = object->start;
          element != json_null; element = element->next) {
-        if (!bson_write_get_value_wrapped_size(
+        if (!M_GetValueWrappedSize(
                 size, element->name->string, element->value)) {
             return false;
         }
@@ -244,40 +235,37 @@ static bool bson_write_get_object_size(
     return true;
 }
 
-static bool bson_write_get_object_wrapped_size(
+static bool M_GetObjectWrappedSize(
     size_t *size, const char *key, const struct json_object_s *object)
 {
     assert(size);
     assert(key);
     assert(object);
-    if (!bson_write_get_marker_size(size, key)) {
+    if (!M_GetMarkerSize(size, key)) {
         return false;
     }
-    if (!bson_write_get_object_size(size, object)) {
+    if (!M_GetObjectSize(size, object)) {
         return false;
     }
     return true;
 }
 
-static bool bson_write_get_value_size(
-    size_t *size, const struct json_value_s *value)
+static bool M_GetValueSize(size_t *size, const struct json_value_s *value)
 {
     assert(size);
     assert(value);
     switch (value->type) {
     case json_type_array:
-        return bson_write_get_array_size(
-            size, (struct json_array_s *)value->payload);
+        return M_GetArraySize(size, (struct json_array_s *)value->payload);
     case json_type_object:
-        return bson_write_get_object_size(
-            size, (struct json_object_s *)value->payload);
+        return M_GetObjectSize(size, (struct json_object_s *)value->payload);
     default:
         LOG_ERROR("Bad BSON root element: %d", value->type);
     }
     return false;
 }
 
-static bool bson_write_get_value_wrapped_size(
+static bool M_GetValueWrappedSize(
     size_t *size, const char *key, const struct json_value_s *value)
 {
     assert(size);
@@ -285,22 +273,22 @@ static bool bson_write_get_value_wrapped_size(
     assert(value);
     switch (value->type) {
     case json_type_null:
-        return bson_write_get_null_wrapped_size(size, key);
+        return M_GetNullWrappedSize(size, key);
     case json_type_true:
-        return bson_write_get_boolean_wrapped_size(size, key);
+        return M_GetBoolWrappedSize(size, key);
     case json_type_false:
-        return bson_write_get_boolean_wrapped_size(size, key);
+        return M_GetBoolWrappedSize(size, key);
     case json_type_number:
-        return bson_write_get_number_wrapped_size(
+        return M_GetNumberWrappedSize(
             size, key, (struct json_number_s *)value->payload);
     case json_type_string:
-        return bson_write_get_string_wrapped_size(
+        return M_GetStringWrappedSize(
             size, key, (struct json_string_s *)value->payload);
     case json_type_array:
-        return bson_write_get_array_wrapped_size(
+        return M_GetArrayWrappedSize(
             size, key, (struct json_array_s *)value->payload);
     case json_type_object:
-        return bson_write_get_object_wrapped_size(
+        return M_GetObjectWrappedSize(
             size, key, (struct json_object_s *)value->payload);
     default:
         LOG_ERROR("Unknown JSON element: %d", value->type);
@@ -308,8 +296,7 @@ static bool bson_write_get_value_wrapped_size(
     }
 }
 
-static char *bson_write_marker(
-    char *data, const char *key, const uint8_t marker)
+static char *M_WriteMarker(char *data, const char *key, const uint8_t marker)
 {
     assert(data);
     assert(key);
@@ -320,23 +307,23 @@ static char *bson_write_marker(
     return data;
 }
 
-static char *bson_write_null_wrapped(char *data, const char *key)
+static char *M_WriteNullWrapped(char *data, const char *key)
 {
     assert(data);
     assert(key);
-    return bson_write_marker(data, key, '\x0A');
+    return M_WriteMarker(data, key, '\x0A');
 }
 
-static char *bson_write_boolean_wrapped(char *data, const char *key, bool value)
+static char *M_WriteBoolWrapped(char *data, const char *key, bool value)
 {
     assert(data);
     assert(key);
-    data = bson_write_marker(data, key, '\x08');
+    data = M_WriteMarker(data, key, '\x08');
     *(int8_t *)data++ = (int8_t)value;
     return data;
 }
 
-static char *bson_write_int32(char *data, const int32_t value)
+static char *M_WriteInt32(char *data, const int32_t value)
 {
     assert(data);
     *(int32_t *)data = value;
@@ -344,16 +331,16 @@ static char *bson_write_int32(char *data, const int32_t value)
     return data;
 }
 
-static char *bson_write_int32_wrapped(
+static char *M_WriteInt32Wrapped(
     char *data, const char *key, const int32_t value)
 {
     assert(data);
     assert(key);
-    data = bson_write_marker(data, key, '\x10');
-    return bson_write_int32(data, value);
+    data = M_WriteMarker(data, key, '\x10');
+    return M_WriteInt32(data, value);
 }
 
-static char *bson_write_double(char *data, const double value)
+static char *M_WriteDouble(char *data, const double value)
 {
     assert(data);
     *(double *)data = value;
@@ -361,16 +348,16 @@ static char *bson_write_double(char *data, const double value)
     return data;
 }
 
-static char *bson_write_double_wrapped(
+static char *M_WriteDoubleWrapped(
     char *data, const char *key, const double value)
 {
     assert(data);
     assert(key);
-    data = bson_write_marker(data, key, '\x01');
-    return bson_write_double(data, value);
+    data = M_WriteMarker(data, key, '\x01');
+    return M_WriteDouble(data, value);
 }
 
-static char *bson_write_number_wrapped(
+static char *M_WriteNumberWrapped(
     char *data, const char *key, const struct json_number_s *number)
 {
     assert(data);
@@ -380,7 +367,7 @@ static char *bson_write_number_wrapped(
 
     // hexadecimal numbers
     if (number->number_size >= 2 && (str[1] == 'x' || str[1] == 'X')) {
-        return bson_write_int32_wrapped(
+        return M_WriteInt32Wrapped(
             data, key, json_strtoumax(number->number, json_null, 0));
     }
 
@@ -392,20 +379,20 @@ static char *bson_write_number_wrapped(
 
     if (!strcmp(str, "Infinity")) {
         // BSON does not support Infinity.
-        return bson_write_double_wrapped(data, key, DBL_MAX);
+        return M_WriteDoubleWrapped(data, key, DBL_MAX);
     } else if (!strcmp(str, "NaN")) {
         // BSON does not support NaN.
-        return bson_write_int32_wrapped(data, key, 0);
+        return M_WriteInt32Wrapped(data, key, 0);
     } else if (strchr(str, '.')) {
-        return bson_write_double_wrapped(data, key, atof(number->number));
+        return M_WriteDoubleWrapped(data, key, atof(number->number));
     } else {
-        return bson_write_int32_wrapped(data, key, atoi(number->number));
+        return M_WriteInt32Wrapped(data, key, atoi(number->number));
     }
 
     return data;
 }
 
-static char *bson_write_string(char *data, const struct json_string_s *string)
+static char *M_WriteString(char *data, const struct json_string_s *string)
 {
     assert(data);
     assert(string);
@@ -417,18 +404,18 @@ static char *bson_write_string(char *data, const struct json_string_s *string)
     return data;
 }
 
-static char *bson_write_string_wrapped(
+static char *M_WriteStringWrapped(
     char *data, const char *key, const struct json_string_s *string)
 {
     assert(data);
     assert(key);
     assert(string);
-    data = bson_write_marker(data, key, '\x02');
-    data = bson_write_string(data, string);
+    data = M_WriteMarker(data, key, '\x02');
+    data = M_WriteString(data, string);
     return data;
 }
 
-static char *bson_write_array(char *data, const struct json_array_s *array)
+static char *M_WriteArray(char *data, const struct json_array_s *array)
 {
     assert(data);
     assert(array);
@@ -440,25 +427,25 @@ static char *bson_write_array(char *data, const struct json_array_s *array)
          element != json_null; element = element->next) {
         sprintf(key, "%d", idx);
         idx++;
-        data = bson_write_value_wrapped(data, key, element->value);
+        data = M_WriteValueWrapped(data, key, element->value);
     }
     *data++ = '\0';
     *(int32_t *)old = data - old;
     return data;
 }
 
-static char *bson_write_array_wrapped(
+static char *M_WriteArrayWrapped(
     char *data, const char *key, const struct json_array_s *array)
 {
     assert(data);
     assert(key);
     assert(array);
-    data = bson_write_marker(data, key, '\x04');
-    data = bson_write_array(data, array);
+    data = M_WriteMarker(data, key, '\x04');
+    data = M_WriteArray(data, array);
     return data;
 }
 
-static char *bson_write_object(char *data, const struct json_object_s *object)
+static char *M_WriteObject(char *data, const struct json_object_s *object)
 {
     assert(data);
     assert(object);
@@ -466,35 +453,34 @@ static char *bson_write_object(char *data, const struct json_object_s *object)
     data += sizeof(int32_t);
     for (struct json_object_element_s *element = object->start;
          element != json_null; element = element->next) {
-        data = bson_write_value_wrapped(
-            data, element->name->string, element->value);
+        data = M_WriteValueWrapped(data, element->name->string, element->value);
     }
     *data++ = '\0';
     *(int32_t *)old = data - old;
     return data;
 }
 
-static char *bson_write_object_wrapped(
+static char *M_WriteObjectWrapped(
     char *data, const char *key, const struct json_object_s *object)
 {
     assert(data);
     assert(key);
     assert(object);
-    data = bson_write_marker(data, key, '\x03');
-    data = bson_write_object(data, object);
+    data = M_WriteMarker(data, key, '\x03');
+    data = M_WriteObject(data, object);
     return data;
 }
 
-static char *bson_write_value(char *data, const struct json_value_s *value)
+static char *M_WriteValue(char *data, const struct json_value_s *value)
 {
     assert(data);
     assert(value);
     switch (value->type) {
     case json_type_array:
-        data = bson_write_array(data, (struct json_array_s *)value->payload);
+        data = M_WriteArray(data, (struct json_array_s *)value->payload);
         break;
     case json_type_object:
-        data = bson_write_object(data, (struct json_object_s *)value->payload);
+        data = M_WriteObject(data, (struct json_object_s *)value->payload);
         break;
     default:
         assert(0);
@@ -502,7 +488,7 @@ static char *bson_write_value(char *data, const struct json_value_s *value)
     return data;
 }
 
-static char *bson_write_value_wrapped(
+static char *M_WriteValueWrapped(
     char *data, const char *key, const struct json_value_s *value)
 {
     assert(data);
@@ -510,22 +496,22 @@ static char *bson_write_value_wrapped(
     assert(value);
     switch (value->type) {
     case json_type_null:
-        return bson_write_null_wrapped(data, key);
+        return M_WriteNullWrapped(data, key);
     case json_type_true:
-        return bson_write_boolean_wrapped(data, key, true);
+        return M_WriteBoolWrapped(data, key, true);
     case json_type_false:
-        return bson_write_boolean_wrapped(data, key, false);
+        return M_WriteBoolWrapped(data, key, false);
     case json_type_number:
-        return bson_write_number_wrapped(
+        return M_WriteNumberWrapped(
             data, key, (struct json_number_s *)value->payload);
     case json_type_string:
-        return bson_write_string_wrapped(
+        return M_WriteStringWrapped(
             data, key, (struct json_string_s *)value->payload);
     case json_type_array:
-        return bson_write_array_wrapped(
+        return M_WriteArrayWrapped(
             data, key, (struct json_array_s *)value->payload);
     case json_type_object:
-        return bson_write_object_wrapped(
+        return M_WriteObjectWrapped(
             data, key, (struct json_object_s *)value->payload);
     default:
         return json_null;
@@ -541,12 +527,12 @@ void *bson_write(const struct json_value_s *value, size_t *out_size)
     }
 
     size_t size = 0;
-    if (!bson_write_get_value_size(&size, value)) {
+    if (!M_GetValueSize(&size, value)) {
         return json_null;
     }
 
     char *data = Memory_Alloc(size);
-    char *data_end = bson_write_value(data, value);
+    char *data_end = M_WriteValue(data, value);
     assert((size_t)(data_end - data) == size);
 
     if (out_size != json_null) {

--- a/src/log_linux.c
+++ b/src/log_linux.c
@@ -6,18 +6,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static void Log_ErrorCallback(void *data, const char *msg, int errnum);
-static int Log_StackTrace(
+static void M_ErrorCallback(void *data, const char *msg, int errnum);
+static int M_StackTrace(
     void *data, uintptr_t pc, const char *filename, int lineno,
     const char *func_name);
-static void Log_SignalHandler(int sig);
+static void M_SignalHandler(int sig);
 
-static void Log_ErrorCallback(void *data, const char *msg, int errnum)
+static void M_ErrorCallback(void *data, const char *msg, int errnum)
 {
     LOG_ERROR("%s", msg);
 }
 
-static int Log_StackTrace(
+static int M_StackTrace(
     void *data, uintptr_t pc, const char *filename, int lineno,
     const char *func_name)
 {
@@ -31,21 +31,21 @@ static int Log_StackTrace(
     return 0;
 }
 
-static void Log_SignalHandler(int sig)
+static void M_SignalHandler(int sig)
 {
     LOG_ERROR("== CRASH REPORT ==");
     LOG_INFO("SIGNAL: %d", sig);
     LOG_INFO("STACK TRACE:");
     struct backtrace_state *state = backtrace_create_state(
-        NULL, BACKTRACE_SUPPORTS_THREADS, Log_ErrorCallback, NULL);
-    backtrace_full(state, 0, Log_StackTrace, Log_ErrorCallback, NULL);
+        NULL, BACKTRACE_SUPPORTS_THREADS, M_ErrorCallback, NULL);
+    backtrace_full(state, 0, M_StackTrace, M_ErrorCallback, NULL);
     exit(EXIT_FAILURE);
 }
 
 void Log_Init_Extra(const char *path)
 {
-    signal(SIGSEGV, Log_SignalHandler);
-    signal(SIGFPE, Log_SignalHandler);
+    signal(SIGSEGV, M_SignalHandler);
+    signal(SIGFPE, M_SignalHandler);
 }
 
 void Log_Shutdown_Extra(void)

--- a/src/log_windows.c
+++ b/src/log_windows.c
@@ -12,13 +12,13 @@
 #include <tlhelp32.h>
 
 static char *m_MiniDumpPath = NULL;
-static char *Log_GetMiniDumpPath(const char *log_path);
-static void Log_CreateMiniDump(EXCEPTION_POINTERS *ex, const char *path);
-static void Log_StackTrace(
+static char *M_GetMiniDumpPath(const char *log_path);
+static void M_CreateMiniDump(EXCEPTION_POINTERS *ex, const char *path);
+static void M_StackTrace(
     uint64_t addr, const char *filename, int line_no, const char *func_name,
     void *context, int column_no);
 
-static char *Log_GetMiniDumpPath(const char *const log_path)
+static char *M_GetMiniDumpPath(const char *const log_path)
 {
     char *dot = strrchr(log_path, '.');
     if (dot == NULL) {
@@ -34,7 +34,7 @@ static char *Log_GetMiniDumpPath(const char *const log_path)
     return minidump_path;
 }
 
-static void Log_StackTrace(
+static void M_StackTrace(
     const uint64_t addr, const char *filename, const int line_no,
     const char *const func_name, void *const context, const int column_no)
 {
@@ -68,7 +68,7 @@ static void Log_StackTrace(
     }
 }
 
-static void Log_CreateMiniDump(
+static void M_CreateMiniDump(
     EXCEPTION_POINTERS *const ex, const char *const path)
 {
     HANDLE handle = CreateFile(
@@ -94,9 +94,9 @@ LONG WINAPI Log_CrashHandler(EXCEPTION_POINTERS *ex)
     LOG_INFO("STACK TRACE:");
 
     int32_t count = 0;
-    dwstOfException(ex->ContextRecord, &Log_StackTrace, &count);
+    dwstOfException(ex->ContextRecord, &M_StackTrace, &count);
 
-    Log_CreateMiniDump(ex, m_MiniDumpPath);
+    M_CreateMiniDump(ex, m_MiniDumpPath);
 
     return EXCEPTION_EXECUTE_HANDLER;
 }
@@ -104,7 +104,7 @@ LONG WINAPI Log_CrashHandler(EXCEPTION_POINTERS *ex)
 void Log_Init_Extra(const char *log_path)
 {
     if (log_path != NULL) {
-        m_MiniDumpPath = Log_GetMiniDumpPath(log_path);
+        m_MiniDumpPath = M_GetMiniDumpPath(log_path);
         SetUnhandledExceptionFilter(Log_CrashHandler);
     }
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -16,7 +16,16 @@ struct VECTOR_PRIV {
     char *items;
 };
 
-static void Vector_EnsureCapacity(VECTOR *vector, int32_t n);
+static void M_EnsureCapacity(VECTOR *vector, int32_t n);
+
+static void M_EnsureCapacity(VECTOR *const vector, const int32_t n)
+{
+    while (vector->count + n > vector->capacity) {
+        vector->capacity *= VECTOR_GROWTH_RATE;
+        P(vector).items = Memory_Realloc(
+            P(vector).items, vector->item_size * vector->capacity);
+    }
+}
 
 VECTOR *Vector_Create(const size_t item_size)
 {
@@ -40,15 +49,6 @@ void Vector_Free(VECTOR *vector)
     Memory_FreePointer(&P(vector).items);
     Memory_FreePointer(&vector->priv);
     Memory_FreePointer(&vector);
-}
-
-static void Vector_EnsureCapacity(VECTOR *const vector, const int32_t n)
-{
-    while (vector->count + n > vector->capacity) {
-        vector->capacity *= VECTOR_GROWTH_RATE;
-        P(vector).items = Memory_Realloc(
-            P(vector).items, vector->item_size * vector->capacity);
-    }
 }
 
 int32_t Vector_IndexOf(const VECTOR *const vector, const void *const item)
@@ -90,14 +90,14 @@ void *Vector_Get(VECTOR *const vector, const int32_t index)
 
 void Vector_Add(VECTOR *const vector, void *const item)
 {
-    Vector_EnsureCapacity(vector, 1);
+    M_EnsureCapacity(vector, 1);
     Vector_Insert(vector, vector->count, item);
 }
 
 void Vector_Insert(VECTOR *const vector, const int32_t index, void *const item)
 {
     assert(index >= 0 && index <= vector->count);
-    Vector_EnsureCapacity(vector, 1);
+    M_EnsureCapacity(vector, 1);
     char *const items = P(vector).items;
     if (index < vector->count) {
         memmove(


### PR DESCRIPTION
Similar change to LostArtefacts/TR1X#1531.

This also changes internal convention used by BSON and JSON parsers to comply, but leaves their public APIs untouched.