### PR TITLE
Refactor typing; fix crash in /set

### DIFF
--- a/include/libtrx/bson.h
+++ b/include/libtrx/bson.h
@@ -3,27 +3,27 @@
 #include "json.h"
 
 typedef enum {
-    bson_parse_error_none = 0,
-    bson_parse_error_invalid_value,
-    bson_parse_error_premature_end_of_buffer,
-    bson_parse_error_unexpected_trailing_bytes,
-    bson_parse_error_unknown,
-} bson_parse_error_e;
+    BSON_PARSE_ERROR_NONE = 0,
+    BSON_PARSE_ERROR_INVALID_VALUE,
+    BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER,
+    BSON_PARSE_ERROR_UNEXPECTED_TRAILING_BYTES,
+    BSON_PARSE_ERROR_UNKNOWN,
+} BSON_PARSE_ERROR;
 
-struct bson_parse_result_s {
-    bson_parse_error_e error;
+typedef struct {
+    BSON_PARSE_ERROR error;
     size_t error_offset;
-};
+} BSON_PARSE_RESULT;
 
 // Parse a BSON file, returning a pointer to the root of the JSON structure.
 // Returns NULL if an error occurred (malformed BSON input, or malloc failed).
-struct json_value_s *bson_parse(const char *src, size_t src_size);
+JSON_VALUE *BSON_Parse(const char *src, size_t src_size);
 
-struct json_value_s *bson_parse_ex(
-    const char *src, size_t src_size, struct bson_parse_result_s *result);
+JSON_VALUE *BSON_ParseEx(
+    const char *src, size_t src_size, BSON_PARSE_RESULT *result);
 
-const char *bson_get_error_description(bson_parse_error_e error);
+const char *BSON_GetErrorDescription(BSON_PARSE_ERROR error);
 
 /* Write out a BSON binary string. Return 0 if an error occurred (malformed
  * JSON input, or malloc failed). The out_size parameter is optional. */
-void *bson_write(const struct json_value_s *value, size_t *out_size);
+void *BSON_Write(const JSON_VALUE *value, size_t *out_size);

--- a/include/libtrx/bson.h
+++ b/include/libtrx/bson.h
@@ -2,16 +2,16 @@
 
 #include "json.h"
 
-enum bson_parse_error_e {
+typedef enum {
     bson_parse_error_none = 0,
     bson_parse_error_invalid_value,
     bson_parse_error_premature_end_of_buffer,
     bson_parse_error_unexpected_trailing_bytes,
     bson_parse_error_unknown,
-};
+} bson_parse_error_e;
 
 struct bson_parse_result_s {
-    enum bson_parse_error_e error;
+    bson_parse_error_e error;
     size_t error_offset;
 };
 
@@ -22,7 +22,7 @@ struct json_value_s *bson_parse(const char *src, size_t src_size);
 struct json_value_s *bson_parse_ex(
     const char *src, size_t src_size, struct bson_parse_result_s *result);
 
-const char *bson_get_error_description(enum bson_parse_error_e error);
+const char *bson_get_error_description(bson_parse_error_e error);
 
 /* Write out a BSON binary string. Return 0 if an error occurred (malformed
  * JSON input, or malloc failed). The out_size parameter is optional. */

--- a/include/libtrx/config/config_file.h
+++ b/include/libtrx/config/config_file.h
@@ -7,19 +7,17 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool ConfigFile_Read(
-    const char *path, void (*load)(struct json_object_s *root_obj));
-bool ConfigFile_Write(
-    const char *path, void (*dump)(struct json_object_s *root_obj));
+bool ConfigFile_Read(const char *path, void (*load)(JSON_OBJECT *root_obj));
+bool ConfigFile_Write(const char *path, void (*dump)(JSON_OBJECT *root_obj));
 
 void ConfigFile_LoadOptions(
-    struct json_object_s *root_obj, const CONFIG_OPTION *options);
+    JSON_OBJECT *root_obj, const CONFIG_OPTION *options);
 void ConfigFile_DumpOptions(
-    struct json_object_s *root_obj, const CONFIG_OPTION *options);
+    JSON_OBJECT *root_obj, const CONFIG_OPTION *options);
 
 int ConfigFile_ReadEnum(
-    struct json_object_s *obj, const char *name, int default_value,
+    JSON_OBJECT *obj, const char *name, int default_value,
     const ENUM_STRING_MAP *enum_map);
 void ConfigFile_WriteEnum(
-    struct json_object_s *obj, const char *name, int value,
+    JSON_OBJECT *obj, const char *name, int value,
     const ENUM_STRING_MAP *enum_map);

--- a/include/libtrx/config/config_option.h
+++ b/include/libtrx/config/config_option.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef enum CONFIG_OPTION_TYPE {
+typedef enum {
     COT_BOOL = 0,
     COT_INT32 = 1,
     COT_FLOAT = 2,

--- a/include/libtrx/game/console/common.h
+++ b/include/libtrx/game/console/common.h
@@ -11,7 +11,7 @@ typedef enum {
     CR_BAD_INVOCATION,
 } COMMAND_RESULT;
 
-typedef struct {
+typedef struct __PACKING {
     const struct __PACKING CONSOLE_COMMAND *cmd;
     const char *prefix;
     const char *args;

--- a/include/libtrx/game/creature.h
+++ b/include/libtrx/game/creature.h
@@ -23,8 +23,8 @@ typedef struct __PACKING {
     LOT_INFO lot;
     XYZ_32 target;
 #if TR_VERSION == 2
-    ITEM_INFO *enemy;
+    ITEM *enemy;
 #endif
-} CREATURE_INFO;
+} CREATURE;
 
-bool Creature_IsEnemy(const ITEM_INFO *item);
+bool Creature_IsEnemy(const ITEM *item);

--- a/include/libtrx/game/effects/types.h
+++ b/include/libtrx/game/effects/types.h
@@ -32,4 +32,4 @@ typedef struct __PACKING {
         } result, prev;
     } interp;
 #endif
-} FX_INFO;
+} FX;

--- a/include/libtrx/game/items/common.h
+++ b/include/libtrx/game/items/common.h
@@ -4,7 +4,7 @@
 
 #include <stdbool.h>
 
-ITEM_INFO *Item_Get(int16_t num);
+ITEM *Item_Get(int16_t num);
 int32_t Item_GetTotalCount(void);
-int32_t Item_GetDistance(const ITEM_INFO *item, const XYZ_32 *target);
-void Item_TakeDamage(ITEM_INFO *item, int16_t damage, bool hit_status);
+int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
+void Item_TakeDamage(ITEM *item, int16_t damage, bool hit_status);

--- a/include/libtrx/game/items/types.h
+++ b/include/libtrx/game/items/types.h
@@ -78,4 +78,4 @@ typedef struct __PACKING {
         } result, prev;
     } interp;
 #endif
-} ITEM_INFO;
+} ITEM;

--- a/include/libtrx/game/items/types.h
+++ b/include/libtrx/game/items/types.h
@@ -47,8 +47,8 @@ typedef struct __PACKING {
     void *priv;
     CARRIED_ITEM *carried_item;
 #elif TR_VERSION == 2
-    int16_t shade1;
-    int16_t shade2;
+    int16_t shade_1;
+    int16_t shade_2;
     int16_t carried_item;
     void *data;
 #endif

--- a/include/libtrx/game/lara/common.h
+++ b/include/libtrx/game/lara/common.h
@@ -4,4 +4,4 @@
 #include "types.h"
 
 LARA_INFO *Lara_GetLaraInfo(void);
-ITEM_INFO *Lara_GetItem(void);
+ITEM *Lara_GetItem(void);

--- a/include/libtrx/game/lara/enum.h
+++ b/include/libtrx/game/lara/enum.h
@@ -25,7 +25,7 @@ typedef enum {
 } LARA_GUN_STATE;
 // clang-format on
 
-typedef enum LARA_MESH {
+typedef enum {
     LM_HIPS = 0,
     LM_THIGH_L = 1,
     LM_CALF_L = 2,

--- a/include/libtrx/game/lara/enum_tr1.h
+++ b/include/libtrx/game/lara/enum_tr1.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // clang-format off
-typedef enum LARA_SHOTGUN_ANIMATION_FRAME {
+typedef enum {
     LF_SG_AIM_START           = 0,
     LF_SG_AIM_BEND            = 1,
     LF_SG_AIM_END             = 12,
@@ -24,7 +24,7 @@ typedef enum LARA_SHOTGUN_ANIMATION_FRAME {
 // clang-format on
 
 // clang-format off
-typedef enum LARA_GUN_ANIMATION_FRAME {
+typedef enum {
     LF_G_AIM_START    = 0,
     LF_G_AIM_BEND     = 1,
     LF_G_AIM_EXTEND   = 3,
@@ -40,7 +40,7 @@ typedef enum LARA_GUN_ANIMATION_FRAME {
 // clang-format on
 
 // clang-format off
-typedef enum LARA_ANIMATION {
+typedef enum {
     LA_RUN                  = 0,
     LA_WALK_FORWARD         = 1,
     LA_RUN_START            = 6,
@@ -93,7 +93,7 @@ typedef enum LARA_ANIMATION {
 } LARA_ANIMATION;
 
 // clang-format off
-typedef enum LARA_STATE {
+typedef enum {
     LS_WALK         = 0,
     LS_RUN          = 1,
     LS_STOP         = 2,
@@ -157,7 +157,7 @@ typedef enum LARA_STATE {
 // clang-format on
 
 // clang-format off
-typedef enum LARA_GUN_TYPE {
+typedef enum {
     LGT_UNKNOWN = -1, // for legacy saves
     LGT_UNARMED = 0,
     LGT_PISTOLS = 1,

--- a/include/libtrx/game/lara/types.h
+++ b/include/libtrx/game/lara/types.h
@@ -36,7 +36,7 @@ typedef struct __PACKING {
     LARA_GUN_TYPE holsters_gun_type;
     LARA_GUN_TYPE back_gun_type;
     int16_t calc_fall_speed;
-    int16_t water_status;
+    LARA_WATER_STATE water_status;
     int16_t pose_count;
     int16_t hit_frame;
     int16_t hit_direction;

--- a/include/libtrx/game/lara/types.h
+++ b/include/libtrx/game/lara/types.h
@@ -45,10 +45,10 @@ typedef struct __PACKING {
     int16_t death_timer;
     int16_t current_active;
     int16_t spaz_effect_count;
-    FX_INFO *spaz_effect;
+    FX *spaz_effect;
     int32_t mesh_effects;
     int16_t *mesh_ptrs[LM_NUMBER_OF];
-    ITEM_INFO *target;
+    ITEM *target;
     int16_t target_angles[2];
     int16_t turn_rate;
     int16_t move_angle;
@@ -125,10 +125,10 @@ typedef struct __PACKING {
     // clang-format on
     int32_t water_surface_dist;
     XYZ_32 last_pos;
-    FX_INFO *spaz_effect;
+    FX *spaz_effect;
     uint32_t mesh_effects;
     int16_t *mesh_ptrs[15];
-    ITEM_INFO *target;
+    ITEM *target;
     int16_t target_angles[2];
     int16_t turn_rate;
     int16_t move_angle;
@@ -147,7 +147,7 @@ typedef struct __PACKING {
     AMMO_INFO harpoon_ammo;
     AMMO_INFO grenade_ammo;
     AMMO_INFO m16_ammo;
-    CREATURE_INFO *creature;
+    CREATURE *creature;
 } LARA_INFO;
 
 #endif

--- a/include/libtrx/game/objects/common.h
+++ b/include/libtrx/game/objects/common.h
@@ -7,7 +7,7 @@
 #include "ids.h"
 #include "types.h"
 
-OBJECT_INFO *Object_GetObject(GAME_OBJECT_ID object_id);
+OBJECT *Object_GetObject(GAME_OBJECT_ID object_id);
 
 bool Object_IsObjectType(
     GAME_OBJECT_ID object_id, const GAME_OBJECT_ID *test_arr);

--- a/include/libtrx/game/objects/types.h
+++ b/include/libtrx/game/objects/types.h
@@ -20,11 +20,11 @@ typedef struct __PACKING {
     void (*initialise)(int16_t item_num);
     void (*control)(int16_t item_num);
     int16_t (*floor_height_func)(
-        const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+        const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
     int16_t (*ceiling_height_func)(
-        const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
-    void (*draw_routine)(ITEM_INFO *item);
-    void (*collision)(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
+        const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+    void (*draw_routine)(ITEM *item);
+    void (*collision)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
     const OBJECT_BOUNDS *(*bounds)(void);
     int16_t anim_idx;
     int16_t hit_points;
@@ -38,7 +38,7 @@ typedef struct __PACKING {
     uint16_t save_hitpoints : 1;
     uint16_t save_flags : 1;
     uint16_t save_anim : 1;
-} OBJECT_INFO;
+} OBJECT;
 
 #elif TR_VERSION == 2
 typedef struct __PACKING {
@@ -50,13 +50,11 @@ typedef struct __PACKING {
     void (*initialise)(int16_t item_num);
     void (*control)(int16_t item_num);
     void (*floor)(
-        const ITEM_INFO *item, int32_t x, int32_t y, int32_t z,
-        int32_t *height);
+        const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *height);
     void (*ceiling)(
-        const ITEM_INFO *item, int32_t x, int32_t y, int32_t z,
-        int32_t *height);
-    void (*draw_routine)(const ITEM_INFO *item);
-    void (*collision)(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
+        const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *height);
+    void (*draw_routine)(const ITEM *item);
+    void (*collision)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
     int16_t anim_idx;
     int16_t hit_points;
@@ -80,5 +78,5 @@ typedef struct __PACKING {
         };
         // clang-format on
     };
-} OBJECT_INFO;
+} OBJECT;
 #endif

--- a/include/libtrx/game/rooms/common.h
+++ b/include/libtrx/game/rooms/common.h
@@ -3,4 +3,4 @@
 #include "types.h"
 
 extern int32_t Room_GetTotalCount(void);
-ROOM_INFO *Room_Get(int32_t room_num);
+ROOM *Room_Get(int32_t room_num);

--- a/include/libtrx/game/rooms/types.h
+++ b/include/libtrx/game/rooms/types.h
@@ -6,19 +6,19 @@
 #include <stdbool.h>
 
 #if TR_VERSION == 1
-typedef struct {
+typedef struct __PACKING {
     TRIGGER_OBJECT type;
     void *parameter;
 } TRIGGER_CMD;
 
-typedef struct {
+typedef struct __PACKING {
     int16_t camera_num;
     uint8_t timer;
     uint8_t glide;
     bool one_shot;
 } TRIGGER_CAMERA_DATA;
 
-typedef struct {
+typedef struct __PACKING {
     TRIGGER_TYPE type;
     int8_t timer;
     int16_t mask;
@@ -32,7 +32,7 @@ typedef struct __PACKING {
     int16_t room_num;
     XYZ_16 normal;
     XYZ_16 vertex[4];
-} DOOR_INFO;
+} PORTAL;
 
 #elif TR_VERSION == 2
 typedef struct __PACKING {
@@ -41,13 +41,13 @@ typedef struct __PACKING {
     int16_t y;
     int16_t z;
     XYZ_16 vertex[4];
-} DOOR_INFO;
+} PORTAL;
 #endif
 
 typedef struct __PACKING {
     uint16_t count;
-    DOOR_INFO door[];
-} DOOR_INFOS;
+    PORTAL portal[];
+} PORTALS;
 
 #if TR_VERSION == 1
 typedef struct __PACKING {
@@ -55,38 +55,38 @@ typedef struct __PACKING {
     int16_t box;
     bool is_death_sector;
     TRIGGER *trigger;
-    struct {
+    struct __PACKING {
         uint8_t pit;
         uint8_t sky;
         int16_t wall;
     } portal_room;
-    struct {
+    struct __PACKING {
         int16_t height;
         int16_t tilt;
     } floor, ceiling;
-} SECTOR_INFO;
+} SECTOR;
 
-typedef struct LIGHT_INFO {
+typedef struct __PACKING {
     XYZ_32 pos;
     int16_t intensity;
     int32_t falloff;
-} LIGHT_INFO;
+} LIGHT;
 
-typedef struct MESH_INFO {
+typedef struct __PACKING {
     XYZ_32 pos;
-    struct {
+    struct __PACKING {
         int16_t y;
     } rot;
     uint16_t shade;
     uint16_t static_num;
-} MESH_INFO;
+} MESH;
 
 typedef struct __PACKING {
     int16_t *data;
-    DOOR_INFOS *doors;
-    SECTOR_INFO *sectors;
-    LIGHT_INFO *light;
-    MESH_INFO *mesh;
+    PORTALS *portals;
+    SECTOR *sectors;
+    LIGHT *light;
+    MESH *mesh;
     int32_t x;
     int32_t y;
     int32_t z;
@@ -106,7 +106,7 @@ typedef struct __PACKING {
     int16_t fx_num;
     int16_t flipped_room;
     uint16_t flags;
-} ROOM_INFO;
+} ROOM;
 
 #elif TR_VERSION == 2
 typedef struct __PACKING {
@@ -116,7 +116,7 @@ typedef struct __PACKING {
     int8_t floor;
     uint8_t sky_room;
     int8_t ceiling;
-} SECTOR_INFO;
+} SECTOR;
 
 typedef struct __PACKING {
     int32_t x;
@@ -126,7 +126,7 @@ typedef struct __PACKING {
     int16_t intensity2;
     int32_t falloff1;
     int32_t falloff2;
-} LIGHT_INFO;
+} LIGHT;
 
 typedef struct __PACKING {
     int32_t x;
@@ -136,14 +136,14 @@ typedef struct __PACKING {
     int16_t shade1;
     int16_t shade2;
     int16_t static_num;
-} MESH_INFO;
+} MESH;
 
 typedef struct __PACKING {
     int16_t *data;
-    DOOR_INFOS *doors;
-    SECTOR_INFO *sector;
-    LIGHT_INFO *light;
-    MESH_INFO *mesh;
+    PORTALS *portals;
+    SECTOR *sector;
+    LIGHT *light;
+    MESH *mesh;
     XYZ_32 pos;
     int32_t min_floor;
     int32_t max_ceiling;
@@ -167,5 +167,5 @@ typedef struct __PACKING {
     int16_t fx_num;
     int16_t flipped_room;
     uint16_t flags;
-} ROOM_INFO;
+} ROOM;
 #endif

--- a/include/libtrx/game/rooms/types.h
+++ b/include/libtrx/game/rooms/types.h
@@ -27,22 +27,13 @@ typedef struct __PACKING {
     int32_t command_count;
     TRIGGER_CMD *commands;
 } TRIGGER;
+#endif
 
 typedef struct __PACKING {
     int16_t room_num;
     XYZ_16 normal;
     XYZ_16 vertex[4];
 } PORTAL;
-
-#elif TR_VERSION == 2
-typedef struct __PACKING {
-    int16_t room;
-    int16_t x;
-    int16_t y;
-    int16_t z;
-    XYZ_16 vertex[4];
-} PORTAL;
-#endif
 
 typedef struct __PACKING {
     uint16_t count;
@@ -51,7 +42,7 @@ typedef struct __PACKING {
 
 #if TR_VERSION == 1
 typedef struct __PACKING {
-    uint16_t index;
+    uint16_t idx;
     int16_t box;
     bool is_death_sector;
     TRIGGER *trigger;
@@ -65,49 +56,6 @@ typedef struct __PACKING {
         int16_t tilt;
     } floor, ceiling;
 } SECTOR;
-
-typedef struct __PACKING {
-    XYZ_32 pos;
-    int16_t intensity;
-    int32_t falloff;
-} LIGHT;
-
-typedef struct __PACKING {
-    XYZ_32 pos;
-    struct __PACKING {
-        int16_t y;
-    } rot;
-    uint16_t shade;
-    uint16_t static_num;
-} MESH;
-
-typedef struct __PACKING {
-    int16_t *data;
-    PORTALS *portals;
-    SECTOR *sectors;
-    LIGHT *light;
-    MESH *mesh;
-    int32_t x;
-    int32_t y;
-    int32_t z;
-    int32_t min_floor;
-    int32_t max_ceiling;
-    int16_t z_size;
-    int16_t x_size;
-    int16_t ambient;
-    int16_t num_lights;
-    int16_t num_meshes;
-    int16_t left;
-    int16_t right;
-    int16_t top;
-    int16_t bottom;
-    int16_t bound_active;
-    int16_t item_num;
-    int16_t fx_num;
-    int16_t flipped_room;
-    uint16_t flags;
-} ROOM;
-
 #elif TR_VERSION == 2
 typedef struct __PACKING {
     uint16_t idx;
@@ -117,41 +65,55 @@ typedef struct __PACKING {
     uint8_t sky_room;
     int8_t ceiling;
 } SECTOR;
+#endif
 
 typedef struct __PACKING {
-    int32_t x;
-    int32_t y;
-    int32_t z;
-    int16_t intensity1;
-    int16_t intensity2;
-    int32_t falloff1;
-    int32_t falloff2;
+    XYZ_32 pos;
+#if TR_VERSION == 1
+    int16_t intensity;
+    int32_t falloff;
+#elif TR_VERSION == 2
+    int16_t intensity_1;
+    int16_t intensity_2;
+    int32_t falloff_1;
+    int32_t falloff_2;
+#endif
 } LIGHT;
 
 typedef struct __PACKING {
-    int32_t x;
-    int32_t y;
-    int32_t z;
-    int16_t y_rot;
-    int16_t shade1;
-    int16_t shade2;
+    XYZ_32 pos;
+    struct __PACKING {
+        int16_t y;
+    } rot;
+#if TR_VERSION == 1
+    uint16_t shade;
+#elif TR_VERSION == 2
+    int16_t shade_1;
+    int16_t shade_2;
+#endif
     int16_t static_num;
 } MESH;
 
 typedef struct __PACKING {
     int16_t *data;
     PORTALS *portals;
-    SECTOR *sector;
-    LIGHT *light;
-    MESH *mesh;
+    SECTOR *sectors;
+    LIGHT *lights;
+    MESH *meshes;
     XYZ_32 pos;
     int32_t min_floor;
     int32_t max_ceiling;
-    int16_t z_size;
-    int16_t x_size;
-    int16_t ambient1;
-    int16_t ambient2;
+    struct __PACKING {
+        int16_t z;
+        int16_t x;
+    } size;
+#if TR_VERSION == 1
+    int16_t ambient;
+#else
+    int16_t ambient_1;
+    int16_t ambient_2;
     int16_t light_mode;
+#endif
     int16_t num_lights;
     int16_t num_meshes;
     int16_t bound_left;
@@ -159,13 +121,14 @@ typedef struct __PACKING {
     int16_t bound_top;
     int16_t bound_bottom;
     uint16_t bound_active;
+#if TR_VERSION == 2
     int16_t test_left;
     int16_t test_right;
     int16_t test_top;
     int16_t test_bottom;
+#endif
     int16_t item_num;
     int16_t fx_num;
     int16_t flipped_room;
     uint16_t flags;
 } ROOM;
-#endif

--- a/include/libtrx/game/sound/common.h
+++ b/include/libtrx/game/sound/common.h
@@ -4,7 +4,7 @@
 #include "ids.h"
 
 // clang-format off
-typedef enum SOUND_PLAY_MODE {
+typedef enum {
     SPM_NORMAL     = 0,
     SPM_UNDERWATER = 1,
     SPM_ALWAYS     = 2,

--- a/include/libtrx/game/sound/ids.h
+++ b/include/libtrx/game/sound/ids.h
@@ -2,7 +2,7 @@
 
 #if TR_VERSION == 1
 // clang-format off
-typedef enum SOUND_EFFECT_ID {
+typedef enum {
     SFX_INVALID               = -1,
     SFX_LARA_FEET             = 0,
     SFX_LARA_CLIMB2           = 1,

--- a/include/libtrx/gfx/2d/2d_renderer.h
+++ b/include/libtrx/gfx/2d/2d_renderer.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef struct GFX_2D_Renderer {
+typedef struct {
     uint32_t width;
     uint32_t height;
     GFX_GL_VertexArray surface_format;

--- a/include/libtrx/gfx/2d/2d_renderer.h
+++ b/include/libtrx/gfx/2d/2d_renderer.h
@@ -13,16 +13,16 @@
 typedef struct {
     uint32_t width;
     uint32_t height;
-    GFX_GL_VertexArray surface_format;
-    GFX_GL_Buffer surface_buffer;
-    GFX_GL_Texture surface_texture;
-    GFX_GL_Sampler sampler;
-    GFX_GL_Program program;
-} GFX_2D_Renderer;
+    GFX_GL_VERTEX_ARRAY surface_format;
+    GFX_GL_BUFFER surface_buffer;
+    GFX_GL_TEXTURE surface_texture;
+    GFX_GL_SAMPLER sampler;
+    GFX_GL_PROGRAM program;
+} GFX_2D_RENDERER;
 
-void GFX_2D_Renderer_Init(GFX_2D_Renderer *renderer);
-void GFX_2D_Renderer_Close(GFX_2D_Renderer *renderer);
+void GFX_2D_Renderer_Init(GFX_2D_RENDERER *renderer);
+void GFX_2D_Renderer_Close(GFX_2D_RENDERER *renderer);
 
 void GFX_2D_Renderer_Upload(
-    GFX_2D_Renderer *renderer, GFX_2D_SurfaceDesc *desc, const uint8_t *data);
-void GFX_2D_Renderer_Render(GFX_2D_Renderer *renderer);
+    GFX_2D_RENDERER *renderer, GFX_2D_SURFACE_DESC *desc, const uint8_t *data);
+void GFX_2D_Renderer_Render(GFX_2D_RENDERER *renderer);

--- a/include/libtrx/gfx/2d/2d_surface.h
+++ b/include/libtrx/gfx/2d/2d_surface.h
@@ -14,24 +14,25 @@ typedef struct {
     int32_t bit_count;
     GLenum tex_format;
     GLenum tex_type;
-} GFX_2D_SurfaceDesc;
+} GFX_2D_SURFACE_DESC;
 
 typedef struct {
     uint8_t *buffer;
-    GFX_2D_SurfaceDesc desc;
+    GFX_2D_SURFACE_DESC desc;
     bool is_locked;
     bool is_dirty;
-} GFX_2D_Surface;
+} GFX_2D_SURFACE;
 
-GFX_2D_Surface *GFX_2D_Surface_Create(const GFX_2D_SurfaceDesc *desc);
-GFX_2D_Surface *GFX_2D_Surface_CreateFromImage(const IMAGE *image);
-void GFX_2D_Surface_Free(GFX_2D_Surface *surface);
+GFX_2D_SURFACE *GFX_2D_Surface_Create(const GFX_2D_SURFACE_DESC *desc);
+GFX_2D_SURFACE *GFX_2D_Surface_CreateFromImage(const IMAGE *image);
+void GFX_2D_Surface_Free(GFX_2D_SURFACE *surface);
 
 void GFX_2D_Surface_Init(
-    GFX_2D_Surface *surface, const GFX_2D_SurfaceDesc *desc);
-void GFX_2D_Surface_Close(GFX_2D_Surface *surface);
+    GFX_2D_SURFACE *surface, const GFX_2D_SURFACE_DESC *desc);
+void GFX_2D_Surface_Close(GFX_2D_SURFACE *surface);
 
-bool GFX_2D_Surface_Clear(GFX_2D_Surface *surface);
+bool GFX_2D_Surface_Clear(GFX_2D_SURFACE *surface);
 
-bool GFX_2D_Surface_Lock(GFX_2D_Surface *surface, GFX_2D_SurfaceDesc *out_desc);
-bool GFX_2D_Surface_Unlock(GFX_2D_Surface *surface);
+bool GFX_2D_Surface_Lock(
+    GFX_2D_SURFACE *surface, GFX_2D_SURFACE_DESC *out_desc);
+bool GFX_2D_Surface_Unlock(GFX_2D_SURFACE *surface);

--- a/include/libtrx/gfx/2d/2d_surface.h
+++ b/include/libtrx/gfx/2d/2d_surface.h
@@ -16,7 +16,7 @@ typedef struct {
     GLenum tex_type;
 } GFX_2D_SurfaceDesc;
 
-typedef struct GFX_2D_Surface {
+typedef struct {
     uint8_t *buffer;
     GFX_2D_SurfaceDesc desc;
     bool is_locked;

--- a/include/libtrx/gfx/3d/3d_renderer.h
+++ b/include/libtrx/gfx/3d/3d_renderer.h
@@ -21,7 +21,7 @@ typedef enum {
     GFX_BlendMode_Multiply,
 } GFX_BlendMode;
 
-typedef struct GFX_3D_Renderer {
+typedef struct {
     const GFX_CONFIG *config;
 
     GFX_GL_Program program;

--- a/include/libtrx/gfx/3d/3d_renderer.h
+++ b/include/libtrx/gfx/3d/3d_renderer.h
@@ -16,20 +16,20 @@
 #include <stdint.h>
 
 typedef enum {
-    GFX_BlendMode_Off,
-    GFX_BlendMode_Normal,
-    GFX_BlendMode_Multiply,
-} GFX_BlendMode;
+    GFX_BLEND_MODE_OFF,
+    GFX_BLEND_MODE_NORMAL,
+    GFX_BLEND_MODE_MULTIPLY,
+} GFX_BLEND_MODE;
 
 typedef struct {
     const GFX_CONFIG *config;
 
-    GFX_GL_Program program;
-    GFX_GL_Sampler sampler;
-    GFX_3D_VertexStream vertex_stream;
+    GFX_GL_PROGRAM program;
+    GFX_GL_SAMPLER sampler;
+    GFX_3D_VERTEX_STREAM vertex_stream;
 
-    GFX_GL_Texture *textures[GFX_MAX_TEXTURES];
-    GFX_GL_Texture *env_map_texture;
+    GFX_GL_TEXTURE *textures[GFX_MAX_TEXTURES];
+    GFX_GL_TEXTURE *env_map_texture;
     int selected_texture_num;
 
     // shader variable locations
@@ -37,42 +37,42 @@ typedef struct {
     GLint loc_mat_model_view;
     GLint loc_texturing_enabled;
     GLint loc_smoothing_enabled;
-} GFX_3D_Renderer;
+} GFX_3D_RENDERER;
 
-void GFX_3D_Renderer_Init(GFX_3D_Renderer *renderer, const GFX_CONFIG *config);
-void GFX_3D_Renderer_Close(GFX_3D_Renderer *renderer);
+void GFX_3D_Renderer_Init(GFX_3D_RENDERER *renderer, const GFX_CONFIG *config);
+void GFX_3D_Renderer_Close(GFX_3D_RENDERER *renderer);
 
-void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer);
-void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer);
-void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer);
+void GFX_3D_Renderer_RenderBegin(GFX_3D_RENDERER *renderer);
+void GFX_3D_Renderer_RenderEnd(GFX_3D_RENDERER *renderer);
+void GFX_3D_Renderer_ClearDepth(GFX_3D_RENDERER *renderer);
 
 int GFX_3D_Renderer_RegisterTexturePage(
-    GFX_3D_Renderer *renderer, const void *data, int width, int height);
+    GFX_3D_RENDERER *renderer, const void *data, int width, int height);
 bool GFX_3D_Renderer_UnregisterTexturePage(
-    GFX_3D_Renderer *renderer, int texture_num);
+    GFX_3D_RENDERER *renderer, int texture_num);
 
-int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_Renderer *renderer);
+int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_RENDERER *renderer);
 bool GFX_3D_Renderer_UnregisterEnvironmentMap(
-    GFX_3D_Renderer *renderer, int texture_num);
-void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_Renderer *renderer);
+    GFX_3D_RENDERER *renderer, int texture_num);
+void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_RENDERER *renderer);
 
-void GFX_3D_Renderer_SelectTexture(GFX_3D_Renderer *renderer, int texture_num);
-void GFX_3D_Renderer_RestoreTexture(GFX_3D_Renderer *renderer);
+void GFX_3D_Renderer_SelectTexture(GFX_3D_RENDERER *renderer, int texture_num);
+void GFX_3D_Renderer_RestoreTexture(GFX_3D_RENDERER *renderer);
 
 void GFX_3D_Renderer_RenderPrimStrip(
-    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count);
+    GFX_3D_RENDERER *renderer, GFX_3D_VERTEX *vertices, int count);
 void GFX_3D_Renderer_RenderPrimFan(
-    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count);
+    GFX_3D_RENDERER *renderer, GFX_3D_VERTEX *vertices, int count);
 void GFX_3D_Renderer_RenderPrimList(
-    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count);
+    GFX_3D_RENDERER *renderer, GFX_3D_VERTEX *vertices, int count);
 
 void GFX_3D_Renderer_SetPrimType(
-    GFX_3D_Renderer *renderer, GFX_3D_PrimType value);
+    GFX_3D_RENDERER *renderer, GFX_3D_PRIM_TYPE value);
 void GFX_3D_Renderer_SetTextureFilter(
-    GFX_3D_Renderer *renderer, GFX_TEXTURE_FILTER filter);
+    GFX_3D_RENDERER *renderer, GFX_TEXTURE_FILTER filter);
 void GFX_3D_Renderer_SetDepthTestEnabled(
-    GFX_3D_Renderer *renderer, bool is_enabled);
+    GFX_3D_RENDERER *renderer, bool is_enabled);
 void GFX_3D_Renderer_SetBlendingMode(
-    GFX_3D_Renderer *renderer, GFX_BlendMode blend_mode);
+    GFX_3D_RENDERER *renderer, GFX_BLEND_MODE blend_mode);
 void GFX_3D_Renderer_SetTexturingEnabled(
-    GFX_3D_Renderer *renderer, bool is_enabled);
+    GFX_3D_RENDERER *renderer, bool is_enabled);

--- a/include/libtrx/gfx/3d/vertex_stream.h
+++ b/include/libtrx/gfx/3d/vertex_stream.h
@@ -17,7 +17,7 @@ typedef struct {
     float r, g, b, a;
 } GFX_3D_Vertex;
 
-typedef struct GFX_3D_VertexStream {
+typedef struct {
     GFX_3D_PrimType prim_type;
     size_t buffer_size;
     GFX_GL_Buffer buffer;

--- a/include/libtrx/gfx/3d/vertex_stream.h
+++ b/include/libtrx/gfx/3d/vertex_stream.h
@@ -9,39 +9,39 @@
 typedef enum {
     GFX_3D_PRIM_LINE = 0,
     GFX_3D_PRIM_TRI = 1,
-} GFX_3D_PrimType;
+} GFX_3D_PRIM_TYPE;
 
 typedef struct {
     float x, y, z;
     float s, t, w;
     float r, g, b, a;
-} GFX_3D_Vertex;
+} GFX_3D_VERTEX;
 
 typedef struct {
-    GFX_3D_PrimType prim_type;
+    GFX_3D_PRIM_TYPE prim_type;
     size_t buffer_size;
-    GFX_GL_Buffer buffer;
-    GFX_GL_VertexArray vtc_format;
+    GFX_GL_BUFFER buffer;
+    GFX_GL_VERTEX_ARRAY vtc_format;
     struct {
-        GFX_3D_Vertex *data;
+        GFX_3D_VERTEX *data;
         size_t count;
         size_t capacity;
     } pending_vertices;
-} GFX_3D_VertexStream;
+} GFX_3D_VERTEX_STREAM;
 
-void GFX_3D_VertexStream_Init(GFX_3D_VertexStream *vertex_stream);
-void GFX_3D_VertexStream_Close(GFX_3D_VertexStream *vertex_stream);
+void GFX_3D_VertexStream_Init(GFX_3D_VERTEX_STREAM *vertex_stream);
+void GFX_3D_VertexStream_Close(GFX_3D_VERTEX_STREAM *vertex_stream);
 
-void GFX_3D_VertexStream_Bind(GFX_3D_VertexStream *vertex_stream);
+void GFX_3D_VertexStream_Bind(GFX_3D_VERTEX_STREAM *vertex_stream);
 
 void GFX_3D_VertexStream_SetPrimType(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_PrimType prim_type);
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_PRIM_TYPE prim_type);
 
 bool GFX_3D_VertexStream_PushPrimStrip(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count);
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertices, int count);
 bool GFX_3D_VertexStream_PushPrimFan(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count);
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertices, int count);
 bool GFX_3D_VertexStream_PushPrimList(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count);
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertices, int count);
 
-void GFX_3D_VertexStream_RenderPending(GFX_3D_VertexStream *vertex_stream);
+void GFX_3D_VertexStream_RenderPending(GFX_3D_VERTEX_STREAM *vertex_stream);

--- a/include/libtrx/gfx/common.h
+++ b/include/libtrx/gfx/common.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef enum GFX_TEXTURE_FILTER {
+typedef enum {
     GFX_TF_FIRST = 0,
     GFX_TF_NN = GFX_TF_FIRST,
     GFX_TF_BILINEAR,
@@ -8,12 +8,12 @@ typedef enum GFX_TEXTURE_FILTER {
     GFX_TF_NUMBER_OF,
 } GFX_TEXTURE_FILTER;
 
-typedef enum GFX_RENDER_MODE {
+typedef enum {
     GFX_RM_LEGACY,
     GFX_RM_FRAMEBUFFER,
 } GFX_RENDER_MODE;
 
-typedef enum GFX_GL_BACKEND {
+typedef enum {
     GFX_GL_21,
     GFX_GL_33C,
 } GFX_GL_BACKEND;

--- a/include/libtrx/gfx/context.h
+++ b/include/libtrx/gfx/context.h
@@ -8,8 +8,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef struct GFX_CONTEXT GFX_CONTEXT;
-
 void GFX_Context_Attach(void *window_handle);
 void GFX_Context_Detach(void);
 

--- a/include/libtrx/gfx/context.h
+++ b/include/libtrx/gfx/context.h
@@ -36,5 +36,5 @@ void GFX_Context_ScheduleScreenshot(const char *path);
 const char *GFX_Context_GetScheduledScreenshotPath(void);
 void GFX_Context_ClearScheduledScreenshotPath(void);
 
-GFX_2D_Renderer *GFX_Context_GetRenderer2D(void);
-GFX_3D_Renderer *GFX_Context_GetRenderer3D(void);
+GFX_2D_RENDERER *GFX_Context_GetRenderer2D(void);
+GFX_3D_RENDERER *GFX_Context_GetRenderer3D(void);

--- a/include/libtrx/gfx/gl/buffer.h
+++ b/include/libtrx/gfx/gl/buffer.h
@@ -2,7 +2,7 @@
 
 #include "gl_core_3_3.h"
 
-typedef struct GFX_GL_Buffer {
+typedef struct {
     GLuint id;
     GLenum target;
 } GFX_GL_Buffer;

--- a/include/libtrx/gfx/gl/buffer.h
+++ b/include/libtrx/gfx/gl/buffer.h
@@ -5,16 +5,16 @@
 typedef struct {
     GLuint id;
     GLenum target;
-} GFX_GL_Buffer;
+} GFX_GL_BUFFER;
 
-void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target);
-void GFX_GL_Buffer_Close(GFX_GL_Buffer *buf);
+void GFX_GL_Buffer_Init(GFX_GL_BUFFER *buf, GLenum target);
+void GFX_GL_Buffer_Close(GFX_GL_BUFFER *buf);
 
-void GFX_GL_Buffer_Bind(GFX_GL_Buffer *buf);
+void GFX_GL_Buffer_Bind(GFX_GL_BUFFER *buf);
 void GFX_GL_Buffer_Data(
-    GFX_GL_Buffer *buf, GLsizei size, const void *data, GLenum usage);
+    GFX_GL_BUFFER *buf, GLsizei size, const void *data, GLenum usage);
 void GFX_GL_Buffer_SubData(
-    GFX_GL_Buffer *buf, GLsizei offset, GLsizei size, const void *data);
-void *GFX_GL_Buffer_Map(GFX_GL_Buffer *buf, GLenum access);
-void GFX_GL_Buffer_Unmap(GFX_GL_Buffer *buf);
-GLint GFX_GL_Buffer_Parameter(GFX_GL_Buffer *buf, GLenum pname);
+    GFX_GL_BUFFER *buf, GLsizei offset, GLsizei size, const void *data);
+void *GFX_GL_Buffer_Map(GFX_GL_BUFFER *buf, GLenum access);
+void GFX_GL_Buffer_Unmap(GFX_GL_BUFFER *buf);
+GLint GFX_GL_Buffer_Parameter(GFX_GL_BUFFER *buf, GLenum pname);

--- a/include/libtrx/gfx/gl/program.h
+++ b/include/libtrx/gfx/gl/program.h
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 
-typedef struct GFX_GL_Program {
+typedef struct {
     GLuint id;
 } GFX_GL_Program;
 

--- a/include/libtrx/gfx/gl/program.h
+++ b/include/libtrx/gfx/gl/program.h
@@ -7,26 +7,26 @@
 
 typedef struct {
     GLuint id;
-} GFX_GL_Program;
+} GFX_GL_PROGRAM;
 
-bool GFX_GL_Program_Init(GFX_GL_Program *program);
-void GFX_GL_Program_Close(GFX_GL_Program *program);
+bool GFX_GL_Program_Init(GFX_GL_PROGRAM *program);
+void GFX_GL_Program_Close(GFX_GL_PROGRAM *program);
 
-void GFX_GL_Program_Bind(GFX_GL_Program *program);
+void GFX_GL_Program_Bind(GFX_GL_PROGRAM *program);
 char *GFX_GL_Program_PreprocessShader(
     const char *content, GLenum type, GFX_GL_BACKEND backend);
 void GFX_GL_Program_AttachShader(
-    GFX_GL_Program *program, GLenum type, const char *path);
-void GFX_GL_Program_Link(GFX_GL_Program *program);
-void GFX_GL_Program_FragmentData(GFX_GL_Program *program, const char *name);
-GLint GFX_GL_Program_UniformLocation(GFX_GL_Program *program, const char *name);
+    GFX_GL_PROGRAM *program, GLenum type, const char *path);
+void GFX_GL_Program_Link(GFX_GL_PROGRAM *program);
+void GFX_GL_Program_FragmentData(GFX_GL_PROGRAM *program, const char *name);
+GLint GFX_GL_Program_UniformLocation(GFX_GL_PROGRAM *program, const char *name);
 
 void GFX_GL_Program_Uniform3f(
-    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2);
+    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2);
 void GFX_GL_Program_Uniform4f(
-    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
+    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
     GLfloat v3);
-void GFX_GL_Program_Uniform1i(GFX_GL_Program *program, GLint loc, GLint v0);
+void GFX_GL_Program_Uniform1i(GFX_GL_PROGRAM *program, GLint loc, GLint v0);
 void GFX_GL_Program_UniformMatrix4fv(
-    GFX_GL_Program *program, GLint loc, GLsizei count, GLboolean transpose,
+    GFX_GL_PROGRAM *program, GLint loc, GLsizei count, GLboolean transpose,
     const GLfloat *value);

--- a/include/libtrx/gfx/gl/sampler.h
+++ b/include/libtrx/gfx/gl/sampler.h
@@ -2,7 +2,7 @@
 
 #include "../gl/gl_core_3_3.h"
 
-typedef struct GFX_GL_Sampler {
+typedef struct {
     GLuint id;
 } GFX_GL_Sampler;
 

--- a/include/libtrx/gfx/gl/sampler.h
+++ b/include/libtrx/gfx/gl/sampler.h
@@ -4,13 +4,13 @@
 
 typedef struct {
     GLuint id;
-} GFX_GL_Sampler;
+} GFX_GL_SAMPLER;
 
-void GFX_GL_Sampler_Init(GFX_GL_Sampler *sampler);
-void GFX_GL_Sampler_Close(GFX_GL_Sampler *sampler);
+void GFX_GL_Sampler_Init(GFX_GL_SAMPLER *sampler);
+void GFX_GL_Sampler_Close(GFX_GL_SAMPLER *sampler);
 
-void GFX_GL_Sampler_Bind(GFX_GL_Sampler *sampler, GLuint unit);
+void GFX_GL_Sampler_Bind(GFX_GL_SAMPLER *sampler, GLuint unit);
 void GFX_GL_Sampler_Parameteri(
-    GFX_GL_Sampler *sampler, GLenum pname, GLint param);
+    GFX_GL_SAMPLER *sampler, GLenum pname, GLint param);
 void GFX_GL_Sampler_Parameterf(
-    GFX_GL_Sampler *sampler, GLenum pname, GLfloat param);
+    GFX_GL_SAMPLER *sampler, GLenum pname, GLfloat param);

--- a/include/libtrx/gfx/gl/texture.h
+++ b/include/libtrx/gfx/gl/texture.h
@@ -5,15 +5,15 @@
 typedef struct {
     GLuint id;
     GLenum target;
-} GFX_GL_Texture;
+} GFX_GL_TEXTURE;
 
-GFX_GL_Texture *GFX_GL_Texture_Create(GLenum target);
-void GFX_GL_Texture_Free(GFX_GL_Texture *texture);
+GFX_GL_TEXTURE *GFX_GL_Texture_Create(GLenum target);
+void GFX_GL_Texture_Free(GFX_GL_TEXTURE *texture);
 
-void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target);
-void GFX_GL_Texture_Close(GFX_GL_Texture *texture);
-void GFX_GL_Texture_Bind(GFX_GL_Texture *texture);
+void GFX_GL_Texture_Init(GFX_GL_TEXTURE *texture, GLenum target);
+void GFX_GL_Texture_Close(GFX_GL_TEXTURE *texture);
+void GFX_GL_Texture_Bind(GFX_GL_TEXTURE *texture);
 void GFX_GL_Texture_Load(
-    GFX_GL_Texture *texture, const void *data, int width, int height,
+    GFX_GL_TEXTURE *texture, const void *data, int width, int height,
     GLint internal_format, GLint format);
-void GFX_GL_Texture_LoadFromBackBuffer(GFX_GL_Texture *texture);
+void GFX_GL_Texture_LoadFromBackBuffer(GFX_GL_TEXTURE *texture);

--- a/include/libtrx/gfx/gl/texture.h
+++ b/include/libtrx/gfx/gl/texture.h
@@ -2,7 +2,7 @@
 
 #include "../gl/gl_core_3_3.h"
 
-typedef struct GFX_GL_Texture {
+typedef struct {
     GLuint id;
     GLenum target;
 } GFX_GL_Texture;

--- a/include/libtrx/gfx/gl/vertex_array.h
+++ b/include/libtrx/gfx/gl/vertex_array.h
@@ -2,7 +2,7 @@
 
 #include "../gl/gl_core_3_3.h"
 
-typedef struct GFX_GL_VertexArray {
+typedef struct {
     GLuint id;
 } GFX_GL_VertexArray;
 

--- a/include/libtrx/gfx/gl/vertex_array.h
+++ b/include/libtrx/gfx/gl/vertex_array.h
@@ -4,11 +4,11 @@
 
 typedef struct {
     GLuint id;
-} GFX_GL_VertexArray;
+} GFX_GL_VERTEX_ARRAY;
 
-void GFX_GL_VertexArray_Init(GFX_GL_VertexArray *array);
-void GFX_GL_VertexArray_Close(GFX_GL_VertexArray *array);
-void GFX_GL_VertexArray_Bind(GFX_GL_VertexArray *array);
+void GFX_GL_VertexArray_Init(GFX_GL_VERTEX_ARRAY *array);
+void GFX_GL_VertexArray_Close(GFX_GL_VERTEX_ARRAY *array);
+void GFX_GL_VertexArray_Bind(GFX_GL_VERTEX_ARRAY *array);
 void GFX_GL_VertexArray_Attribute(
-    GFX_GL_VertexArray *array, GLuint index, GLint size, GLenum type,
+    GFX_GL_VERTEX_ARRAY *array, GLuint index, GLint size, GLenum type,
     GLboolean normalized, GLsizei stride, GLsizei offset);

--- a/include/libtrx/gfx/renderer.h
+++ b/include/libtrx/gfx/renderer.h
@@ -8,4 +8,4 @@ typedef struct GFX_Renderer {
     void (*reset)(struct GFX_Renderer *renderer);
     void (*swap_buffers)(struct GFX_Renderer *renderer);
     void *priv;
-} GFX_Renderer;
+} GFX_RENDERER;

--- a/include/libtrx/gfx/renderers/fbo_renderer.h
+++ b/include/libtrx/gfx/renderers/fbo_renderer.h
@@ -2,4 +2,4 @@
 
 #include "../renderer.h"
 
-extern GFX_Renderer g_GFX_Renderer_FBO;
+extern GFX_RENDERER g_GFX_Renderer_FBO;

--- a/include/libtrx/gfx/renderers/legacy_renderer.h
+++ b/include/libtrx/gfx/renderers/legacy_renderer.h
@@ -1,3 +1,3 @@
 #include "../renderer.h"
 
-extern GFX_Renderer g_GFX_Renderer_Legacy;
+extern GFX_RENDERER g_GFX_Renderer_Legacy;

--- a/include/libtrx/json.h
+++ b/include/libtrx/json.h
@@ -12,7 +12,7 @@
 #define json_uintmax_t uintmax_t
 #define json_strtoumax strtoumax
 
-enum json_type_e {
+typedef enum {
     json_type_string,
     json_type_number,
     json_type_object,
@@ -20,7 +20,7 @@ enum json_type_e {
     json_type_true,
     json_type_false,
     json_type_null
-};
+} json_type_e;
 
 struct json_string_s {
     char *string;
@@ -172,7 +172,7 @@ struct json_value_s *json_value_from_object(struct json_object_s *obj);
 
 void json_value_free(struct json_value_s *value);
 
-enum json_parse_error_e {
+typedef enum {
     json_parse_error_none = 0,
     json_parse_error_expected_comma_or_closing_bracket,
     json_parse_error_expected_colon,
@@ -185,7 +185,7 @@ enum json_parse_error_e {
     json_parse_error_allocator_failed,
     json_parse_error_unexpected_trailing_characters,
     json_parse_error_unknown
-};
+} json_parse_error_e;
 
 struct json_parse_result_s {
     size_t error;
@@ -194,7 +194,7 @@ struct json_parse_result_s {
     size_t error_row_no;
 };
 
-enum json_parse_flags_e {
+typedef enum {
     json_parse_flags_default = 0,
 
     /* allow trailing commas in objects and arrays. For example, both [true,]
@@ -267,7 +267,7 @@ enum json_parse_flags_e {
          | json_parse_flags_allow_leading_or_trailing_decimal_point
          | json_parse_flags_allow_inf_and_nan
          | json_parse_flags_allow_multi_line_strings)
-};
+} json_parse_flags_e;
 
 /* Parse a JSON text file, returning a pointer to the root of the JSON
  * structure. json_parse performs 1 call to malloc for the entire encoding.
@@ -285,7 +285,7 @@ struct json_value_s *json_parse_ex(
     void *(*alloc_func_ptr)(void *, size_t), void *user_data,
     struct json_parse_result_s *result);
 
-const char *json_get_error_description(enum json_parse_error_e error);
+const char *json_get_error_description(json_parse_error_e error);
 
 /* Write out a minified JSON utf-8 string. This string is an encoding of the
  * minimal string characters required to still encode the same data.

--- a/include/libtrx/json.h
+++ b/include/libtrx/json.h
@@ -8,291 +8,274 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define json_null NULL
 #define json_uintmax_t uintmax_t
 #define json_strtoumax strtoumax
 
 typedef enum {
-    json_type_string,
-    json_type_number,
-    json_type_object,
-    json_type_array,
-    json_type_true,
-    json_type_false,
-    json_type_null
-} json_type_e;
+    JSON_TYPE_STRING,
+    JSON_TYPE_NUMBER,
+    JSON_TYPE_OBJECT,
+    JSON_TYPE_ARRAY,
+    JSON_TYPE_TRUE,
+    JSON_TYPE_FALSE,
+    JSON_TYPE_NULL
+} JSON_TYPE;
 
-struct json_string_s {
-    char *string;
-    size_t string_size;
-    size_t ref_count;
-};
-
-struct json_string_ex_s {
-    struct json_string_s string;
-    size_t offset;
-    size_t line_no;
-    size_t row_no;
-};
-
-struct json_number_s {
-    char *number;
-    size_t number_size;
-    size_t ref_count;
-};
-
-struct json_object_element_s {
-    struct json_string_s *name;
-    struct json_value_s *value;
-    struct json_object_element_s *next;
-    size_t ref_count;
-};
-
-struct json_object_s {
-    struct json_object_element_s *start;
-    size_t length;
-    size_t ref_count;
-};
-
-struct json_array_element_s {
-    struct json_value_s *value;
-    struct json_array_element_s *next;
-    size_t ref_count;
-};
-
-struct json_array_s {
-    struct json_array_element_s *start;
-    size_t length;
-    size_t ref_count;
-};
-
-struct json_value_s {
+typedef struct {
     void *payload;
     size_t type;
     size_t ref_count;
-};
+} JSON_VALUE;
 
-struct json_value_ex_s {
-    struct json_value_s value;
+typedef struct {
+    char *string;
+    size_t string_size;
+    size_t ref_count;
+} JSON_STRING;
+
+typedef struct {
+    JSON_STRING string;
     size_t offset;
     size_t line_no;
     size_t row_no;
-};
+} JSON_STRING_EX;
+
+typedef struct {
+    char *number;
+    size_t number_size;
+    size_t ref_count;
+} JSON_NUMBER;
+
+typedef struct JSON_OBJECT_ELEMENT {
+    JSON_STRING *name;
+    JSON_VALUE *value;
+    struct JSON_OBJECT_ELEMENT *next;
+    size_t ref_count;
+} JSON_OBJECT_ELEMENT;
+
+typedef struct {
+    JSON_OBJECT_ELEMENT *start;
+    size_t length;
+    size_t ref_count;
+} JSON_OBJECT;
+
+typedef struct JSON_ARRAY_ELEMENT {
+    JSON_VALUE *value;
+    struct JSON_ARRAY_ELEMENT *next;
+    size_t ref_count;
+} JSON_ARRAY_ELEMENT;
+
+typedef struct {
+    JSON_ARRAY_ELEMENT *start;
+    size_t length;
+    size_t ref_count;
+} JSON_ARRAY;
+
+typedef struct {
+    JSON_VALUE value;
+    size_t offset;
+    size_t line_no;
+    size_t row_no;
+} JSON_VALUE_EX;
 
 // numbers
-struct json_number_s *json_number_new_int(int number);
-struct json_number_s *json_number_new_int64(int64_t number);
-struct json_number_s *json_number_new_double(double number);
-void json_number_free(struct json_number_s *num);
+JSON_NUMBER *JSON_NumberNewInt(int number);
+JSON_NUMBER *JSON_NumberNewInt64(int64_t number);
+JSON_NUMBER *JSON_NumberNewDouble(double number);
+void JSON_NumberFree(JSON_NUMBER *num);
 
 // strings
-struct json_string_s *json_string_new(const char *string);
-void json_string_free(struct json_string_s *str);
+JSON_STRING *JSON_StringNew(const char *string);
+void JSON_StringFree(JSON_STRING *str);
 
 // arrays
-struct json_array_s *json_array_new(void);
-void json_array_free(struct json_array_s *arr);
-void json_array_element_free(struct json_array_element_s *element);
+JSON_ARRAY *JSON_ArrayNew(void);
+void JSON_ArrayFree(JSON_ARRAY *arr);
+void JSON_ArrayElementFree(JSON_ARRAY_ELEMENT *element);
 
-void json_array_append(struct json_array_s *arr, struct json_value_s *value);
-void json_array_append_bool(struct json_array_s *arr, int b);
-void json_array_append_int(struct json_array_s *arr, int number);
-void json_array_append_double(struct json_array_s *arr, double number);
-void json_array_append_string(struct json_array_s *arr, const char *string);
-void json_array_append_array(
-    struct json_array_s *arr, struct json_array_s *arr2);
-void json_array_append_object(
-    struct json_array_s *arr, struct json_object_s *obj);
+void JSON_ArrayAppend(JSON_ARRAY *arr, JSON_VALUE *value);
+void JSON_ArrayApendBool(JSON_ARRAY *arr, int b);
+void JSON_ArrayAppendInt(JSON_ARRAY *arr, int number);
+void JSON_ArrayAppendDouble(JSON_ARRAY *arr, double number);
+void JSON_ArrayAppendString(JSON_ARRAY *arr, const char *string);
+void JSON_ArrayAppendArray(JSON_ARRAY *arr, JSON_ARRAY *arr2);
+void JSON_ArrayAppendObject(JSON_ARRAY *arr, JSON_OBJECT *obj);
 
-struct json_value_s *json_array_get_value(
-    struct json_array_s *arr, const size_t idx);
-int json_array_get_bool(struct json_array_s *arr, const size_t idx, int d);
-int json_array_get_int(struct json_array_s *arr, const size_t idx, int d);
-double json_array_get_double(
-    struct json_array_s *arr, const size_t idx, double d);
-const char *json_array_get_string(
-    struct json_array_s *arr, const size_t idx, const char *d);
-struct json_array_s *json_array_get_array(
-    struct json_array_s *arr, const size_t idx);
-struct json_object_s *json_array_get_object(
-    struct json_array_s *arr, const size_t idx);
+JSON_VALUE *JSON_ArrayGetValue(JSON_ARRAY *arr, const size_t idx);
+int JSON_ArrayGetBool(JSON_ARRAY *arr, const size_t idx, int d);
+int JSON_ArrayGetInt(JSON_ARRAY *arr, const size_t idx, int d);
+double JSON_ArrayGetDouble(JSON_ARRAY *arr, const size_t idx, double d);
+const char *JSON_ArrayGetString(
+    JSON_ARRAY *arr, const size_t idx, const char *d);
+JSON_ARRAY *JSON_ArrayGetArray(JSON_ARRAY *arr, const size_t idx);
+JSON_OBJECT *JSON_ArrayGetObject(JSON_ARRAY *arr, const size_t idx);
 
 // objects
-struct json_object_s *json_object_new(void);
-void json_object_free(struct json_object_s *obj);
-void json_object_element_free(struct json_object_element_s *element);
+JSON_OBJECT *JSON_ObjectNew(void);
+void JSON_ObjectFree(JSON_OBJECT *obj);
+void JSON_ObjectElementFree(JSON_OBJECT_ELEMENT *element);
 
-void json_object_append(
-    struct json_object_s *obj, const char *key, struct json_value_s *value);
-void json_object_append_bool(struct json_object_s *obj, const char *key, int b);
-void json_object_append_int(
-    struct json_object_s *obj, const char *key, int number);
-void json_object_append_int64(
-    struct json_object_s *obj, const char *key, int64_t number);
-void json_object_append_double(
-    struct json_object_s *obj, const char *key, double number);
-void json_object_append_string(
-    struct json_object_s *obj, const char *key, const char *string);
-void json_object_append_array(
-    struct json_object_s *obj, const char *key, struct json_array_s *arr);
-void json_object_append_object(
-    struct json_object_s *obj, const char *key, struct json_object_s *obj2);
+void JSON_ObjectAppend(JSON_OBJECT *obj, const char *key, JSON_VALUE *value);
+void JSON_ObjectAppendBool(JSON_OBJECT *obj, const char *key, int b);
+void JSON_ObjectAppendInt(JSON_OBJECT *obj, const char *key, int number);
+void JSON_ObjectAppendInt64(JSON_OBJECT *obj, const char *key, int64_t number);
+void JSON_ObjectAppendDouble(JSON_OBJECT *obj, const char *key, double number);
+void JSON_ObjectAppendString(
+    JSON_OBJECT *obj, const char *key, const char *string);
+void JSON_ObjectAppendArray(JSON_OBJECT *obj, const char *key, JSON_ARRAY *arr);
+void JSON_ObjectAppendObject(
+    JSON_OBJECT *obj, const char *key, JSON_OBJECT *obj2);
 
-void json_object_evict_key(struct json_object_s *obj, const char *key);
+void JSON_ObjectEvictKey(JSON_OBJECT *obj, const char *key);
 
-struct json_value_s *json_object_get_value(
-    struct json_object_s *obj, const char *key);
-int json_object_get_bool(struct json_object_s *obj, const char *key, int d);
-int json_object_get_int(struct json_object_s *obj, const char *key, int d);
-int64_t json_object_get_int64(
-    struct json_object_s *obj, const char *key, int64_t d);
-double json_object_get_double(
-    struct json_object_s *obj, const char *key, double d);
-const char *json_object_get_string(
-    struct json_object_s *obj, const char *key, const char *d);
-struct json_array_s *json_object_get_array(
-    struct json_object_s *obj, const char *key);
-struct json_object_s *json_object_get_object(
-    struct json_object_s *obj, const char *key);
+JSON_VALUE *JSON_ObjectGetValue(JSON_OBJECT *obj, const char *key);
+int JSON_ObjectGetBool(JSON_OBJECT *obj, const char *key, int d);
+int JSON_ObjectGetInt(JSON_OBJECT *obj, const char *key, int d);
+int64_t JSON_ObjectGetInt64(JSON_OBJECT *obj, const char *key, int64_t d);
+double JSON_ObjectGetDouble(JSON_OBJECT *obj, const char *key, double d);
+const char *JSON_ObjectGetString(
+    JSON_OBJECT *obj, const char *key, const char *d);
+JSON_ARRAY *JSON_ObjectGetArray(JSON_OBJECT *obj, const char *key);
+JSON_OBJECT *JSON_ObjectGetObject(JSON_OBJECT *obj, const char *key);
 
 // values
-struct json_string_s *json_value_as_string(struct json_value_s *value);
-struct json_number_s *json_value_as_number(struct json_value_s *value);
-struct json_object_s *json_value_as_object(struct json_value_s *value);
-struct json_array_s *json_value_as_array(struct json_value_s *value);
-int json_value_is_true(const struct json_value_s *value);
-int json_value_is_false(const struct json_value_s *value);
-int json_value_is_null(const struct json_value_s *value);
+JSON_STRING *JSON_ValueAsString(JSON_VALUE *value);
+JSON_NUMBER *JSON_ValueAsNumber(JSON_VALUE *value);
+JSON_OBJECT *JSON_ValueAsObject(JSON_VALUE *value);
+JSON_ARRAY *JSON_ValueAsArray(JSON_VALUE *value);
+int JSON_ValueIsTrue(const JSON_VALUE *value);
+int JSON_ValueIsFalse(const JSON_VALUE *value);
+int JSON_ValueIsNull(const JSON_VALUE *value);
 
-struct json_value_s *json_value_from_bool(int b);
-struct json_value_s *json_value_from_number(struct json_number_s *num);
-struct json_value_s *json_value_from_string(struct json_string_s *str);
-struct json_value_s *json_value_from_array(struct json_array_s *arr);
-struct json_value_s *json_value_from_object(struct json_object_s *obj);
+JSON_VALUE *JSON_ValueFromBool(int b);
+JSON_VALUE *JSON_ValueFromNumber(JSON_NUMBER *num);
+JSON_VALUE *JSON_ValueFromString(JSON_STRING *str);
+JSON_VALUE *JSON_ValueFromArray(JSON_ARRAY *arr);
+JSON_VALUE *JSON_ValueFromObject(JSON_OBJECT *obj);
 
-void json_value_free(struct json_value_s *value);
+void JSON_ValueFree(JSON_VALUE *value);
 
 typedef enum {
-    json_parse_error_none = 0,
-    json_parse_error_expected_comma_or_closing_bracket,
-    json_parse_error_expected_colon,
-    json_parse_error_expected_opening_quote,
-    json_parse_error_invalid_string_escape_sequence,
-    json_parse_error_invalid_number_format,
-    json_parse_error_invalid_value,
-    json_parse_error_premature_end_of_buffer,
-    json_parse_error_invalid_string,
-    json_parse_error_allocator_failed,
-    json_parse_error_unexpected_trailing_characters,
-    json_parse_error_unknown
-} json_parse_error_e;
+    JSON_PARSE_ERROR_NONE = 0,
+    JSON_PARSE_ERROR_EXPECTED_COMMA_OR_CLOSING_BRACKET,
+    JSON_PARSE_ERROR_EXPECTED_COLON,
+    JSON_PARSE_ERROR_EXPECTED_OPENING_QUOTE,
+    JSON_PARSE_ERROR_INVALID_STRING_ESCAPE_SEQUENCE,
+    JSON_PARSE_ERROR_INVALID_NUMBER_FORMAT,
+    JSON_PARSE_ERROR_INVALID_VALUE,
+    JSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER,
+    JSON_PARSE_ERROR_INVALID_STRING,
+    JSON_PARSE_ERROR_ALLOCATOR_FAILED,
+    JSON_PARSE_ERROR_UNEXPECTED_TRAILING_CHARACTERS,
+    JSON_PARSE_ERROR_UNKNOWN
+} JSON_PARSE_ERROR;
 
-struct json_parse_result_s {
+typedef struct {
     size_t error;
     size_t error_offset;
     size_t error_line_no;
     size_t error_row_no;
-};
+} JSON_PARSE_RESULT;
 
 typedef enum {
-    json_parse_flags_default = 0,
+    JSON_PARSE_FLAGS_DEFAULT = 0,
 
     /* allow trailing commas in objects and arrays. For example, both [true,]
        and
        {"a" : null,} would be allowed with this option on. */
-    json_parse_flags_allow_trailing_comma = 0x1,
+    JSON_PARSE_FLAGS_ALLOW_TRAILING_COMMA = 0x1,
 
     /* allow unquoted keys for objects. For example, {a : null} would be allowed
        with this option on. */
-    json_parse_flags_allow_unquoted_keys = 0x2,
+    JSON_PARSE_FLAGS_ALLOW_UNQUOTED_KEYS = 0x2,
 
     /* allow a global unbracketed object. For example, a : null, b : true, c :
        {} would be allowed with this option on. */
-    json_parse_flags_allow_global_object = 0x4,
+    JSON_PARSE_FLAGS_ALLOW_GLOBAL_OBJECT = 0x4,
 
     /* allow objects to use '=' instead of ':' between key/value pairs. For
        example, a = null, b : true would be allowed with this option on. */
-    json_parse_flags_allow_equals_in_object = 0x8,
+    JSON_PARSE_FLAGS_ALLOW_EQUALS_IN_OBJECT = 0x8,
 
     /* allow that objects don't have to have comma separators between key/value
        pairs. */
-    json_parse_flags_allow_no_commas = 0x10,
+    JSON_PARSE_FLAGS_ALLOW_NO_COMMAS = 0x10,
 
     /* allow c-style comments (either variants) to be ignored in the input JSON
        file. */
-    json_parse_flags_allow_c_style_comments = 0x20,
+    JSON_PARSE_FLAGS_ALLOW_C_STYLE_COMMENTS = 0x20,
 
     /* deprecated flag, unused. */
-    json_parse_flags_deprecated = 0x40,
+    JSON_PARSE_FLAGS_DEPRECATED = 0x40,
 
     /* record location information for each value. */
-    json_parse_flags_allow_location_information = 0x80,
+    JSON_PARSE_FLAGS_ALLOW_LOCATION_INFORMATION = 0x80,
 
     /* allow strings to be 'single quoted'. */
-    json_parse_flags_allow_single_quoted_strings = 0x100,
+    JSON_PARSE_FLAGS_ALLOW_SINGLE_QUOTED_STRINGS = 0x100,
 
     /* allow numbers to be hexadecimal. */
-    json_parse_flags_allow_hexadecimal_numbers = 0x200,
+    JSON_PARSE_FLAGS_ALLOW_HEXADECIMAL_NUMBERS = 0x200,
 
     /* allow numbers like +123 to be parsed. */
-    json_parse_flags_allow_leading_plus_sign = 0x400,
+    JSON_PARSE_FLAGS_ALLOW_LEADING_PLUS_SIGN = 0x400,
 
     /* allow numbers like .0123 or 123. to be parsed. */
-    json_parse_flags_allow_leading_or_trailing_decimal_point = 0x800,
+    JSON_PARSE_FLAGS_ALLOW_LEADING_OR_TRAILING_DECIMAL_POINT = 0x800,
 
     /* allow Infinity, -Infinity, NaN, -NaN. */
-    json_parse_flags_allow_inf_and_nan = 0x1000,
+    JSON_PARSE_FLAGS_ALLOW_INF_AND_NAN = 0x1000,
 
     /* allow multi line string values. */
-    json_parse_flags_allow_multi_line_strings = 0x2000,
+    JSON_PARSE_FLAGS_ALLOW_MULTI_LINE_STRINGS = 0x2000,
 
     /* allow simplified JSON to be parsed. Simplified JSON is an enabling of a
        set of other parsing options. */
-    json_parse_flags_allow_simplified_json =
-        (json_parse_flags_allow_trailing_comma
-         | json_parse_flags_allow_unquoted_keys
-         | json_parse_flags_allow_global_object
-         | json_parse_flags_allow_equals_in_object
-         | json_parse_flags_allow_no_commas),
+    JSON_PARSE_FLAGS_ALLOW_SIMPLIFIED_JSON =
+        (JSON_PARSE_FLAGS_ALLOW_TRAILING_COMMA
+         | JSON_PARSE_FLAGS_ALLOW_UNQUOTED_KEYS
+         | JSON_PARSE_FLAGS_ALLOW_GLOBAL_OBJECT
+         | JSON_PARSE_FLAGS_ALLOW_EQUALS_IN_OBJECT
+         | JSON_PARSE_FLAGS_ALLOW_NO_COMMAS),
 
     /* allow JSON5 to be parsed. JSON5 is an enabling of a set of other parsing
        options. */
-    json_parse_flags_allow_json5 =
-        (json_parse_flags_allow_trailing_comma
-         | json_parse_flags_allow_unquoted_keys
-         | json_parse_flags_allow_c_style_comments
-         | json_parse_flags_allow_single_quoted_strings
-         | json_parse_flags_allow_hexadecimal_numbers
-         | json_parse_flags_allow_leading_plus_sign
-         | json_parse_flags_allow_leading_or_trailing_decimal_point
-         | json_parse_flags_allow_inf_and_nan
-         | json_parse_flags_allow_multi_line_strings)
-} json_parse_flags_e;
+    JSON_PARSE_FLAGS_ALLOW_JSON5 =
+        (JSON_PARSE_FLAGS_ALLOW_TRAILING_COMMA
+         | JSON_PARSE_FLAGS_ALLOW_UNQUOTED_KEYS
+         | JSON_PARSE_FLAGS_ALLOW_C_STYLE_COMMENTS
+         | JSON_PARSE_FLAGS_ALLOW_SINGLE_QUOTED_STRINGS
+         | JSON_PARSE_FLAGS_ALLOW_HEXADECIMAL_NUMBERS
+         | JSON_PARSE_FLAGS_ALLOW_LEADING_PLUS_SIGN
+         | JSON_PARSE_FLAGS_ALLOW_LEADING_OR_TRAILING_DECIMAL_POINT
+         | JSON_PARSE_FLAGS_ALLOW_INF_AND_NAN
+         | JSON_PARSE_FLAGS_ALLOW_MULTI_LINE_STRINGS)
+} JSON_PARSE_FLAGS;
 
 /* Parse a JSON text file, returning a pointer to the root of the JSON
- * structure. json_parse performs 1 call to malloc for the entire encoding.
+ * structure. JSON_Parse performs 1 call to malloc for the entire encoding.
  * Returns 0 if an error occurred (malformed JSON input, or malloc failed). */
-struct json_value_s *json_parse(const void *src, size_t src_size);
+JSON_VALUE *JSON_Parse(const void *src, size_t src_size);
 
 /* Parse a JSON text file, returning a pointer to the root of the JSON
- * structure. json_parse performs 1 call to alloc_func_ptr for the entire
+ * structure. JSON_Parse performs 1 call to alloc_func_ptr for the entire
  * encoding. Returns 0 if an error occurred (malformed JSON input, or malloc
  * failed). If an error occurred, the result struct (if not NULL) will explain
  * the type of error, and the location in the input it occurred. If
  * alloc_func_ptr is null then malloc is used. */
-struct json_value_s *json_parse_ex(
+JSON_VALUE *JSON_ParseEx(
     const void *src, size_t src_size, size_t flags_bitset,
     void *(*alloc_func_ptr)(void *, size_t), void *user_data,
-    struct json_parse_result_s *result);
+    JSON_PARSE_RESULT *result);
 
-const char *json_get_error_description(json_parse_error_e error);
+const char *JSON_GetErrorDescription(JSON_PARSE_ERROR error);
 
 /* Write out a minified JSON utf-8 string. This string is an encoding of the
  * minimal string characters required to still encode the same data.
  * json_write_minified performs 1 call to malloc for the entire encoding. Return
  * 0 if an error occurred (malformed JSON input, or malloc failed). The out_size
  * parameter is optional as the utf-8 string is null terminated. */
-void *json_write_minified(const struct json_value_s *value, size_t *out_size);
+void *JSON_WriteMinified(const JSON_VALUE *value, size_t *out_size);
 
 /* Write out a pretty JSON utf-8 string. This string is encoded such that the
  * resultant JSON is pretty in that it is easily human readable. The indent and
@@ -303,6 +286,6 @@ void *json_write_minified(const struct json_value_s *value, size_t *out_size);
  * json_write_pretty performs 1 call to malloc for the entire encoding. Return 0
  * if an error occurred (malformed JSON input, or malloc failed). The out_size
  * parameter is optional as the utf-8 string is null terminated. */
-void *json_write_pretty(
-    const struct json_value_s *value, const char *indent, const char *newline,
+void *JSON_WritePretty(
+    const JSON_VALUE *value, const char *indent, const char *newline,
     size_t *out_size);

--- a/src/engine/audio_sample.c
+++ b/src/engine/audio_sample.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <time.h>
 
-typedef struct AUDIO_SAMPLE {
+typedef struct {
     char *original_data;
     size_t original_size;
 
@@ -33,7 +33,7 @@ typedef struct AUDIO_SAMPLE {
     int32_t num_samples;
 } AUDIO_SAMPLE;
 
-typedef struct AUDIO_SAMPLE_SOUND {
+typedef struct {
     bool is_used;
     bool is_looped;
     bool is_playing;
@@ -50,7 +50,7 @@ typedef struct AUDIO_SAMPLE_SOUND {
     AUDIO_SAMPLE *sample;
 } AUDIO_SAMPLE_SOUND;
 
-typedef struct AUDIO_AV_BUFFER {
+typedef struct {
     const char *data;
     const char *ptr;
     int32_t size;

--- a/src/engine/audio_stream.c
+++ b/src/engine/audio_stream.c
@@ -28,7 +28,7 @@
 #define READ_BUFFER_SIZE                                                       \
     (AUDIO_SAMPLES * AUDIO_WORKING_CHANNELS * sizeof(AUDIO_WORKING_FORMAT))
 
-typedef struct AUDIO_STREAM_SOUND {
+typedef struct {
     bool is_used;
     bool is_playing;
     bool is_read_done;

--- a/src/game/console/cmd/config.c
+++ b/src/game/console/cmd/config.c
@@ -227,7 +227,10 @@ COMMAND_RESULT Console_Cmd_Config_Helper(
         if (M_GetCurrentValue(option, cur_value, 128)) {
             Console_Log(GS(OSD_CONFIG_OPTION_GET), normalized_name, cur_value);
             result = CR_SUCCESS;
+        } else {
+            result = CR_FAILURE;
         }
+        return result;
     }
 
     if (M_SetCurrentValue(option, new_value)) {

--- a/src/game/console/cmd/die.c
+++ b/src/game/console/cmd/die.c
@@ -6,11 +6,16 @@
 #include "game/objects/common.h"
 #include "game/objects/ids.h"
 #include "game/sound.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
     if (!Object_GetObject(O_LARA)->loaded) {
         return CR_UNAVAILABLE;
     }

--- a/src/game/console/cmd/die.c
+++ b/src/game/console/cmd/die.c
@@ -21,7 +21,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    ITEM_INFO *const lara_item = Lara_GetItem();
+    ITEM *const lara_item = Lara_GetItem();
     if (lara_item->hit_points <= 0) {
         return CR_UNAVAILABLE;
     }

--- a/src/game/console/cmd/end_level.c
+++ b/src/game/console/cmd/end_level.c
@@ -7,7 +7,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
-    if (!String_Equivalent(ctx->args, "")) {
+    if (!String_IsEmpty(ctx->args)) {
         return CR_BAD_INVOCATION;
     }
 

--- a/src/game/console/cmd/exit_game.c
+++ b/src/game/console/cmd/exit_game.c
@@ -1,11 +1,16 @@
 #include "game/console/cmd/exit_game.h"
 
 #include "game/gameflow/common.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
     Gameflow_OverrideCommand((GAMEFLOW_COMMAND) { .action = GF_EXIT_GAME });
     return CR_SUCCESS;
 }

--- a/src/game/console/cmd/exit_to_title.c
+++ b/src/game/console/cmd/exit_to_title.c
@@ -1,11 +1,16 @@
 #include "game/console/cmd/exit_to_title.h"
 
 #include "game/gameflow/common.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
     Gameflow_OverrideCommand((GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE });
     return CR_SUCCESS;
 }

--- a/src/game/console/cmd/fly.c
+++ b/src/game/console/cmd/fly.c
@@ -3,6 +3,8 @@
 #include "game/game.h"
 #include "game/game_string.h"
 #include "game/lara/cheat.h"
+#include "game/lara/common.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
@@ -11,7 +13,27 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     if (!Game_IsPlayable()) {
         return CR_UNAVAILABLE;
     }
-    Lara_Cheat_EnterFlyMode();
+
+    bool enable;
+    if (String_ParseBool(ctx->args, &enable)) {
+        if (enable) {
+            Lara_Cheat_EnterFlyMode();
+        } else {
+            Lara_Cheat_ExitFlyMode();
+        }
+        return CR_SUCCESS;
+    }
+
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (lara->water_status == LWS_CHEAT) {
+        Lara_Cheat_ExitFlyMode();
+    } else {
+        Lara_Cheat_EnterFlyMode();
+    }
     return CR_SUCCESS;
 }
 

--- a/src/game/console/cmd/give_item.c
+++ b/src/game/console/cmd/give_item.c
@@ -49,7 +49,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         args++;
     }
 
-    if (String_Equivalent(args, "")) {
+    if (String_IsEmpty(ctx->args)) {
         return CR_BAD_INVOCATION;
     }
 

--- a/src/game/console/cmd/heal.c
+++ b/src/game/console/cmd/heal.c
@@ -5,11 +5,16 @@
 #include "game/lara/common.h"
 #include "game/lara/const.h"
 #include "game/lara/misc.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
     if (!Game_IsPlayable()) {
         return CR_UNAVAILABLE;
     }

--- a/src/game/console/cmd/heal.c
+++ b/src/game/console/cmd/heal.c
@@ -19,7 +19,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_UNAVAILABLE;
     }
 
-    ITEM_INFO *const lara_item = Lara_GetItem();
+    ITEM *const lara_item = Lara_GetItem();
     if (lara_item->hit_points == LARA_MAX_HITPOINTS) {
         Console_Log(GS(OSD_HEAL_ALREADY_FULL_HP));
         return CR_SUCCESS;

--- a/src/game/console/cmd/kill.c
+++ b/src/game/console/cmd/kill.c
@@ -30,7 +30,7 @@ static COMMAND_RESULT M_KillAllEnemies(void)
 {
     int32_t num_killed = 0;
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
-        const ITEM_INFO *const item = Item_Get(item_num);
+        const ITEM *const item = Item_Get(item_num);
         if (!Creature_IsEnemy(item)) {
             continue;
         }
@@ -57,8 +57,8 @@ static COMMAND_RESULT M_KillNearestEnemies(void)
             break;
         }
 
-        const ITEM_INFO *const lara_item = Lara_GetItem();
-        const ITEM_INFO *const item = Item_Get(best_item_num);
+        const ITEM *const lara_item = Lara_GetItem();
+        const ITEM *const item = Item_Get(best_item_num);
         const int32_t distance = Item_GetDistance(item, &lara_item->pos);
         found |= Lara_Cheat_KillEnemy(best_item_num);
         if (distance >= WALL_L) {
@@ -84,7 +84,7 @@ static COMMAND_RESULT M_KillEnemyType(const char *const enemy_name)
         Object_IdsFromName(enemy_name, &match_count, M_CanTargetObjectCreature);
 
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
-        const ITEM_INFO *const item = Item_Get(item_num);
+        const ITEM *const item = Item_Get(item_num);
 
         bool is_matched = false;
         for (int32_t i = 0; i < match_count; i++) {

--- a/src/game/console/cmd/kill.c
+++ b/src/game/console/cmd/kill.c
@@ -15,6 +15,9 @@
 #include "strings.h"
 
 static bool M_CanTargetObjectCreature(GAME_OBJECT_ID object_id);
+static COMMAND_RESULT M_KillAllEnemies(void);
+static COMMAND_RESULT M_KillNearestEnemies(void);
+static COMMAND_RESULT M_KillEnemyType(const char *enemy_name);
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static bool M_CanTargetObjectCreature(const GAME_OBJECT_ID object_id)
@@ -23,100 +26,107 @@ static bool M_CanTargetObjectCreature(const GAME_OBJECT_ID object_id)
         || Object_IsObjectType(object_id, g_AllyObjects);
 }
 
+static COMMAND_RESULT M_KillAllEnemies(void)
+{
+    int32_t num_killed = 0;
+    for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
+        const ITEM_INFO *const item = Item_Get(item_num);
+        if (!Creature_IsEnemy(item)) {
+            continue;
+        }
+        if (Lara_Cheat_KillEnemy(item_num)) {
+            num_killed++;
+        }
+    }
+
+    if (num_killed == 0) {
+        Console_Log(GS(OSD_KILL_ALL_FAIL));
+        return CR_FAILURE;
+    }
+
+    Console_Log(GS(OSD_KILL_ALL), num_killed);
+    return CR_SUCCESS;
+}
+
+static COMMAND_RESULT M_KillNearestEnemies(void)
+{
+    bool found = false;
+    while (true) {
+        const int16_t best_item_num = Lara_GetNearestEnemy();
+        if (best_item_num == NO_ITEM) {
+            break;
+        }
+
+        const ITEM_INFO *const lara_item = Lara_GetItem();
+        const ITEM_INFO *const item = Item_Get(best_item_num);
+        const int32_t distance = Item_GetDistance(item, &lara_item->pos);
+        found |= Lara_Cheat_KillEnemy(best_item_num);
+        if (distance >= WALL_L) {
+            break;
+        }
+    }
+
+    if (!found) {
+        Console_Log(GS(OSD_KILL_FAIL));
+        return CR_FAILURE;
+    }
+
+    Console_Log(GS(OSD_KILL));
+    return CR_SUCCESS;
+}
+
+static COMMAND_RESULT M_KillEnemyType(const char *const enemy_name)
+{
+    bool matches_found = false;
+    int32_t num_killed = 0;
+    int32_t match_count = 0;
+    GAME_OBJECT_ID *matching_objs =
+        Object_IdsFromName(enemy_name, &match_count, M_CanTargetObjectCreature);
+
+    for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
+        const ITEM_INFO *const item = Item_Get(item_num);
+
+        bool is_matched = false;
+        for (int32_t i = 0; i < match_count; i++) {
+            if (matching_objs[i] == item->object_id) {
+                is_matched = true;
+                break;
+            }
+        }
+        if (!is_matched) {
+            continue;
+        }
+        matches_found = true;
+
+        if (Lara_Cheat_KillEnemy(item_num)) {
+            num_killed++;
+        }
+    }
+    Memory_FreePointer(&matching_objs);
+
+    if (!matches_found) {
+        Console_Log(GS(OSD_INVALID_OBJECT), enemy_name);
+        return CR_FAILURE;
+    }
+    if (num_killed == 0) {
+        Console_Log(GS(OSD_OBJECT_NOT_FOUND), enemy_name);
+        return CR_FAILURE;
+    }
+    Console_Log(GS(OSD_KILL_ALL), num_killed);
+    return CR_SUCCESS;
+}
+
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
-    // kill all the enemies in the level
     if (String_Equivalent(ctx->args, "all")) {
-        int32_t num_killed = 0;
-        for (int16_t item_num = 0; item_num < Item_GetTotalCount();
-             item_num++) {
-            const ITEM_INFO *const item = Item_Get(item_num);
-            if (!Creature_IsEnemy(item)) {
-                continue;
-            }
-            if (Lara_Cheat_KillEnemy(item_num)) {
-                num_killed++;
-            }
-        }
-
-        if (num_killed == 0) {
-            Console_Log(GS(OSD_KILL_ALL_FAIL));
-            return CR_FAILURE;
-        }
-
-        Console_Log(GS(OSD_KILL_ALL), num_killed);
-        return CR_SUCCESS;
+        return M_KillAllEnemies();
     }
 
-    // kill all the enemies around Lara within one tile, or a single nearest
-    // enemy
-    if (String_Equivalent(ctx->args, "")) {
-        bool found = false;
-        while (true) {
-            const int16_t best_item_num = Lara_GetNearestEnemy();
-            if (best_item_num == NO_ITEM) {
-                break;
-            }
-
-            const ITEM_INFO *const lara_item = Lara_GetItem();
-            const ITEM_INFO *const item = Item_Get(best_item_num);
-            const int32_t distance = Item_GetDistance(item, &lara_item->pos);
-            found |= Lara_Cheat_KillEnemy(best_item_num);
-            if (distance >= WALL_L) {
-                break;
-            }
-        }
-
-        if (!found) {
-            Console_Log(GS(OSD_KILL_FAIL));
-            return CR_FAILURE;
-        }
-
-        Console_Log(GS(OSD_KILL));
-        return CR_SUCCESS;
+    if (String_IsEmpty(ctx->args)) {
+        return M_KillNearestEnemies();
     }
 
-    // kill a single enemy type
-    {
-        bool matches_found = false;
-        int32_t num_killed = 0;
-        int32_t match_count = 0;
-        GAME_OBJECT_ID *matching_objs = Object_IdsFromName(
-            ctx->args, &match_count, M_CanTargetObjectCreature);
-
-        for (int16_t item_num = 0; item_num < Item_GetTotalCount();
-             item_num++) {
-            const ITEM_INFO *const item = Item_Get(item_num);
-
-            bool is_matched = false;
-            for (int32_t i = 0; i < match_count; i++) {
-                if (matching_objs[i] == item->object_id) {
-                    is_matched = true;
-                    break;
-                }
-            }
-            if (!is_matched) {
-                continue;
-            }
-            matches_found = true;
-
-            if (Lara_Cheat_KillEnemy(item_num)) {
-                num_killed++;
-            }
-        }
-        Memory_FreePointer(&matching_objs);
-
-        if (!matches_found) {
-            Console_Log(GS(OSD_INVALID_OBJECT), ctx->args);
-            return CR_FAILURE;
-        }
-        if (num_killed == 0) {
-            Console_Log(GS(OSD_OBJECT_NOT_FOUND), ctx->args);
-            return CR_FAILURE;
-        }
-        Console_Log(GS(OSD_KILL_ALL), num_killed);
-        return CR_SUCCESS;
-    }
+    return M_KillEnemyType(ctx->args);
 }
 
 CONSOLE_COMMAND g_Console_Cmd_Kill = {

--- a/src/game/console/cmd/play_demo.c
+++ b/src/game/console/cmd/play_demo.c
@@ -1,11 +1,16 @@
 #include "game/console/cmd/play_demo.h"
 
 #include "game/gameflow/common.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
     Gameflow_OverrideCommand((GAMEFLOW_COMMAND) { .action = GF_START_DEMO });
     return CR_SUCCESS;
 }

--- a/src/game/console/cmd/pos.c
+++ b/src/game/console/cmd/pos.c
@@ -5,11 +5,16 @@
 #include "game/game_string.h"
 #include "game/lara/common.h"
 #include "game/objects/common.h"
+#include "strings.h"
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
     const OBJECT_INFO *const object = Object_GetObject(O_LARA);
     if (!object->loaded) {
         return CR_UNAVAILABLE;

--- a/src/game/console/cmd/pos.c
+++ b/src/game/console/cmd/pos.c
@@ -15,12 +15,12 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_BAD_INVOCATION;
     }
 
-    const OBJECT_INFO *const object = Object_GetObject(O_LARA);
+    const OBJECT *const object = Object_GetObject(O_LARA);
     if (!object->loaded) {
         return CR_UNAVAILABLE;
     }
 
-    const ITEM_INFO *const lara_item = Lara_GetItem();
+    const ITEM *const lara_item = Lara_GetItem();
 
     // clang-format off
     Console_Log(

--- a/src/game/console/cmd/set_health.c
+++ b/src/game/console/cmd/set_health.c
@@ -17,7 +17,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_UNAVAILABLE;
     }
 
-    ITEM_INFO *const lara_item = Lara_GetItem();
+    ITEM *const lara_item = Lara_GetItem();
     if (String_IsEmpty(ctx->args)) {
         Console_Log(GS(OSD_CURRENT_HEALTH_GET), lara_item->hit_points);
         return CR_SUCCESS;

--- a/src/game/console/cmd/teleport.c
+++ b/src/game/console/cmd/teleport.c
@@ -63,20 +63,12 @@ static COMMAND_RESULT M_TeleportToRoom(const int16_t room_num)
     }
 
     const ROOM *const room = Room_Get(room_num);
-#if TR_VERSION == 1
-    const int32_t rx = room->x;
-    const int32_t rz = room->z;
-#elif TR_VERSION == 2
-    const int32_t rx = room->pos.x;
-    const int32_t rz = room->pos.z;
-#endif
-
-    const int32_t x1 = rx + WALL_L;
-    const int32_t x2 = rx + (room->x_size << WALL_SHIFT) - WALL_L;
+    const int32_t x1 = room->pos.x + WALL_L;
+    const int32_t x2 = room->pos.x + (room->size.x << WALL_SHIFT) - WALL_L;
     const int32_t y1 = room->min_floor;
     const int32_t y2 = room->max_ceiling;
-    const int32_t z1 = rz + WALL_L;
-    const int32_t z2 = rz + (room->z_size << WALL_SHIFT) - WALL_L;
+    const int32_t z1 = room->pos.z + WALL_L;
+    const int32_t z2 = room->pos.z + (room->size.z << WALL_SHIFT) - WALL_L;
 
     bool success = false;
     for (int32_t i = 0; i < 100; i++) {

--- a/src/game/console/cmd/teleport.c
+++ b/src/game/console/cmd/teleport.c
@@ -62,7 +62,7 @@ static COMMAND_RESULT M_TeleportToRoom(const int16_t room_num)
         return CR_FAILURE;
     }
 
-    const ROOM_INFO *const room = Room_Get(room_num);
+    const ROOM *const room = Room_Get(room_num);
 #if TR_VERSION == 1
     const int32_t rx = room->x;
     const int32_t rz = room->z;
@@ -109,12 +109,12 @@ static COMMAND_RESULT M_TeleportToObject(const char *const user_input)
     GAME_OBJECT_ID *matching_objs =
         Object_IdsFromName(user_input, &match_count, M_CanTargetObject);
 
-    const ITEM_INFO *const lara_item = Lara_GetItem();
-    const ITEM_INFO *best_item = NULL;
+    const ITEM *const lara_item = Lara_GetItem();
+    const ITEM *best_item = NULL;
     int32_t best_distance = INT32_MAX;
 
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
-        const ITEM_INFO *const item = Item_Get(item_num);
+        const ITEM *const item = Item_Get(item_num);
         if (Object_IsObjectType(item->object_id, g_PickupObjects)
             && (item->status == IS_INVISIBLE || item->status == IS_DEACTIVATED
                 || item->room_num == NO_ROOM)) {
@@ -168,7 +168,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_UNAVAILABLE;
     }
 
-    const ITEM_INFO *const lara_item = Lara_GetItem();
+    const ITEM *const lara_item = Lara_GetItem();
     if (!lara_item->hit_points) {
         return CR_UNAVAILABLE;
     }

--- a/src/game/console/cmd/teleport.c
+++ b/src/game/console/cmd/teleport.c
@@ -173,13 +173,11 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_UNAVAILABLE;
     }
 
-    // X Y Z
     float x, y, z;
     if (sscanf(ctx->args, "%f %f %f", &x, &y, &z) == 3) {
         return M_TeleportToXYZ(x, y, z);
     }
 
-    // Room number
     int16_t room_num = -1;
     if (sscanf(ctx->args, "%hd", &room_num) == 1) {
         return M_TeleportToRoom(room_num);

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -4,7 +4,7 @@
 #include "utils.h"
 
 void Item_TakeDamage(
-    ITEM_INFO *const item, const int16_t damage, const bool hit_status)
+    ITEM *const item, const int16_t damage, const bool hit_status)
 {
 #if TR_VERSION == 1
     if (item->hit_points == DONT_TARGET) {

--- a/src/gfx/2d/2d_renderer.c
+++ b/src/gfx/2d/2d_renderer.c
@@ -6,7 +6,7 @@
 
 #include <assert.h>
 
-void GFX_2D_Renderer_Init(GFX_2D_Renderer *renderer)
+void GFX_2D_Renderer_Init(GFX_2D_RENDERER *renderer)
 {
     LOG_INFO("");
     assert(renderer);
@@ -47,7 +47,7 @@ void GFX_2D_Renderer_Init(GFX_2D_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
-void GFX_2D_Renderer_Close(GFX_2D_Renderer *renderer)
+void GFX_2D_Renderer_Close(GFX_2D_RENDERER *renderer)
 {
     LOG_INFO("");
     assert(renderer);
@@ -60,7 +60,7 @@ void GFX_2D_Renderer_Close(GFX_2D_Renderer *renderer)
 }
 
 void GFX_2D_Renderer_Upload(
-    GFX_2D_Renderer *renderer, GFX_2D_SurfaceDesc *desc, const uint8_t *data)
+    GFX_2D_RENDERER *renderer, GFX_2D_SURFACE_DESC *desc, const uint8_t *data)
 {
     const uint32_t width = desc->width;
     const uint32_t height = desc->height;
@@ -85,7 +85,7 @@ void GFX_2D_Renderer_Upload(
     }
 }
 
-void GFX_2D_Renderer_Render(GFX_2D_Renderer *renderer)
+void GFX_2D_Renderer_Render(GFX_2D_RENDERER *renderer)
 {
     GFX_GL_Program_Bind(&renderer->program);
     GFX_GL_Buffer_Bind(&renderer->surface_buffer);

--- a/src/gfx/2d/2d_surface.c
+++ b/src/gfx/2d/2d_surface.c
@@ -7,16 +7,16 @@
 #include <assert.h>
 #include <string.h>
 
-GFX_2D_Surface *GFX_2D_Surface_Create(const GFX_2D_SurfaceDesc *desc)
+GFX_2D_SURFACE *GFX_2D_Surface_Create(const GFX_2D_SURFACE_DESC *desc)
 {
-    GFX_2D_Surface *surface = Memory_Alloc(sizeof(GFX_2D_Surface));
+    GFX_2D_SURFACE *surface = Memory_Alloc(sizeof(GFX_2D_SURFACE));
     GFX_2D_Surface_Init(surface, desc);
     return surface;
 }
 
-GFX_2D_Surface *GFX_2D_Surface_CreateFromImage(const IMAGE *image)
+GFX_2D_SURFACE *GFX_2D_Surface_CreateFromImage(const IMAGE *image)
 {
-    GFX_2D_Surface *surface = Memory_Alloc(sizeof(GFX_2D_Surface));
+    GFX_2D_SURFACE *surface = Memory_Alloc(sizeof(GFX_2D_SURFACE));
     surface->is_locked = false;
     surface->is_dirty = true;
     surface->desc.width = image->width;
@@ -33,7 +33,7 @@ GFX_2D_Surface *GFX_2D_Surface_CreateFromImage(const IMAGE *image)
     return surface;
 }
 
-void GFX_2D_Surface_Free(GFX_2D_Surface *surface)
+void GFX_2D_Surface_Free(GFX_2D_SURFACE *surface)
 {
     if (surface) {
         GFX_2D_Surface_Close(surface);
@@ -42,13 +42,13 @@ void GFX_2D_Surface_Free(GFX_2D_Surface *surface)
 }
 
 void GFX_2D_Surface_Init(
-    GFX_2D_Surface *surface, const GFX_2D_SurfaceDesc *desc)
+    GFX_2D_SURFACE *surface, const GFX_2D_SURFACE_DESC *desc)
 {
     surface->is_locked = false;
     surface->is_dirty = false;
     surface->desc = *desc;
 
-    GFX_2D_SurfaceDesc display_desc = {
+    GFX_2D_SURFACE_DESC display_desc = {
         .bit_count = 32,
         .width = GFX_Context_GetDisplayWidth(),
         .height = GFX_Context_GetDisplayHeight(),
@@ -76,12 +76,12 @@ void GFX_2D_Surface_Init(
     surface->desc.pixels = NULL;
 }
 
-void GFX_2D_Surface_Close(GFX_2D_Surface *surface)
+void GFX_2D_Surface_Close(GFX_2D_SURFACE *surface)
 {
     Memory_FreePointer(&surface->buffer);
 }
 
-bool GFX_2D_Surface_Clear(GFX_2D_Surface *surface)
+bool GFX_2D_Surface_Clear(GFX_2D_SURFACE *surface)
 {
     if (surface->is_locked) {
         LOG_ERROR("Surface is locked");
@@ -93,7 +93,7 @@ bool GFX_2D_Surface_Clear(GFX_2D_Surface *surface)
     return true;
 }
 
-bool GFX_2D_Surface_Lock(GFX_2D_Surface *surface, GFX_2D_SurfaceDesc *out_desc)
+bool GFX_2D_Surface_Lock(GFX_2D_SURFACE *surface, GFX_2D_SURFACE_DESC *out_desc)
 {
     assert(surface != NULL);
     if (surface->is_locked) {
@@ -112,7 +112,7 @@ bool GFX_2D_Surface_Lock(GFX_2D_Surface *surface, GFX_2D_SurfaceDesc *out_desc)
     return true;
 }
 
-bool GFX_2D_Surface_Unlock(GFX_2D_Surface *surface)
+bool GFX_2D_Surface_Unlock(GFX_2D_SURFACE *surface)
 {
     // ensure that the surface is actually locked
     if (!surface->is_locked) {

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -7,13 +7,13 @@
 #include <assert.h>
 #include <stddef.h>
 
-static void M_SelectTextureImpl(GFX_3D_Renderer *renderer, int texture_num);
+static void M_SelectTextureImpl(GFX_3D_RENDERER *renderer, int texture_num);
 
-static void M_SelectTextureImpl(GFX_3D_Renderer *renderer, int texture_num)
+static void M_SelectTextureImpl(GFX_3D_RENDERER *renderer, int texture_num)
 {
     assert(renderer);
 
-    GFX_GL_Texture *texture = NULL;
+    GFX_GL_TEXTURE *texture = NULL;
     if (texture_num == GFX_ENV_MAP_TEXTURE) {
         texture = renderer->env_map_texture;
     } else if (texture_num != GFX_NO_TEXTURE) {
@@ -32,7 +32,7 @@ static void M_SelectTextureImpl(GFX_3D_Renderer *renderer, int texture_num)
 }
 
 void GFX_3D_Renderer_Init(
-    GFX_3D_Renderer *renderer, const GFX_CONFIG *const config)
+    GFX_3D_RENDERER *renderer, const GFX_CONFIG *const config)
 {
     LOG_INFO("");
     assert(renderer);
@@ -90,7 +90,7 @@ void GFX_3D_Renderer_Init(
     GFX_GL_CheckError();
 }
 
-void GFX_3D_Renderer_Close(GFX_3D_Renderer *renderer)
+void GFX_3D_Renderer_Close(GFX_3D_RENDERER *renderer)
 {
     LOG_INFO("");
     assert(renderer);
@@ -100,7 +100,7 @@ void GFX_3D_Renderer_Close(GFX_3D_Renderer *renderer)
     GFX_GL_Sampler_Close(&renderer->sampler);
 }
 
-void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer)
+void GFX_3D_Renderer_RenderBegin(GFX_3D_RENDERER *renderer)
 {
     assert(renderer);
     glEnable(GL_BLEND);
@@ -141,7 +141,7 @@ void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
-void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer)
+void GFX_3D_Renderer_RenderEnd(GFX_3D_RENDERER *renderer)
 {
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
@@ -149,19 +149,19 @@ void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
-void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer)
+void GFX_3D_Renderer_ClearDepth(GFX_3D_RENDERER *renderer)
 {
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
     glClear(GL_DEPTH_BUFFER_BIT);
     GFX_GL_CheckError();
 }
 
-int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_Renderer *const renderer)
+int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_RENDERER *const renderer)
 {
     assert(renderer != NULL);
     assert(renderer->env_map_texture == NULL);
 
-    GFX_GL_Texture *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
+    GFX_GL_TEXTURE *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
     renderer->env_map_texture = texture;
 
     GFX_3D_Renderer_RestoreTexture(renderer);
@@ -170,11 +170,11 @@ int GFX_3D_Renderer_RegisterEnvironmentMap(GFX_3D_Renderer *const renderer)
 }
 
 bool GFX_3D_Renderer_UnregisterEnvironmentMap(
-    GFX_3D_Renderer *const renderer, const int texture_num)
+    GFX_3D_RENDERER *const renderer, const int texture_num)
 {
     assert(renderer != NULL);
 
-    GFX_GL_Texture *const texture = renderer->env_map_texture;
+    GFX_GL_TEXTURE *const texture = renderer->env_map_texture;
     if (texture == NULL) {
         LOG_ERROR("No environment map registered");
         return false;
@@ -196,11 +196,11 @@ bool GFX_3D_Renderer_UnregisterEnvironmentMap(
     return true;
 }
 
-void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_Renderer *const renderer)
+void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_RENDERER *const renderer)
 {
     assert(renderer != NULL);
 
-    GFX_GL_Texture *const env_map = renderer->env_map_texture;
+    GFX_GL_TEXTURE *const env_map = renderer->env_map_texture;
     if (env_map != NULL) {
         GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
         GFX_GL_Texture_LoadFromBackBuffer(env_map);
@@ -209,11 +209,11 @@ void GFX_3D_Renderer_FillEnvironmentMap(GFX_3D_Renderer *const renderer)
 }
 
 int GFX_3D_Renderer_RegisterTexturePage(
-    GFX_3D_Renderer *renderer, const void *data, int width, int height)
+    GFX_3D_RENDERER *renderer, const void *data, int width, int height)
 {
     assert(renderer);
     assert(data);
-    GFX_GL_Texture *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
+    GFX_GL_TEXTURE *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
     GFX_GL_Texture_Load(texture, data, width, height, GL_RGBA, GL_RGBA);
 
     int texture_num = GFX_NO_TEXTURE;
@@ -232,13 +232,13 @@ int GFX_3D_Renderer_RegisterTexturePage(
 }
 
 bool GFX_3D_Renderer_UnregisterTexturePage(
-    GFX_3D_Renderer *renderer, int texture_num)
+    GFX_3D_RENDERER *renderer, int texture_num)
 {
     assert(renderer);
     assert(texture_num >= 0);
     assert(texture_num < GFX_MAX_TEXTURES);
 
-    GFX_GL_Texture *texture = renderer->textures[texture_num];
+    GFX_GL_TEXTURE *texture = renderer->textures[texture_num];
     if (!texture) {
         LOG_ERROR("Invalid texture handle");
         return false;
@@ -256,7 +256,7 @@ bool GFX_3D_Renderer_UnregisterTexturePage(
 }
 
 void GFX_3D_Renderer_RenderPrimStrip(
-    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count)
+    GFX_3D_RENDERER *renderer, GFX_3D_VERTEX *vertices, int count)
 {
     assert(renderer);
     assert(vertices);
@@ -265,7 +265,7 @@ void GFX_3D_Renderer_RenderPrimStrip(
 }
 
 void GFX_3D_Renderer_RenderPrimFan(
-    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count)
+    GFX_3D_RENDERER *renderer, GFX_3D_VERTEX *vertices, int count)
 {
     assert(renderer);
     assert(vertices);
@@ -273,14 +273,14 @@ void GFX_3D_Renderer_RenderPrimFan(
 }
 
 void GFX_3D_Renderer_RenderPrimList(
-    GFX_3D_Renderer *renderer, GFX_3D_Vertex *vertices, int count)
+    GFX_3D_RENDERER *renderer, GFX_3D_VERTEX *vertices, int count)
 {
     assert(renderer);
     assert(vertices);
     GFX_3D_VertexStream_PushPrimList(&renderer->vertex_stream, vertices, count);
 }
 
-void GFX_3D_Renderer_SelectTexture(GFX_3D_Renderer *renderer, int texture_num)
+void GFX_3D_Renderer_SelectTexture(GFX_3D_RENDERER *renderer, int texture_num)
 {
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
@@ -288,14 +288,14 @@ void GFX_3D_Renderer_SelectTexture(GFX_3D_Renderer *renderer, int texture_num)
     M_SelectTextureImpl(renderer, texture_num);
 }
 
-void GFX_3D_Renderer_RestoreTexture(GFX_3D_Renderer *renderer)
+void GFX_3D_Renderer_RestoreTexture(GFX_3D_RENDERER *renderer)
 {
     assert(renderer);
     M_SelectTextureImpl(renderer, renderer->selected_texture_num);
 }
 
 void GFX_3D_Renderer_SetPrimType(
-    GFX_3D_Renderer *renderer, GFX_3D_PrimType value)
+    GFX_3D_RENDERER *renderer, GFX_3D_PRIM_TYPE value)
 {
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
@@ -303,7 +303,7 @@ void GFX_3D_Renderer_SetPrimType(
 }
 
 void GFX_3D_Renderer_SetTextureFilter(
-    GFX_3D_Renderer *renderer, GFX_TEXTURE_FILTER filter)
+    GFX_3D_RENDERER *renderer, GFX_TEXTURE_FILTER filter)
 {
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
@@ -319,7 +319,7 @@ void GFX_3D_Renderer_SetTextureFilter(
 }
 
 void GFX_3D_Renderer_SetDepthTestEnabled(
-    GFX_3D_Renderer *renderer, bool is_enabled)
+    GFX_3D_RENDERER *renderer, bool is_enabled)
 {
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
@@ -331,26 +331,26 @@ void GFX_3D_Renderer_SetDepthTestEnabled(
 }
 
 void GFX_3D_Renderer_SetBlendingMode(
-    GFX_3D_Renderer *const renderer, const GFX_BlendMode blend_mode)
+    GFX_3D_RENDERER *const renderer, const GFX_BLEND_MODE blend_mode)
 {
     assert(renderer != NULL);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
 
     switch (blend_mode) {
-    case GFX_BlendMode_Off:
+    case GFX_BLEND_MODE_OFF:
         glBlendFunc(GL_ONE, GL_ZERO);
         break;
-    case GFX_BlendMode_Normal:
+    case GFX_BLEND_MODE_NORMAL:
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         break;
-    case GFX_BlendMode_Multiply:
+    case GFX_BLEND_MODE_MULTIPLY:
         glBlendFunc(GL_DST_COLOR, GL_SRC_COLOR);
         break;
     }
 }
 
 void GFX_3D_Renderer_SetTexturingEnabled(
-    GFX_3D_Renderer *renderer, bool is_enabled)
+    GFX_3D_RENDERER *renderer, bool is_enabled)
 {
     assert(renderer);
     GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);

--- a/src/gfx/3d/vertex_stream.c
+++ b/src/gfx/3d/vertex_stream.c
@@ -11,24 +11,24 @@ static const GLenum GL_PRIM_MODES[] = {
 };
 
 static void M_PushVertex(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertex);
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertex);
 
 static void M_PushVertex(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertex)
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertex)
 {
     if (vertex_stream->pending_vertices.count + 1
         >= vertex_stream->pending_vertices.capacity) {
         vertex_stream->pending_vertices.capacity += 1000;
         vertex_stream->pending_vertices.data = Memory_Realloc(
             vertex_stream->pending_vertices.data,
-            vertex_stream->pending_vertices.capacity * sizeof(GFX_3D_Vertex));
+            vertex_stream->pending_vertices.capacity * sizeof(GFX_3D_VERTEX));
     }
 
     vertex_stream->pending_vertices
         .data[vertex_stream->pending_vertices.count++] = *vertex;
 }
 
-void GFX_3D_VertexStream_Init(GFX_3D_VertexStream *vertex_stream)
+void GFX_3D_VertexStream_Init(GFX_3D_VERTEX_STREAM *vertex_stream)
 {
     vertex_stream->prim_type = GFX_3D_PRIM_TRI;
     vertex_stream->buffer_size = 0;
@@ -51,7 +51,7 @@ void GFX_3D_VertexStream_Init(GFX_3D_VertexStream *vertex_stream)
     GFX_GL_CheckError();
 }
 
-void GFX_3D_VertexStream_Close(GFX_3D_VertexStream *vertex_stream)
+void GFX_3D_VertexStream_Close(GFX_3D_VERTEX_STREAM *vertex_stream)
 {
     GFX_GL_VertexArray_Close(&vertex_stream->vtc_format);
     GFX_GL_Buffer_Close(&vertex_stream->buffer);
@@ -59,19 +59,19 @@ void GFX_3D_VertexStream_Close(GFX_3D_VertexStream *vertex_stream)
     Memory_FreePointer(&vertex_stream->pending_vertices.data);
 }
 
-void GFX_3D_VertexStream_Bind(GFX_3D_VertexStream *vertex_stream)
+void GFX_3D_VertexStream_Bind(GFX_3D_VERTEX_STREAM *vertex_stream)
 {
     GFX_GL_Buffer_Bind(&vertex_stream->buffer);
 }
 
 void GFX_3D_VertexStream_SetPrimType(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_PrimType prim_type)
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_PRIM_TYPE prim_type)
 {
     vertex_stream->prim_type = prim_type;
 }
 
 bool GFX_3D_VertexStream_PushPrimStrip(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertices, int count)
 {
     if (vertex_stream->prim_type != GFX_3D_PRIM_TRI) {
         LOG_ERROR("Unsupported prim type: %d", vertex_stream->prim_type);
@@ -95,7 +95,7 @@ bool GFX_3D_VertexStream_PushPrimStrip(
 }
 
 bool GFX_3D_VertexStream_PushPrimFan(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertices, int count)
 {
     if (vertex_stream->prim_type != GFX_3D_PRIM_TRI) {
         LOG_ERROR("Unsupported prim type: %d", vertex_stream->prim_type);
@@ -119,7 +119,7 @@ bool GFX_3D_VertexStream_PushPrimFan(
 }
 
 bool GFX_3D_VertexStream_PushPrimList(
-    GFX_3D_VertexStream *vertex_stream, GFX_3D_Vertex *vertices, int count)
+    GFX_3D_VERTEX_STREAM *vertex_stream, GFX_3D_VERTEX *vertices, int count)
 {
     for (int i = 0; i < count; i++) {
         M_PushVertex(vertex_stream, &vertices[i]);
@@ -127,7 +127,7 @@ bool GFX_3D_VertexStream_PushPrimList(
     return true;
 }
 
-void GFX_3D_VertexStream_RenderPending(GFX_3D_VertexStream *vertex_stream)
+void GFX_3D_VertexStream_RenderPending(GFX_3D_VERTEX_STREAM *vertex_stream)
 {
     if (!vertex_stream->pending_vertices.count) {
         return;
@@ -137,7 +137,7 @@ void GFX_3D_VertexStream_RenderPending(GFX_3D_VertexStream *vertex_stream)
 
     // resize GPU buffer if required
     size_t buffer_size =
-        sizeof(GFX_3D_Vertex) * vertex_stream->pending_vertices.count;
+        sizeof(GFX_3D_VERTEX) * vertex_stream->pending_vertices.count;
     if (buffer_size > vertex_stream->buffer_size) {
         LOG_INFO(
             "Vertex buffer resize: %d -> %d", vertex_stream->buffer_size,

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -12,7 +12,7 @@
 #include <SDL2/SDL_video.h>
 #include <string.h>
 
-typedef struct GFX_CONTEXT {
+typedef struct {
     SDL_GLContext context;
     SDL_Window *window_handle;
 

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -24,9 +24,9 @@ typedef struct {
     int32_t window_height;
 
     char *scheduled_screenshot_path;
-    GFX_Renderer *renderer;
-    GFX_2D_Renderer renderer_2d;
-    GFX_3D_Renderer renderer_3d;
+    GFX_RENDERER *renderer;
+    GFX_2D_RENDERER renderer_2d;
+    GFX_3D_RENDERER renderer_3d;
 } GFX_CONTEXT;
 
 static GFX_CONTEXT m_Context = { 0 };
@@ -318,12 +318,12 @@ void GFX_Context_ClearScheduledScreenshotPath(void)
     Memory_FreePointer(&m_Context.scheduled_screenshot_path);
 }
 
-GFX_2D_Renderer *GFX_Context_GetRenderer2D(void)
+GFX_2D_RENDERER *GFX_Context_GetRenderer2D(void)
 {
     return &m_Context.renderer_2d;
 }
 
-GFX_3D_Renderer *GFX_Context_GetRenderer3D(void)
+GFX_3D_RENDERER *GFX_Context_GetRenderer3D(void)
 {
     return &m_Context.renderer_3d;
 }

--- a/src/gfx/gl/buffer.c
+++ b/src/gfx/gl/buffer.c
@@ -4,7 +4,7 @@
 
 #include <assert.h>
 
-void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target)
+void GFX_GL_Buffer_Init(GFX_GL_BUFFER *buf, GLenum target)
 {
     assert(buf);
     buf->target = target;
@@ -12,14 +12,14 @@ void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target)
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Buffer_Close(GFX_GL_Buffer *buf)
+void GFX_GL_Buffer_Close(GFX_GL_BUFFER *buf)
 {
     assert(buf);
     glDeleteBuffers(1, &buf->id);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Buffer_Bind(GFX_GL_Buffer *buf)
+void GFX_GL_Buffer_Bind(GFX_GL_BUFFER *buf)
 {
     assert(buf);
     glBindBuffer(buf->target, buf->id);
@@ -27,7 +27,7 @@ void GFX_GL_Buffer_Bind(GFX_GL_Buffer *buf)
 }
 
 void GFX_GL_Buffer_Data(
-    GFX_GL_Buffer *buf, GLsizei size, const void *data, GLenum usage)
+    GFX_GL_BUFFER *buf, GLsizei size, const void *data, GLenum usage)
 {
     assert(buf);
     glBufferData(buf->target, size, data, usage);
@@ -35,14 +35,14 @@ void GFX_GL_Buffer_Data(
 }
 
 void GFX_GL_Buffer_SubData(
-    GFX_GL_Buffer *buf, GLsizei offset, GLsizei size, const void *data)
+    GFX_GL_BUFFER *buf, GLsizei offset, GLsizei size, const void *data)
 {
     assert(buf);
     glBufferSubData(buf->target, offset, size, data);
     GFX_GL_CheckError();
 }
 
-void *GFX_GL_Buffer_Map(GFX_GL_Buffer *buf, GLenum access)
+void *GFX_GL_Buffer_Map(GFX_GL_BUFFER *buf, GLenum access)
 {
     assert(buf);
     void *ret = glMapBuffer(buf->target, access);
@@ -50,14 +50,14 @@ void *GFX_GL_Buffer_Map(GFX_GL_Buffer *buf, GLenum access)
     return ret;
 }
 
-void GFX_GL_Buffer_Unmap(GFX_GL_Buffer *buf)
+void GFX_GL_Buffer_Unmap(GFX_GL_BUFFER *buf)
 {
     assert(buf);
     glUnmapBuffer(buf->target);
     GFX_GL_CheckError();
 }
 
-GLint GFX_GL_Buffer_Parameter(GFX_GL_Buffer *buf, GLenum pname)
+GLint GFX_GL_Buffer_Parameter(GFX_GL_BUFFER *buf, GLenum pname)
 {
     assert(buf);
     GLint params = 0;

--- a/src/gfx/gl/program.c
+++ b/src/gfx/gl/program.c
@@ -10,7 +10,7 @@
 #include <stddef.h>
 #include <string.h>
 
-bool GFX_GL_Program_Init(GFX_GL_Program *program)
+bool GFX_GL_Program_Init(GFX_GL_PROGRAM *program)
 {
     assert(program);
     program->id = glCreateProgram();
@@ -22,7 +22,7 @@ bool GFX_GL_Program_Init(GFX_GL_Program *program)
     return true;
 }
 
-void GFX_GL_Program_Close(GFX_GL_Program *program)
+void GFX_GL_Program_Close(GFX_GL_PROGRAM *program)
 {
     if (program->id) {
         glDeleteProgram(program->id);
@@ -31,7 +31,7 @@ void GFX_GL_Program_Close(GFX_GL_Program *program)
     }
 }
 
-void GFX_GL_Program_Bind(GFX_GL_Program *program)
+void GFX_GL_Program_Bind(GFX_GL_PROGRAM *program)
 {
     glUseProgram(program->id);
     GFX_GL_CheckError();
@@ -83,7 +83,7 @@ char *GFX_GL_Program_PreprocessShader(
 }
 
 void GFX_GL_Program_AttachShader(
-    GFX_GL_Program *program, GLenum type, const char *path)
+    GFX_GL_PROGRAM *program, GLenum type, const char *path)
 {
     GLuint shader_id = glCreateShader(type);
     GFX_GL_CheckError();
@@ -135,7 +135,7 @@ void GFX_GL_Program_AttachShader(
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Program_Link(GFX_GL_Program *program)
+void GFX_GL_Program_Link(GFX_GL_PROGRAM *program)
 {
     glLinkProgram(program->id);
     GFX_GL_CheckError();
@@ -158,13 +158,13 @@ void GFX_GL_Program_Link(GFX_GL_Program *program)
     }
 }
 
-void GFX_GL_Program_FragmentData(GFX_GL_Program *program, const char *name)
+void GFX_GL_Program_FragmentData(GFX_GL_PROGRAM *program, const char *name)
 {
     glBindFragDataLocation(program->id, 0, name);
     GFX_GL_CheckError();
 }
 
-GLint GFX_GL_Program_UniformLocation(GFX_GL_Program *program, const char *name)
+GLint GFX_GL_Program_UniformLocation(GFX_GL_PROGRAM *program, const char *name)
 {
     GLint location = glGetUniformLocation(program->id, name);
     GFX_GL_CheckError();
@@ -175,28 +175,28 @@ GLint GFX_GL_Program_UniformLocation(GFX_GL_Program *program, const char *name)
 }
 
 void GFX_GL_Program_Uniform3f(
-    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2)
+    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2)
 {
     glUniform3f(loc, v0, v1, v2);
     GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_Uniform4f(
-    GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
+    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
     GLfloat v3)
 {
     glUniform4f(loc, v0, v1, v2, v3);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Program_Uniform1i(GFX_GL_Program *program, GLint loc, GLint v0)
+void GFX_GL_Program_Uniform1i(GFX_GL_PROGRAM *program, GLint loc, GLint v0)
 {
     glUniform1i(loc, v0);
     GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_UniformMatrix4fv(
-    GFX_GL_Program *program, GLint loc, GLsizei count, GLboolean transpose,
+    GFX_GL_PROGRAM *program, GLint loc, GLsizei count, GLboolean transpose,
     const GLfloat *value)
 {
     glUniformMatrix4fv(loc, count, transpose, value);

--- a/src/gfx/gl/sampler.c
+++ b/src/gfx/gl/sampler.c
@@ -2,33 +2,33 @@
 
 #include "gfx/gl/utils.h"
 
-void GFX_GL_Sampler_Init(GFX_GL_Sampler *sampler)
+void GFX_GL_Sampler_Init(GFX_GL_SAMPLER *sampler)
 {
     glGenSamplers(1, &sampler->id);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Sampler_Close(GFX_GL_Sampler *sampler)
+void GFX_GL_Sampler_Close(GFX_GL_SAMPLER *sampler)
 {
     glDeleteSamplers(1, &sampler->id);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Sampler_Bind(GFX_GL_Sampler *sampler, GLuint unit)
+void GFX_GL_Sampler_Bind(GFX_GL_SAMPLER *sampler, GLuint unit)
 {
     glBindSampler(unit, sampler->id);
     GFX_GL_CheckError();
 }
 
 void GFX_GL_Sampler_Parameteri(
-    GFX_GL_Sampler *sampler, GLenum pname, GLint param)
+    GFX_GL_SAMPLER *sampler, GLenum pname, GLint param)
 {
     glSamplerParameteri(sampler->id, pname, param);
     GFX_GL_CheckError();
 }
 
 void GFX_GL_Sampler_Parameterf(
-    GFX_GL_Sampler *sampler, GLenum pname, GLfloat param)
+    GFX_GL_SAMPLER *sampler, GLenum pname, GLfloat param)
 {
     glSamplerParameterf(sampler->id, pname, param);
     GFX_GL_CheckError();

--- a/src/gfx/gl/texture.c
+++ b/src/gfx/gl/texture.c
@@ -6,14 +6,14 @@
 
 #include <assert.h>
 
-GFX_GL_Texture *GFX_GL_Texture_Create(GLenum target)
+GFX_GL_TEXTURE *GFX_GL_Texture_Create(GLenum target)
 {
-    GFX_GL_Texture *texture = Memory_Alloc(sizeof(GFX_GL_Texture));
+    GFX_GL_TEXTURE *texture = Memory_Alloc(sizeof(GFX_GL_TEXTURE));
     GFX_GL_Texture_Init(texture, target);
     return texture;
 }
 
-void GFX_GL_Texture_Free(GFX_GL_Texture *texture)
+void GFX_GL_Texture_Free(GFX_GL_TEXTURE *texture)
 {
     if (texture != NULL) {
         GFX_GL_Texture_Close(texture);
@@ -21,7 +21,7 @@ void GFX_GL_Texture_Free(GFX_GL_Texture *texture)
     }
 }
 
-void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target)
+void GFX_GL_Texture_Init(GFX_GL_TEXTURE *texture, GLenum target)
 {
     assert(texture != NULL);
     texture->target = target;
@@ -29,14 +29,14 @@ void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target)
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Texture_Close(GFX_GL_Texture *texture)
+void GFX_GL_Texture_Close(GFX_GL_TEXTURE *texture)
 {
     assert(texture != NULL);
     glDeleteTextures(1, &texture->id);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Texture_Bind(GFX_GL_Texture *texture)
+void GFX_GL_Texture_Bind(GFX_GL_TEXTURE *texture)
 {
     assert(texture != NULL);
     glBindTexture(texture->target, texture->id);
@@ -44,7 +44,7 @@ void GFX_GL_Texture_Bind(GFX_GL_Texture *texture)
 }
 
 void GFX_GL_Texture_Load(
-    GFX_GL_Texture *texture, const void *data, int width, int height,
+    GFX_GL_TEXTURE *texture, const void *data, int width, int height,
     GLint internal_format, GLint format)
 {
     assert(texture != NULL);
@@ -62,7 +62,7 @@ void GFX_GL_Texture_Load(
     GFX_GL_CheckError();
 }
 
-void GFX_GL_Texture_LoadFromBackBuffer(GFX_GL_Texture *const texture)
+void GFX_GL_Texture_LoadFromBackBuffer(GFX_GL_TEXTURE *const texture)
 {
     assert(texture != NULL);
 

--- a/src/gfx/gl/vertex_array.c
+++ b/src/gfx/gl/vertex_array.c
@@ -5,21 +5,21 @@
 #include <assert.h>
 #include <stdint.h>
 
-void GFX_GL_VertexArray_Init(GFX_GL_VertexArray *array)
+void GFX_GL_VertexArray_Init(GFX_GL_VERTEX_ARRAY *array)
 {
     assert(array);
     glGenVertexArrays(1, &array->id);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_VertexArray_Close(GFX_GL_VertexArray *array)
+void GFX_GL_VertexArray_Close(GFX_GL_VERTEX_ARRAY *array)
 {
     assert(array);
     glDeleteVertexArrays(1, &array->id);
     GFX_GL_CheckError();
 }
 
-void GFX_GL_VertexArray_Bind(GFX_GL_VertexArray *array)
+void GFX_GL_VertexArray_Bind(GFX_GL_VERTEX_ARRAY *array)
 {
     assert(array);
     glBindVertexArray(array->id);
@@ -27,7 +27,7 @@ void GFX_GL_VertexArray_Bind(GFX_GL_VertexArray *array)
 }
 
 void GFX_GL_VertexArray_Attribute(
-    GFX_GL_VertexArray *array, GLuint index, GLint size, GLenum type,
+    GFX_GL_VERTEX_ARRAY *array, GLuint index, GLint size, GLenum type,
     GLboolean normalized, GLsizei stride, GLsizei offset)
 {
     assert(array);

--- a/src/gfx/renderers/fbo_renderer.c
+++ b/src/gfx/renderers/fbo_renderer.c
@@ -25,23 +25,23 @@ typedef struct {
     GLuint fbo;
     GLuint rbo;
 
-    GFX_GL_VertexArray vertex_array;
-    GFX_GL_Buffer buffer;
-    GFX_GL_Texture texture;
-    GFX_GL_Sampler sampler;
-    GFX_GL_Program program;
-} GFX_Renderer_FBO_Context;
+    GFX_GL_VERTEX_ARRAY vertex_array;
+    GFX_GL_BUFFER buffer;
+    GFX_GL_TEXTURE texture;
+    GFX_GL_SAMPLER sampler;
+    GFX_GL_PROGRAM program;
+} M_CONTEXT;
 
-static void M_SwapBuffers(GFX_Renderer *renderer);
-static void M_Init(GFX_Renderer *renderer, const GFX_CONFIG *config);
-static void M_Shutdown(GFX_Renderer *renderer);
-static void M_Reset(GFX_Renderer *renderer);
+static void M_SwapBuffers(GFX_RENDERER *renderer);
+static void M_Init(GFX_RENDERER *renderer, const GFX_CONFIG *config);
+static void M_Shutdown(GFX_RENDERER *renderer);
+static void M_Reset(GFX_RENDERER *renderer);
 
-static void M_Render(GFX_Renderer *renderer);
-static void M_Bind(const GFX_Renderer *renderer);
-static void M_Unbind(const GFX_Renderer *renderer);
+static void M_Render(GFX_RENDERER *renderer);
+static void M_Bind(const GFX_RENDERER *renderer);
+static void M_Unbind(const GFX_RENDERER *renderer);
 
-static void M_SwapBuffers(GFX_Renderer *renderer)
+static void M_SwapBuffers(GFX_RENDERER *renderer)
 {
     if (GFX_Context_GetScheduledScreenshotPath()) {
         GFX_Screenshot_CaptureToFile(GFX_Context_GetScheduledScreenshotPath());
@@ -62,14 +62,13 @@ static void M_SwapBuffers(GFX_Renderer *renderer)
     GFX_Context_SwitchToDisplayViewport();
 }
 
-static void M_Init(GFX_Renderer *const renderer, const GFX_CONFIG *const config)
+static void M_Init(GFX_RENDERER *const renderer, const GFX_CONFIG *const config)
 {
     LOG_INFO("");
 
     assert(renderer != NULL);
-    renderer->priv = (GFX_Renderer_FBO_Context *)Memory_Alloc(
-        sizeof(GFX_Renderer_FBO_Context));
-    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    renderer->priv = (M_CONTEXT *)Memory_Alloc(sizeof(M_CONTEXT));
+    M_CONTEXT *priv = renderer->priv;
     assert(priv != NULL);
 
     priv->config = config;
@@ -144,12 +143,12 @@ static void M_Init(GFX_Renderer *const renderer, const GFX_CONFIG *const config)
     }
 }
 
-static void M_Shutdown(GFX_Renderer *renderer)
+static void M_Shutdown(GFX_RENDERER *renderer)
 {
     LOG_INFO("");
 
     assert(renderer != NULL);
-    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    M_CONTEXT *priv = renderer->priv;
     assert(priv != NULL);
 
     if (!priv->fbo) {
@@ -167,19 +166,19 @@ static void M_Shutdown(GFX_Renderer *renderer)
     Memory_FreePointer(&renderer->priv);
 }
 
-static void M_Reset(GFX_Renderer *renderer)
+static void M_Reset(GFX_RENDERER *renderer)
 {
-    GFX_Renderer_FBO_Context *const priv = renderer->priv;
+    M_CONTEXT *const priv = renderer->priv;
     const GFX_CONFIG *const config = priv->config;
 
     renderer->shutdown(renderer);
     renderer->init(renderer, config);
 }
 
-static void M_Render(GFX_Renderer *renderer)
+static void M_Render(GFX_RENDERER *renderer)
 {
     assert(renderer != NULL);
-    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    M_CONTEXT *priv = renderer->priv;
     assert(priv != NULL);
 
     const GLuint filter = priv->config->display_filter == GFX_TF_BILINEAR
@@ -225,20 +224,20 @@ static void M_Render(GFX_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
-static void M_Bind(const GFX_Renderer *renderer)
+static void M_Bind(const GFX_RENDERER *renderer)
 {
     assert(renderer != NULL);
-    GFX_Renderer_FBO_Context *priv = renderer->priv;
+    M_CONTEXT *priv = renderer->priv;
     assert(priv != NULL);
     glBindFramebuffer(GL_FRAMEBUFFER, priv->fbo);
 }
 
-static void M_Unbind(const GFX_Renderer *renderer)
+static void M_Unbind(const GFX_RENDERER *renderer)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-GFX_Renderer g_GFX_Renderer_FBO = {
+GFX_RENDERER g_GFX_Renderer_FBO = {
     .swap_buffers = &M_SwapBuffers,
     .init = &M_Init,
     .shutdown = &M_Shutdown,

--- a/src/gfx/renderers/legacy_renderer.c
+++ b/src/gfx/renderers/legacy_renderer.c
@@ -7,9 +7,9 @@
 #include <SDL2/SDL_video.h>
 #include <assert.h>
 
-static void M_SwapBuffers(GFX_Renderer *renderer);
+static void M_SwapBuffers(GFX_RENDERER *renderer);
 
-static void M_SwapBuffers(GFX_Renderer *renderer)
+static void M_SwapBuffers(GFX_RENDERER *renderer)
 {
     assert(renderer != NULL);
 
@@ -26,7 +26,7 @@ static void M_SwapBuffers(GFX_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
-GFX_Renderer g_GFX_Renderer_Legacy = {
+GFX_RENDERER g_GFX_Renderer_Legacy = {
     .priv = NULL,
     .swap_buffers = &M_SwapBuffers,
     .init = NULL,

--- a/src/json/bson_parse.c
+++ b/src/json/bson_parse.c
@@ -695,7 +695,7 @@ struct json_value_s *bson_parse_ex(
     return value;
 }
 
-const char *bson_get_error_description(enum bson_parse_error_e error)
+const char *bson_get_error_description(bson_parse_error_e error)
 {
     switch (error) {
     case bson_parse_error_none:

--- a/src/json/bson_write.c
+++ b/src/json/bson_write.c
@@ -19,19 +19,19 @@ static bool M_GetInt32WrappedSize(size_t *size, const char *key);
 static bool M_GetDoubleSize(size_t *size);
 static bool M_GetDoubleWrappedSize(size_t *size, const char *key);
 static bool M_GetNumberWrappedSize(
-    size_t *size, const char *key, const struct json_number_s *number);
-static bool M_GetStringSize(size_t *size, const struct json_string_s *string);
+    size_t *size, const char *key, const JSON_NUMBER *number);
+static bool M_GetStringSize(size_t *size, const JSON_STRING *string);
 static bool M_GetStringWrappedSize(
-    size_t *size, const char *key, const struct json_string_s *string);
-static bool M_GetArraySize(size_t *size, const struct json_array_s *array);
+    size_t *size, const char *key, const JSON_STRING *string);
+static bool M_GetArraySize(size_t *size, const JSON_ARRAY *array);
 static bool M_GetArrayWrappedSize(
-    size_t *size, const char *key, const struct json_array_s *array);
-static bool M_GetObjectSize(size_t *size, const struct json_object_s *object);
+    size_t *size, const char *key, const JSON_ARRAY *array);
+static bool M_GetObjectSize(size_t *size, const JSON_OBJECT *object);
 static bool M_GetObjectWrappedSize(
-    size_t *size, const char *key, const struct json_object_s *object);
-static bool M_GetValueSize(size_t *size, const struct json_value_s *value);
+    size_t *size, const char *key, const JSON_OBJECT *object);
+static bool M_GetValueSize(size_t *size, const JSON_VALUE *value);
 static bool M_GetValueWrappedSize(
-    size_t *size, const char *key, const struct json_value_s *value);
+    size_t *size, const char *key, const JSON_VALUE *value);
 
 static char *M_WriteMarker(char *data, const char *key, const uint8_t marker);
 static char *M_WriteNullWrapped(char *data, const char *key);
@@ -43,19 +43,19 @@ static char *M_WriteDouble(char *data, const double value);
 static char *M_WriteDoubleWrapped(
     char *data, const char *key, const double value);
 static char *M_WriteNumberWrapped(
-    char *data, const char *key, const struct json_number_s *number);
-static char *M_WriteString(char *data, const struct json_string_s *string);
+    char *data, const char *key, const JSON_NUMBER *number);
+static char *M_WriteString(char *data, const JSON_STRING *string);
 static char *M_WriteStringWrapped(
-    char *data, const char *key, const struct json_string_s *string);
-static char *M_WriteArray(char *data, const struct json_array_s *array);
+    char *data, const char *key, const JSON_STRING *string);
+static char *M_WriteArray(char *data, const JSON_ARRAY *array);
 static char *M_WriteArrayWrapped(
-    char *data, const char *key, const struct json_array_s *array);
-static char *M_WriteObject(char *data, const struct json_object_s *object);
+    char *data, const char *key, const JSON_ARRAY *array);
+static char *M_WriteObject(char *data, const JSON_OBJECT *object);
 static char *M_WriteObjectWrapped(
-    char *data, const char *key, const struct json_object_s *object);
-static char *M_WriteValue(char *data, const struct json_value_s *value);
+    char *data, const char *key, const JSON_OBJECT *object);
+static char *M_WriteValue(char *data, const JSON_VALUE *value);
 static char *M_WriteValueWrapped(
-    char *data, const char *key, const struct json_value_s *value);
+    char *data, const char *key, const JSON_VALUE *value);
 
 static bool M_GetMarkerSize(size_t *size, const char *key)
 {
@@ -126,7 +126,7 @@ static bool M_GetDoubleWrappedSize(size_t *size, const char *key)
 }
 
 static bool M_GetNumberWrappedSize(
-    size_t *size, const char *key, const struct json_number_s *number)
+    size_t *size, const char *key, const JSON_NUMBER *number)
 {
     assert(size);
     assert(key);
@@ -160,7 +160,7 @@ static bool M_GetNumberWrappedSize(
     return false;
 }
 
-static bool M_GetStringSize(size_t *size, const struct json_string_s *string)
+static bool M_GetStringSize(size_t *size, const JSON_STRING *string)
 {
     assert(size);
     assert(string);
@@ -171,7 +171,7 @@ static bool M_GetStringSize(size_t *size, const struct json_string_s *string)
 }
 
 static bool M_GetStringWrappedSize(
-    size_t *size, const char *key, const struct json_string_s *string)
+    size_t *size, const char *key, const JSON_STRING *string)
 {
     assert(size);
     assert(key);
@@ -185,15 +185,15 @@ static bool M_GetStringWrappedSize(
     return true;
 }
 
-static bool M_GetArraySize(size_t *size, const struct json_array_s *array)
+static bool M_GetArraySize(size_t *size, const JSON_ARRAY *array)
 {
     assert(size);
     assert(array);
     char key[12];
     int idx = 0;
     *size += sizeof(int32_t); // object size
-    for (struct json_array_element_s *element = array->start;
-         element != json_null; element = element->next) {
+    for (JSON_ARRAY_ELEMENT *element = array->start; element != NULL;
+         element = element->next) {
         sprintf(key, "%d", idx);
         idx++;
         if (!M_GetValueWrappedSize(size, key, element->value)) {
@@ -205,7 +205,7 @@ static bool M_GetArraySize(size_t *size, const struct json_array_s *array)
 }
 
 static bool M_GetArrayWrappedSize(
-    size_t *size, const char *key, const struct json_array_s *array)
+    size_t *size, const char *key, const JSON_ARRAY *array)
 {
     assert(size);
     assert(key);
@@ -219,13 +219,13 @@ static bool M_GetArrayWrappedSize(
     return true;
 }
 
-static bool M_GetObjectSize(size_t *size, const struct json_object_s *object)
+static bool M_GetObjectSize(size_t *size, const JSON_OBJECT *object)
 {
     assert(size);
     assert(object);
     *size += sizeof(int32_t); // object size
-    for (struct json_object_element_s *element = object->start;
-         element != json_null; element = element->next) {
+    for (JSON_OBJECT_ELEMENT *element = object->start; element != NULL;
+         element = element->next) {
         if (!M_GetValueWrappedSize(
                 size, element->name->string, element->value)) {
             return false;
@@ -236,7 +236,7 @@ static bool M_GetObjectSize(size_t *size, const struct json_object_s *object)
 }
 
 static bool M_GetObjectWrappedSize(
-    size_t *size, const char *key, const struct json_object_s *object)
+    size_t *size, const char *key, const JSON_OBJECT *object)
 {
     assert(size);
     assert(key);
@@ -250,15 +250,15 @@ static bool M_GetObjectWrappedSize(
     return true;
 }
 
-static bool M_GetValueSize(size_t *size, const struct json_value_s *value)
+static bool M_GetValueSize(size_t *size, const JSON_VALUE *value)
 {
     assert(size);
     assert(value);
     switch (value->type) {
-    case json_type_array:
-        return M_GetArraySize(size, (struct json_array_s *)value->payload);
-    case json_type_object:
-        return M_GetObjectSize(size, (struct json_object_s *)value->payload);
+    case JSON_TYPE_ARRAY:
+        return M_GetArraySize(size, (JSON_ARRAY *)value->payload);
+    case JSON_TYPE_OBJECT:
+        return M_GetObjectSize(size, (JSON_OBJECT *)value->payload);
     default:
         LOG_ERROR("Bad BSON root element: %d", value->type);
     }
@@ -266,30 +266,26 @@ static bool M_GetValueSize(size_t *size, const struct json_value_s *value)
 }
 
 static bool M_GetValueWrappedSize(
-    size_t *size, const char *key, const struct json_value_s *value)
+    size_t *size, const char *key, const JSON_VALUE *value)
 {
     assert(size);
     assert(key);
     assert(value);
     switch (value->type) {
-    case json_type_null:
+    case JSON_TYPE_NULL:
         return M_GetNullWrappedSize(size, key);
-    case json_type_true:
+    case JSON_TYPE_TRUE:
         return M_GetBoolWrappedSize(size, key);
-    case json_type_false:
+    case JSON_TYPE_FALSE:
         return M_GetBoolWrappedSize(size, key);
-    case json_type_number:
-        return M_GetNumberWrappedSize(
-            size, key, (struct json_number_s *)value->payload);
-    case json_type_string:
-        return M_GetStringWrappedSize(
-            size, key, (struct json_string_s *)value->payload);
-    case json_type_array:
-        return M_GetArrayWrappedSize(
-            size, key, (struct json_array_s *)value->payload);
-    case json_type_object:
-        return M_GetObjectWrappedSize(
-            size, key, (struct json_object_s *)value->payload);
+    case JSON_TYPE_NUMBER:
+        return M_GetNumberWrappedSize(size, key, (JSON_NUMBER *)value->payload);
+    case JSON_TYPE_STRING:
+        return M_GetStringWrappedSize(size, key, (JSON_STRING *)value->payload);
+    case JSON_TYPE_ARRAY:
+        return M_GetArrayWrappedSize(size, key, (JSON_ARRAY *)value->payload);
+    case JSON_TYPE_OBJECT:
+        return M_GetObjectWrappedSize(size, key, (JSON_OBJECT *)value->payload);
     default:
         LOG_ERROR("Unknown JSON element: %d", value->type);
         return false;
@@ -358,7 +354,7 @@ static char *M_WriteDoubleWrapped(
 }
 
 static char *M_WriteNumberWrapped(
-    char *data, const char *key, const struct json_number_s *number)
+    char *data, const char *key, const JSON_NUMBER *number)
 {
     assert(data);
     assert(key);
@@ -368,7 +364,7 @@ static char *M_WriteNumberWrapped(
     // hexadecimal numbers
     if (number->number_size >= 2 && (str[1] == 'x' || str[1] == 'X')) {
         return M_WriteInt32Wrapped(
-            data, key, json_strtoumax(number->number, json_null, 0));
+            data, key, json_strtoumax(number->number, NULL, 0));
     }
 
     // skip leading sign
@@ -392,7 +388,7 @@ static char *M_WriteNumberWrapped(
     return data;
 }
 
-static char *M_WriteString(char *data, const struct json_string_s *string)
+static char *M_WriteString(char *data, const JSON_STRING *string)
 {
     assert(data);
     assert(string);
@@ -405,7 +401,7 @@ static char *M_WriteString(char *data, const struct json_string_s *string)
 }
 
 static char *M_WriteStringWrapped(
-    char *data, const char *key, const struct json_string_s *string)
+    char *data, const char *key, const JSON_STRING *string)
 {
     assert(data);
     assert(key);
@@ -415,7 +411,7 @@ static char *M_WriteStringWrapped(
     return data;
 }
 
-static char *M_WriteArray(char *data, const struct json_array_s *array)
+static char *M_WriteArray(char *data, const JSON_ARRAY *array)
 {
     assert(data);
     assert(array);
@@ -423,8 +419,8 @@ static char *M_WriteArray(char *data, const struct json_array_s *array)
     int idx = 0;
     char *old = data;
     data += sizeof(int32_t);
-    for (struct json_array_element_s *element = array->start;
-         element != json_null; element = element->next) {
+    for (JSON_ARRAY_ELEMENT *element = array->start; element != NULL;
+         element = element->next) {
         sprintf(key, "%d", idx);
         idx++;
         data = M_WriteValueWrapped(data, key, element->value);
@@ -435,7 +431,7 @@ static char *M_WriteArray(char *data, const struct json_array_s *array)
 }
 
 static char *M_WriteArrayWrapped(
-    char *data, const char *key, const struct json_array_s *array)
+    char *data, const char *key, const JSON_ARRAY *array)
 {
     assert(data);
     assert(key);
@@ -445,14 +441,14 @@ static char *M_WriteArrayWrapped(
     return data;
 }
 
-static char *M_WriteObject(char *data, const struct json_object_s *object)
+static char *M_WriteObject(char *data, const JSON_OBJECT *object)
 {
     assert(data);
     assert(object);
     char *old = data;
     data += sizeof(int32_t);
-    for (struct json_object_element_s *element = object->start;
-         element != json_null; element = element->next) {
+    for (JSON_OBJECT_ELEMENT *element = object->start; element != NULL;
+         element = element->next) {
         data = M_WriteValueWrapped(data, element->name->string, element->value);
     }
     *data++ = '\0';
@@ -461,7 +457,7 @@ static char *M_WriteObject(char *data, const struct json_object_s *object)
 }
 
 static char *M_WriteObjectWrapped(
-    char *data, const char *key, const struct json_object_s *object)
+    char *data, const char *key, const JSON_OBJECT *object)
 {
     assert(data);
     assert(key);
@@ -471,16 +467,16 @@ static char *M_WriteObjectWrapped(
     return data;
 }
 
-static char *M_WriteValue(char *data, const struct json_value_s *value)
+static char *M_WriteValue(char *data, const JSON_VALUE *value)
 {
     assert(data);
     assert(value);
     switch (value->type) {
-    case json_type_array:
-        data = M_WriteArray(data, (struct json_array_s *)value->payload);
+    case JSON_TYPE_ARRAY:
+        data = M_WriteArray(data, (JSON_ARRAY *)value->payload);
         break;
-    case json_type_object:
-        data = M_WriteObject(data, (struct json_object_s *)value->payload);
+    case JSON_TYPE_OBJECT:
+        data = M_WriteObject(data, (JSON_OBJECT *)value->payload);
         break;
     default:
         assert(0);
@@ -489,53 +485,49 @@ static char *M_WriteValue(char *data, const struct json_value_s *value)
 }
 
 static char *M_WriteValueWrapped(
-    char *data, const char *key, const struct json_value_s *value)
+    char *data, const char *key, const JSON_VALUE *value)
 {
     assert(data);
     assert(key);
     assert(value);
     switch (value->type) {
-    case json_type_null:
+    case JSON_TYPE_NULL:
         return M_WriteNullWrapped(data, key);
-    case json_type_true:
+    case JSON_TYPE_TRUE:
         return M_WriteBoolWrapped(data, key, true);
-    case json_type_false:
+    case JSON_TYPE_FALSE:
         return M_WriteBoolWrapped(data, key, false);
-    case json_type_number:
-        return M_WriteNumberWrapped(
-            data, key, (struct json_number_s *)value->payload);
-    case json_type_string:
-        return M_WriteStringWrapped(
-            data, key, (struct json_string_s *)value->payload);
-    case json_type_array:
-        return M_WriteArrayWrapped(
-            data, key, (struct json_array_s *)value->payload);
-    case json_type_object:
-        return M_WriteObjectWrapped(
-            data, key, (struct json_object_s *)value->payload);
+    case JSON_TYPE_NUMBER:
+        return M_WriteNumberWrapped(data, key, (JSON_NUMBER *)value->payload);
+    case JSON_TYPE_STRING:
+        return M_WriteStringWrapped(data, key, (JSON_STRING *)value->payload);
+    case JSON_TYPE_ARRAY:
+        return M_WriteArrayWrapped(data, key, (JSON_ARRAY *)value->payload);
+    case JSON_TYPE_OBJECT:
+        return M_WriteObjectWrapped(data, key, (JSON_OBJECT *)value->payload);
     default:
-        return json_null;
+        return NULL;
     }
 }
 
-void *bson_write(const struct json_value_s *value, size_t *out_size)
+void *BSON_Write(const JSON_VALUE *value, size_t *out_size)
 {
     assert(value);
     *out_size = -1;
-    if (value == json_null) {
-        return json_null;
+    if (value == NULL) {
+        return NULL;
     }
 
     size_t size = 0;
     if (!M_GetValueSize(&size, value)) {
-        return json_null;
+        return NULL;
     }
 
     char *data = Memory_Alloc(size);
     char *data_end = M_WriteValue(data, value);
     assert((size_t)(data_end - data) == size);
 
-    if (out_size != json_null) {
+    if (out_size != NULL) {
         *out_size = size;
     }
 

--- a/src/json/json_base.c
+++ b/src/json/json_base.c
@@ -7,91 +7,91 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct json_string_s *json_value_as_string(struct json_value_s *const value)
+JSON_STRING *JSON_ValueAsString(JSON_VALUE *const value)
 {
-    if (!value || value->type != json_type_string) {
-        return json_null;
+    if (!value || value->type != JSON_TYPE_STRING) {
+        return NULL;
     }
 
-    return (struct json_string_s *)value->payload;
+    return (JSON_STRING *)value->payload;
 }
 
-struct json_number_s *json_value_as_number(struct json_value_s *const value)
+JSON_NUMBER *JSON_ValueAsNumber(JSON_VALUE *const value)
 {
-    if (!value || value->type != json_type_number) {
-        return json_null;
+    if (!value || value->type != JSON_TYPE_NUMBER) {
+        return NULL;
     }
 
-    return (struct json_number_s *)value->payload;
+    return (JSON_NUMBER *)value->payload;
 }
 
-struct json_object_s *json_value_as_object(struct json_value_s *const value)
+JSON_OBJECT *JSON_ValueAsObject(JSON_VALUE *const value)
 {
-    if (!value || value->type != json_type_object) {
-        return json_null;
+    if (!value || value->type != JSON_TYPE_OBJECT) {
+        return NULL;
     }
 
-    return (struct json_object_s *)value->payload;
+    return (JSON_OBJECT *)value->payload;
 }
 
-struct json_array_s *json_value_as_array(struct json_value_s *const value)
+JSON_ARRAY *JSON_ValueAsArray(JSON_VALUE *const value)
 {
-    if (!value || value->type != json_type_array) {
-        return json_null;
+    if (!value || value->type != JSON_TYPE_ARRAY) {
+        return NULL;
     }
 
-    return (struct json_array_s *)value->payload;
+    return (JSON_ARRAY *)value->payload;
 }
 
-int json_value_is_true(const struct json_value_s *const value)
+int JSON_ValueIsTrue(const JSON_VALUE *const value)
 {
-    return value && value->type == json_type_true;
+    return value && value->type == JSON_TYPE_TRUE;
 }
 
-int json_value_is_false(const struct json_value_s *const value)
+int JSON_ValueIsFalse(const JSON_VALUE *const value)
 {
-    return value && value->type == json_type_false;
+    return value && value->type == JSON_TYPE_FALSE;
 }
 
-int json_value_is_null(const struct json_value_s *const value)
+int JSON_ValueIsNull(const JSON_VALUE *const value)
 {
-    return value && value->type == json_type_null;
+    return value && value->type == JSON_TYPE_NULL;
 }
 
-struct json_number_s *json_number_new_int(int number)
+JSON_NUMBER *JSON_NumberNewInt(int number)
 {
     size_t size = snprintf(NULL, 0, "%d", number) + 1;
     char *buf = Memory_Alloc(size);
     sprintf(buf, "%d", number);
-    struct json_number_s *elem = Memory_Alloc(sizeof(struct json_number_s));
+    JSON_NUMBER *elem = Memory_Alloc(sizeof(JSON_NUMBER));
     elem->number = buf;
     elem->number_size = strlen(buf);
     return elem;
 }
 
-struct json_number_s *json_number_new_int64(int64_t number)
+JSON_NUMBER *JSON_NumberNewInt64(int64_t number)
 {
     size_t size = snprintf(NULL, 0, "%" PRId64, number) + 1;
     char *buf = Memory_Alloc(size);
     sprintf(buf, "%" PRId64, number);
-    struct json_number_s *elem = Memory_Alloc(sizeof(struct json_number_s));
+    JSON_NUMBER *elem = Memory_Alloc(sizeof(JSON_NUMBER));
     elem->number = buf;
     elem->number_size = strlen(buf);
     return elem;
 }
 
-struct json_number_s *json_number_new_double(double number)
+JSON_NUMBER *JSON_NumberNewDouble(double number)
 {
     size_t size = snprintf(NULL, 0, "%f", number) + 1;
     char *buf = Memory_Alloc(size);
     sprintf(buf, "%f", number);
-    struct json_number_s *elem = Memory_Alloc(sizeof(struct json_number_s));
+    JSON_NUMBER *elem = Memory_Alloc(sizeof(JSON_NUMBER));
     elem->number = buf;
     elem->number_size = strlen(buf);
     return elem;
 }
 
-void json_number_free(struct json_number_s *num)
+void JSON_NumberFree(JSON_NUMBER *num)
 {
     if (!num->ref_count) {
         Memory_Free(num->number);
@@ -99,15 +99,15 @@ void json_number_free(struct json_number_s *num)
     }
 }
 
-struct json_string_s *json_string_new(const char *string)
+JSON_STRING *JSON_StringNew(const char *string)
 {
-    struct json_string_s *str = Memory_Alloc(sizeof(struct json_string_s));
+    JSON_STRING *str = Memory_Alloc(sizeof(JSON_STRING));
     str->string = Memory_DupStr(string);
     str->string_size = strlen(string);
     return str;
 }
 
-void json_string_free(struct json_string_s *str)
+void JSON_StringFree(JSON_STRING *str)
 {
     if (!str->ref_count) {
         Memory_Free(str->string);
@@ -115,21 +115,21 @@ void json_string_free(struct json_string_s *str)
     }
 }
 
-struct json_array_s *json_array_new(void)
+JSON_ARRAY *JSON_ArrayNew(void)
 {
-    struct json_array_s *arr = Memory_Alloc(sizeof(struct json_array_s));
+    JSON_ARRAY *arr = Memory_Alloc(sizeof(JSON_ARRAY));
     arr->start = NULL;
     arr->length = 0;
     return arr;
 }
 
-void json_array_free(struct json_array_s *arr)
+void JSON_ArrayFree(JSON_ARRAY *arr)
 {
-    struct json_array_element_s *elem = arr->start;
+    JSON_ARRAY_ELEMENT *elem = arr->start;
     while (elem) {
-        struct json_array_element_s *next = elem->next;
-        json_value_free(elem->value);
-        json_array_element_free(elem);
+        JSON_ARRAY_ELEMENT *next = elem->next;
+        JSON_ValueFree(elem->value);
+        JSON_ArrayElementFree(elem);
         elem = next;
     }
     if (!arr->ref_count) {
@@ -137,21 +137,20 @@ void json_array_free(struct json_array_s *arr)
     }
 }
 
-void json_array_element_free(struct json_array_element_s *element)
+void JSON_ArrayElementFree(JSON_ARRAY_ELEMENT *element)
 {
     if (!element->ref_count) {
         Memory_FreePointer(&element);
     }
 }
 
-void json_array_append(struct json_array_s *arr, struct json_value_s *value)
+void JSON_ArrayAppend(JSON_ARRAY *arr, JSON_VALUE *value)
 {
-    struct json_array_element_s *elem =
-        Memory_Alloc(sizeof(struct json_array_element_s));
+    JSON_ARRAY_ELEMENT *elem = Memory_Alloc(sizeof(JSON_ARRAY_ELEMENT));
     elem->value = value;
     elem->next = NULL;
     if (arr->start) {
-        struct json_array_element_s *target = arr->start;
+        JSON_ARRAY_ELEMENT *target = arr->start;
         while (target->next) {
             target = target->next;
         }
@@ -162,127 +161,120 @@ void json_array_append(struct json_array_s *arr, struct json_value_s *value)
     arr->length++;
 }
 
-void json_array_append_bool(struct json_array_s *arr, int b)
+void JSON_ArrayApendBool(JSON_ARRAY *arr, int b)
 {
-    json_array_append(arr, json_value_from_bool(b));
+    JSON_ArrayAppend(arr, JSON_ValueFromBool(b));
 }
 
-void json_array_append_int(struct json_array_s *arr, int number)
+void JSON_ArrayAppendInt(JSON_ARRAY *arr, int number)
 {
-    json_array_append(arr, json_value_from_number(json_number_new_int(number)));
+    JSON_ArrayAppend(arr, JSON_ValueFromNumber(JSON_NumberNewInt(number)));
 }
 
-void json_array_append_double(struct json_array_s *arr, double number)
+void JSON_ArrayAppendDouble(JSON_ARRAY *arr, double number)
 {
-    json_array_append(
-        arr, json_value_from_number(json_number_new_double(number)));
+    JSON_ArrayAppend(arr, JSON_ValueFromNumber(JSON_NumberNewDouble(number)));
 }
 
-void json_array_append_string(struct json_array_s *arr, const char *string)
+void JSON_ArrayAppendString(JSON_ARRAY *arr, const char *string)
 {
-    json_array_append(arr, json_value_from_string(json_string_new(string)));
+    JSON_ArrayAppend(arr, JSON_ValueFromString(JSON_StringNew(string)));
 }
 
-void json_array_append_array(
-    struct json_array_s *arr, struct json_array_s *arr2)
+void JSON_ArrayAppendArray(JSON_ARRAY *arr, JSON_ARRAY *arr2)
 {
-    json_array_append(arr, json_value_from_array(arr2));
+    JSON_ArrayAppend(arr, JSON_ValueFromArray(arr2));
 }
 
-void json_array_append_object(
-    struct json_array_s *arr, struct json_object_s *obj)
+void JSON_ArrayAppendObject(JSON_ARRAY *arr, JSON_OBJECT *obj)
 {
-    json_array_append(arr, json_value_from_object(obj));
+    JSON_ArrayAppend(arr, JSON_ValueFromObject(obj));
 }
 
-struct json_value_s *json_array_get_value(
-    struct json_array_s *arr, const size_t idx)
+JSON_VALUE *JSON_ArrayGetValue(JSON_ARRAY *arr, const size_t idx)
 {
     if (!arr || idx >= arr->length) {
-        return json_null;
+        return NULL;
     }
-    struct json_array_element_s *elem = arr->start;
+    JSON_ARRAY_ELEMENT *elem = arr->start;
     for (size_t i = 0; i < idx; i++) {
         elem = elem->next;
     }
     return elem->value;
 }
 
-int json_array_get_bool(struct json_array_s *arr, const size_t idx, int d)
+int JSON_ArrayGetBool(JSON_ARRAY *arr, const size_t idx, int d)
 {
-    struct json_value_s *value = json_array_get_value(arr, idx);
-    if (json_value_is_true(value)) {
+    JSON_VALUE *value = JSON_ArrayGetValue(arr, idx);
+    if (JSON_ValueIsTrue(value)) {
         return 1;
-    } else if (json_value_is_false(value)) {
+    } else if (JSON_ValueIsFalse(value)) {
         return 0;
     }
     return d;
 }
 
-int json_array_get_int(struct json_array_s *arr, const size_t idx, int d)
+int JSON_ArrayGetInt(JSON_ARRAY *arr, const size_t idx, int d)
 {
-    struct json_value_s *value = json_array_get_value(arr, idx);
-    struct json_number_s *num = json_value_as_number(value);
+    JSON_VALUE *value = JSON_ArrayGetValue(arr, idx);
+    JSON_NUMBER *num = JSON_ValueAsNumber(value);
     if (num) {
         return atoi(num->number);
     }
     return d;
 }
 
-double json_array_get_double(
-    struct json_array_s *arr, const size_t idx, double d)
+double JSON_ArrayGetDouble(JSON_ARRAY *arr, const size_t idx, double d)
 {
-    struct json_value_s *value = json_array_get_value(arr, idx);
-    struct json_number_s *num = json_value_as_number(value);
+    JSON_VALUE *value = JSON_ArrayGetValue(arr, idx);
+    JSON_NUMBER *num = JSON_ValueAsNumber(value);
     if (num) {
         return atof(num->number);
     }
     return d;
 }
 
-const char *json_array_get_string(
-    struct json_array_s *arr, const size_t idx, const char *d)
+const char *JSON_ArrayGetString(
+    JSON_ARRAY *arr, const size_t idx, const char *d)
 {
-    struct json_value_s *value = json_array_get_value(arr, idx);
-    struct json_string_s *str = json_value_as_string(value);
+    JSON_VALUE *value = JSON_ArrayGetValue(arr, idx);
+    JSON_STRING *str = JSON_ValueAsString(value);
     if (str) {
         return str->string;
     }
     return d;
 }
 
-struct json_array_s *json_array_get_array(
-    struct json_array_s *arr, const size_t idx)
+JSON_ARRAY *JSON_ArrayGetArray(JSON_ARRAY *arr, const size_t idx)
 {
-    struct json_value_s *value = json_array_get_value(arr, idx);
-    struct json_array_s *arr2 = json_value_as_array(value);
+    JSON_VALUE *value = JSON_ArrayGetValue(arr, idx);
+    JSON_ARRAY *arr2 = JSON_ValueAsArray(value);
     return arr2;
 }
 
-struct json_object_s *json_array_get_object(
-    struct json_array_s *arr, const size_t idx)
+JSON_OBJECT *JSON_ArrayGetObject(JSON_ARRAY *arr, const size_t idx)
 {
-    struct json_value_s *value = json_array_get_value(arr, idx);
-    struct json_object_s *obj = json_value_as_object(value);
+    JSON_VALUE *value = JSON_ArrayGetValue(arr, idx);
+    JSON_OBJECT *obj = JSON_ValueAsObject(value);
     return obj;
 }
 
-struct json_object_s *json_object_new(void)
+JSON_OBJECT *JSON_ObjectNew(void)
 {
-    struct json_object_s *obj = Memory_Alloc(sizeof(struct json_object_s));
+    JSON_OBJECT *obj = Memory_Alloc(sizeof(JSON_OBJECT));
     obj->start = NULL;
     obj->length = 0;
     return obj;
 }
 
-void json_object_free(struct json_object_s *obj)
+void JSON_ObjectFree(JSON_OBJECT *obj)
 {
-    struct json_object_element_s *elem = obj->start;
+    JSON_OBJECT_ELEMENT *elem = obj->start;
     while (elem) {
-        struct json_object_element_s *next = elem->next;
-        json_string_free(elem->name);
-        json_value_free(elem->value);
-        json_object_element_free(elem);
+        JSON_OBJECT_ELEMENT *next = elem->next;
+        JSON_StringFree(elem->name);
+        JSON_ValueFree(elem->value);
+        JSON_ObjectElementFree(elem);
         elem = next;
     }
     if (!obj->ref_count) {
@@ -290,23 +282,21 @@ void json_object_free(struct json_object_s *obj)
     }
 }
 
-void json_object_element_free(struct json_object_element_s *element)
+void JSON_ObjectElementFree(JSON_OBJECT_ELEMENT *element)
 {
     if (!element->ref_count) {
         Memory_FreePointer(&element);
     }
 }
 
-void json_object_append(
-    struct json_object_s *obj, const char *key, struct json_value_s *value)
+void JSON_ObjectAppend(JSON_OBJECT *obj, const char *key, JSON_VALUE *value)
 {
-    struct json_object_element_s *elem =
-        Memory_Alloc(sizeof(struct json_object_element_s));
-    elem->name = json_string_new(key);
+    JSON_OBJECT_ELEMENT *elem = Memory_Alloc(sizeof(JSON_OBJECT_ELEMENT));
+    elem->name = JSON_StringNew(key);
     elem->value = value;
     elem->next = NULL;
     if (obj->start) {
-        struct json_object_element_s *target = obj->start;
+        JSON_OBJECT_ELEMENT *target = obj->start;
         while (target->next) {
             target = target->next;
         }
@@ -317,58 +307,53 @@ void json_object_append(
     obj->length++;
 }
 
-void json_object_append_bool(struct json_object_s *obj, const char *key, int b)
+void JSON_ObjectAppendBool(JSON_OBJECT *obj, const char *key, int b)
 {
-    json_object_append(obj, key, json_value_from_bool(b));
+    JSON_ObjectAppend(obj, key, JSON_ValueFromBool(b));
 }
 
-void json_object_append_int(
-    struct json_object_s *obj, const char *key, int number)
+void JSON_ObjectAppendInt(JSON_OBJECT *obj, const char *key, int number)
 {
-    json_object_append(
-        obj, key, json_value_from_number(json_number_new_int(number)));
+    JSON_ObjectAppend(
+        obj, key, JSON_ValueFromNumber(JSON_NumberNewInt(number)));
 }
 
-void json_object_append_int64(
-    struct json_object_s *obj, const char *key, int64_t number)
+void JSON_ObjectAppendInt64(JSON_OBJECT *obj, const char *key, int64_t number)
 {
-    json_object_append(
-        obj, key, json_value_from_number(json_number_new_int64(number)));
+    JSON_ObjectAppend(
+        obj, key, JSON_ValueFromNumber(JSON_NumberNewInt64(number)));
 }
 
-void json_object_append_double(
-    struct json_object_s *obj, const char *key, double number)
+void JSON_ObjectAppendDouble(JSON_OBJECT *obj, const char *key, double number)
 {
-    json_object_append(
-        obj, key, json_value_from_number(json_number_new_double(number)));
+    JSON_ObjectAppend(
+        obj, key, JSON_ValueFromNumber(JSON_NumberNewDouble(number)));
 }
 
-void json_object_append_string(
-    struct json_object_s *obj, const char *key, const char *string)
+void JSON_ObjectAppendString(
+    JSON_OBJECT *obj, const char *key, const char *string)
 {
-    json_object_append(
-        obj, key, json_value_from_string(json_string_new(string)));
+    JSON_ObjectAppend(obj, key, JSON_ValueFromString(JSON_StringNew(string)));
 }
 
-void json_object_append_array(
-    struct json_object_s *obj, const char *key, struct json_array_s *arr)
+void JSON_ObjectAppendArray(JSON_OBJECT *obj, const char *key, JSON_ARRAY *arr)
 {
-    json_object_append(obj, key, json_value_from_array(arr));
+    JSON_ObjectAppend(obj, key, JSON_ValueFromArray(arr));
 }
 
-void json_object_append_object(
-    struct json_object_s *obj, const char *key, struct json_object_s *obj2)
+void JSON_ObjectAppendObject(
+    JSON_OBJECT *obj, const char *key, JSON_OBJECT *obj2)
 {
-    json_object_append(obj, key, json_value_from_object(obj2));
+    JSON_ObjectAppend(obj, key, JSON_ValueFromObject(obj2));
 }
 
-void json_object_evict_key(struct json_object_s *obj, const char *key)
+void JSON_ObjectEvictKey(JSON_OBJECT *obj, const char *key)
 {
     if (!obj) {
         return;
     }
-    struct json_object_element_s *elem = obj->start;
-    struct json_object_element_s *prev = json_null;
+    JSON_OBJECT_ELEMENT *elem = obj->start;
+    JSON_OBJECT_ELEMENT *prev = NULL;
     while (elem) {
         if (!strcmp(elem->name->string, key)) {
             if (!prev) {
@@ -376,7 +361,7 @@ void json_object_evict_key(struct json_object_s *obj, const char *key)
             } else {
                 prev->next = elem->next;
             }
-            json_object_element_free(elem);
+            JSON_ObjectElementFree(elem);
             return;
         }
         prev = elem;
@@ -384,154 +369,149 @@ void json_object_evict_key(struct json_object_s *obj, const char *key)
     }
 }
 
-struct json_value_s *json_object_get_value(
-    struct json_object_s *obj, const char *key)
+JSON_VALUE *JSON_ObjectGetValue(JSON_OBJECT *obj, const char *key)
 {
     if (!obj) {
-        return json_null;
+        return NULL;
     }
-    struct json_object_element_s *elem = obj->start;
+    JSON_OBJECT_ELEMENT *elem = obj->start;
     while (elem) {
         if (!strcmp(elem->name->string, key)) {
             return elem->value;
         }
         elem = elem->next;
     }
-    return json_null;
+    return NULL;
 }
 
-int json_object_get_bool(struct json_object_s *obj, const char *key, int d)
+int JSON_ObjectGetBool(JSON_OBJECT *obj, const char *key, int d)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    if (json_value_is_true(value)) {
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    if (JSON_ValueIsTrue(value)) {
         return 1;
-    } else if (json_value_is_false(value)) {
+    } else if (JSON_ValueIsFalse(value)) {
         return 0;
     }
     return d;
 }
 
-int json_object_get_int(struct json_object_s *obj, const char *key, int d)
+int JSON_ObjectGetInt(JSON_OBJECT *obj, const char *key, int d)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    struct json_number_s *num = json_value_as_number(value);
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    JSON_NUMBER *num = JSON_ValueAsNumber(value);
     if (num) {
         return atoi(num->number);
     }
     return d;
 }
 
-int64_t json_object_get_int64(
-    struct json_object_s *obj, const char *key, int64_t d)
+int64_t JSON_ObjectGetInt64(JSON_OBJECT *obj, const char *key, int64_t d)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    struct json_number_s *num = json_value_as_number(value);
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    JSON_NUMBER *num = JSON_ValueAsNumber(value);
     if (num) {
         return strtoll(num->number, NULL, 10);
     }
     return d;
 }
 
-double json_object_get_double(
-    struct json_object_s *obj, const char *key, double d)
+double JSON_ObjectGetDouble(JSON_OBJECT *obj, const char *key, double d)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    struct json_number_s *num = json_value_as_number(value);
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    JSON_NUMBER *num = JSON_ValueAsNumber(value);
     if (num) {
         return atof(num->number);
     }
     return d;
 }
 
-const char *json_object_get_string(
-    struct json_object_s *obj, const char *key, const char *d)
+const char *JSON_ObjectGetString(
+    JSON_OBJECT *obj, const char *key, const char *d)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    struct json_string_s *str = json_value_as_string(value);
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    JSON_STRING *str = JSON_ValueAsString(value);
     if (str) {
         return str->string;
     }
     return d;
 }
 
-struct json_array_s *json_object_get_array(
-    struct json_object_s *obj, const char *key)
+JSON_ARRAY *JSON_ObjectGetArray(JSON_OBJECT *obj, const char *key)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    struct json_array_s *arr = json_value_as_array(value);
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    JSON_ARRAY *arr = JSON_ValueAsArray(value);
     return arr;
 }
 
-struct json_object_s *json_object_get_object(
-    struct json_object_s *obj, const char *key)
+JSON_OBJECT *JSON_ObjectGetObject(JSON_OBJECT *obj, const char *key)
 {
-    struct json_value_s *value = json_object_get_value(obj, key);
-    struct json_object_s *obj2 = json_value_as_object(value);
+    JSON_VALUE *value = JSON_ObjectGetValue(obj, key);
+    JSON_OBJECT *obj2 = JSON_ValueAsObject(value);
     return obj2;
 }
 
-struct json_value_s *json_value_from_bool(int b)
+JSON_VALUE *JSON_ValueFromBool(int b)
 {
-    struct json_value_s *value = Memory_Alloc(sizeof(struct json_value_s));
-    value->type = b ? json_type_true : json_type_false;
+    JSON_VALUE *value = Memory_Alloc(sizeof(JSON_VALUE));
+    value->type = b ? JSON_TYPE_TRUE : JSON_TYPE_FALSE;
     value->payload = NULL;
     return value;
 }
 
-struct json_value_s *json_value_from_number(struct json_number_s *num)
+JSON_VALUE *JSON_ValueFromNumber(JSON_NUMBER *num)
 {
-    struct json_value_s *value = Memory_Alloc(sizeof(struct json_value_s));
-    value->type = json_type_number;
+    JSON_VALUE *value = Memory_Alloc(sizeof(JSON_VALUE));
+    value->type = JSON_TYPE_NUMBER;
     value->payload = num;
     return value;
 }
 
-struct json_value_s *json_value_from_string(struct json_string_s *str)
+JSON_VALUE *JSON_ValueFromString(JSON_STRING *str)
 {
-    struct json_value_s *value = Memory_Alloc(sizeof(struct json_value_s));
-    value->type = json_type_string;
+    JSON_VALUE *value = Memory_Alloc(sizeof(JSON_VALUE));
+    value->type = JSON_TYPE_STRING;
     value->payload = str;
     return value;
 }
 
-struct json_value_s *json_value_from_array(struct json_array_s *arr)
+JSON_VALUE *JSON_ValueFromArray(JSON_ARRAY *arr)
 {
-    struct json_value_s *value = Memory_Alloc(sizeof(struct json_value_s));
-    value->type = json_type_array;
+    JSON_VALUE *value = Memory_Alloc(sizeof(JSON_VALUE));
+    value->type = JSON_TYPE_ARRAY;
     value->payload = arr;
     return value;
 }
 
-struct json_value_s *json_value_from_object(struct json_object_s *obj)
+JSON_VALUE *JSON_ValueFromObject(JSON_OBJECT *obj)
 {
-    struct json_value_s *value = Memory_Alloc(sizeof(struct json_value_s));
-    value->type = json_type_object;
+    JSON_VALUE *value = Memory_Alloc(sizeof(JSON_VALUE));
+    value->type = JSON_TYPE_OBJECT;
     value->payload = obj;
     return value;
 }
 
-void json_value_free(struct json_value_s *value)
+void JSON_ValueFree(JSON_VALUE *value)
 {
     if (!value) {
         return;
     }
     if (!value->ref_count) {
         switch (value->type) {
-        case json_type_number:
-            json_number_free((struct json_number_s *)value->payload);
+        case JSON_TYPE_NUMBER:
+            JSON_NumberFree((JSON_NUMBER *)value->payload);
             break;
-        case json_type_string:
-            json_string_free((struct json_string_s *)value->payload);
+        case JSON_TYPE_STRING:
+            JSON_StringFree((JSON_STRING *)value->payload);
             break;
-        case json_type_array:
-            json_array_free((struct json_array_s *)value->payload);
+        case JSON_TYPE_ARRAY:
+            JSON_ArrayFree((JSON_ARRAY *)value->payload);
             break;
-        case json_type_object:
-            json_object_free((struct json_object_s *)value->payload);
+        case JSON_TYPE_OBJECT:
+            JSON_ObjectFree((JSON_OBJECT *)value->payload);
             break;
-        case json_type_true:
-        case json_type_null:
-        case json_type_false:
+        case JSON_TYPE_TRUE:
+        case JSON_TYPE_NULL:
+        case JSON_TYPE_FALSE:
             break;
         }
 

--- a/src/json/json_parse.c
+++ b/src/json/json_parse.c
@@ -1761,7 +1761,7 @@ struct json_value_s *json_parse_ex(
     return (struct json_value_s *)allocation;
 }
 
-const char *json_get_error_description(enum json_parse_error_e error)
+const char *json_get_error_description(json_parse_error_e error)
 {
     switch (error) {
     case json_parse_error_none:


### PR DESCRIPTION
- Changes the naming conventions in the JSON module to match the rest of the project (finally!)
- Changes the naming conventions in the GFX module to match the rest of the project
- Merges room-related structures in TR1 and TR2; renames some fields
- Renames `ROOM_INFO` to just `ROOM`. The same for a lot of other structures
- Improves sanitization of some console commands.
- Fixes a crash in `/set` (sadly present in both TR1X and TR2X in the newest stable)